### PR TITLE
Jim/regionvoice

### DIFF
--- a/OpenSim/Data/MySQL/MySQLRegionData.cs
+++ b/OpenSim/Data/MySQL/MySQLRegionData.cs
@@ -2001,10 +2001,6 @@ namespace OpenSim.Data.MySQL
                 //Enum. libsecondlife.Parcel.ParcelStatus
             newData.Flags = Convert.ToUInt32(row["LandFlags"]);
 
-            //temporarily OR in estate voice on all parcels
-            newData.Flags |= (uint)OpenMetaverse.ParcelFlags.AllowVoiceChat;
-            newData.Flags |= (uint)OpenMetaverse.ParcelFlags.UseEstateVoiceChan;
-
             newData.LandingType = Convert.ToByte(row["LandingType"]);
             newData.MediaAutoScale = Convert.ToByte(row["MediaAutoScale"]);
             newData.MediaID = new UUID(Convert.ToString(row["MediaTextureUUID"]));

--- a/OpenSim/Framework/EstateSettings.cs
+++ b/OpenSim/Framework/EstateSettings.cs
@@ -481,28 +481,17 @@ namespace OpenSim.Framework
             {
                 case "region_flags":
                     RegionFlags flags = (RegionFlags)(uint)configuration_result;
-                    if ((flags & RegionFlags.AllowVoice) != 0)
-                        m_AllowVoice = true;
-                    if ((flags & RegionFlags.AllowDirectTeleport) != 0)
-                        m_AllowDirectTeleport = true;
-                    if ((flags & RegionFlags.DenyAnonymous) != 0)
-                         m_DenyAnonymous = true;
-                    if ((flags & RegionFlags.DenyIdentified) != 0)
-                        m_DenyIdentified = true;
-                    if ((flags & RegionFlags.DenyTransacted) != 0)
-                        m_DenyTransacted = true;
-                    if ((flags & RegionFlags.AbuseEmailToEstateOwner) != 0)
-                        m_AbuseEmailToEstateOwner = true;
-                    if ((flags & RegionFlags.BlockDwell) != 0)
-                        m_BlockDwell = true;
-                    if ((flags & RegionFlags.EstateSkipScripts) != 0)
-                        m_EstateSkipScripts = true;
-                    if ((flags & RegionFlags.ResetHomeOnTeleport) != 0)
-                        m_ResetHomeOnTeleport = true;
-                    if ((flags & RegionFlags.TaxFree) != 0)
-                        m_TaxFree = true;
-                    if ((flags & RegionFlags.PublicAllowed) != 0)
-                        m_PublicAccess = true;
+                    m_AllowVoice = ((flags & RegionFlags.AllowVoice) != 0);
+                    m_AllowDirectTeleport = ((flags & RegionFlags.AllowDirectTeleport) != 0);
+                    m_DenyAnonymous = ((flags & RegionFlags.DenyAnonymous) != 0);
+                    m_DenyIdentified = ((flags & RegionFlags.DenyIdentified) != 0);
+                    m_DenyTransacted = ((flags & RegionFlags.DenyTransacted) != 0);
+                    m_AbuseEmailToEstateOwner = ((flags & RegionFlags.AbuseEmailToEstateOwner) != 0);
+                    m_BlockDwell = ((flags & RegionFlags.BlockDwell) != 0);
+                    m_EstateSkipScripts = ((flags & RegionFlags.EstateSkipScripts) != 0);
+                    m_ResetHomeOnTeleport = ((flags & RegionFlags.ResetHomeOnTeleport) != 0);
+                    m_TaxFree = ((flags & RegionFlags.TaxFree) != 0);
+                    m_PublicAccess = ((flags & RegionFlags.PublicAllowed) != 0);
                     break;
                 case "billable_factor":
                     m_BillableFactor = (float) configuration_result;

--- a/OpenSim/Framework/EstateSettings.cs
+++ b/OpenSim/Framework/EstateSettings.cs
@@ -481,7 +481,7 @@ namespace OpenSim.Framework
             {
                 case "region_flags":
                     RegionFlags flags = (RegionFlags)(uint)configuration_result;
-                    if ((flags & (RegionFlags)(1<<29)) != 0)
+                    if ((flags & RegionFlags.AllowVoice) != 0)
                         m_AllowVoice = true;
                     if ((flags & RegionFlags.AllowDirectTeleport) != 0)
                         m_AllowDirectTeleport = true;

--- a/OpenSim/Region/CoreModules/World/Estate/EstateManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Estate/EstateManagementModule.cs
@@ -1362,12 +1362,18 @@ namespace OpenSim.Region.CoreModules.World.Estate
             if (m_scene.RegionInfo.RegionSettings.AllowLandJoinDivide)
                 flags |= RegionFlags.AllowParcelChanges;
             if (m_scene.RegionInfo.RegionSettings.BlockShowInSearch)
-                flags |= (RegionFlags)(1 << 29);
+                flags |= RegionFlags.BlockParcelSearch;
 
             if (m_scene.RegionInfo.RegionSettings.FixedSun)
                 flags |= RegionFlags.SunFixed;
             if (m_scene.RegionInfo.RegionSettings.Sandbox)
                 flags |= RegionFlags.Sandbox;
+            if (m_scene.RegionInfo.EstateSettings.AllowVoice)
+                flags |= RegionFlags.AllowVoice;
+            if (m_scene.RegionInfo.EstateSettings.BlockDwell)
+                flags |= RegionFlags.BlockDwell;
+            if (m_scene.RegionInfo.EstateSettings.ResetHomeOnTeleport)
+                flags |= RegionFlags.ResetHomeOnTeleport;
 
             // Fudge these to always on, so the menu options activate
             //
@@ -1414,7 +1420,7 @@ namespace OpenSim.Region.CoreModules.World.Estate
             if (m_scene.RegionInfo.EstateSettings.TaxFree)
                 flags |= RegionFlags.TaxFree;
             if (m_scene.RegionInfo.EstateSettings.DenyMinors)
-                flags |= (RegionFlags)(1 << 30);
+                flags |= (RegionFlags.DenyAgeUnverified);
 
             return (uint)flags;
         }

--- a/OpenSim/Region/CoreModules/World/Land/LandObject.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandObject.cs
@@ -188,7 +188,7 @@ namespace OpenSim.Region.CoreModules.World.Land
         public void sendLandProperties(int sequence_id, bool snap_selection, int request_result, IClientAPI remote_client)
         {
             IEstateModule estateModule = m_scene.RequestModuleInterface<IEstateModule>();
-            uint regionFlags = 336723974 & ~((uint)(RegionFlags.AllowLandmark | RegionFlags.AllowSetHome));
+            uint regionFlags = (uint)(RegionFlags.PublicAllowed | RegionFlags.AllowDirectTeleport | RegionFlags.AllowParcelChanges | RegionFlags.AllowVoice);
             if (estateModule != null)
                 regionFlags = estateModule.GetRegionFlags();
 


### PR DESCRIPTION
These changes address problems with recognizing some estate settings options, fixes an incorrect magic number for AllowVoice in the region flags, adds proper support for the voice options in Region/Estate/Parcel settings, and removes the temporary override that allowed it to mostly work in the past.