### PR TITLE
Added support for Mono's implementation of SQLite.

### DIFF
--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -60,11 +60,15 @@ namespace OpenSim.Region.Framework.Scenes
 
     public partial class Scene : SceneBase
     {
+        #if __MonoCS__
+        // TODO: Some cross-platform implementation.
+        #else
         [DllImport("kernel32.dll")]
         static extern bool SetThreadPriority(IntPtr hThread, ThreadPriorityLevel nPriority);
 
         [DllImport("kernel32.dll")]
         static extern IntPtr GetCurrentThread();
+        #endif
 
         /// <summary>
         /// The lowest an object can fall/travel before being considered off world
@@ -1085,8 +1089,12 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         void DoTiming()
         {
+            #if __MonoCS__
+            // TODO: Some cross-platform implementation.
+            #else
             IntPtr thrdHandle = GetCurrentThread();
             SetThreadPriority(thrdHandle, ThreadPriorityLevel.TimeCritical);
+            #endif
 
             byte tickNum = 0;
             while (true)

--- a/prebuild.xml
+++ b/prebuild.xml
@@ -1816,6 +1816,7 @@
       <Reference name="protobuf-net" path="../../bin/"/>
       <Reference name="Antlr3.Runtime" path="../../bin/"/>
       <Reference name="System.Data.SQLite" path="../../bin/"/>
+      <Reference name="Mono.Data.Sqlite"/>
       <Reference name="SmartThreadPool"/>
       <Files>
         <Match buildAction="EmbeddedResource" path="Resources" pattern="*.addin.xml" recurse="true"/>
@@ -2223,6 +2224,7 @@
       <Reference name="PhysX.Net.dll" path="../../bin/"/>
       <Reference name="protobuf-net" path="../../bin/"/>
       <Reference name="System.Data.SQLite" path="../../bin/"/>
+      <Reference name="Mono.Data.Sqlite"/>
 
       <Files>
         <Match pattern="*.addin.xml" path="Resources" buildAction="EmbeddedResource" recurse="true"/>
@@ -2313,6 +2315,7 @@
       <Reference name="protobuf-net" path="../../bin/"/>
       <Reference name="Antlr3.Runtime" path="../../bin/"/>
       <Reference name="System.Data.SQLite" path="../../bin/"/>
+      <Reference name="Mono.Data.Sqlite"/>
       <Reference name="SmartThreadPool"/>
       <Files>
         <Match pattern="*.cs" recurse="true"/>
@@ -2360,6 +2363,7 @@
       <Reference name="protobuf-net" path="../../../bin/"/>
       <Reference name="Antlr3.Runtime" path="../../../bin/"/>
       <Reference name="System.Data.SQLite" path="../../../bin/"/>
+      <Reference name="Mono.Data.Sqlite"/>
       <Reference name="KellermanSoftware.Compare-NET-Objects" path="../../../bin/"/>
       <Reference name="SmartThreadPool"/>
       <Files>


### PR DESCRIPTION
Mono ships its own implementation of SQLite: `Mono.Data.Sqlite`
Note the casing: Sqlite instead of SQLite.  This is the same across all the classes and functions, hence a pile of `#if __MonoCS__` tests.