### PR TITLE
llResetScript calls are now throttled after 5 per second.

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -189,7 +189,7 @@ namespace InWorldz.Phlox.Engine
                         ScriptShoutError("Script '" + llGetScriptName() + "' calling llResetScript too frequently: " + context);
                         m_resetWarned = DateTime.Now;
                     }
-                    ScriptSleep(5000);  // punish script for 5 seconds after 5 resets in the same minute
+                    ScriptSleep(5000);  // punish the script for 5 seconds after too many resets in the same period
                 }
             }
             else


### PR DESCRIPTION
Added a throttle, with user and console warning messages, for excessive
calls to llResetScript (reset loops). Triggered after more than 5 resets
are requested for a script in a single second.