### PR TITLE
Jim/jsonset

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -13628,9 +13628,10 @@ namespace InWorldz.Phlox.Engine
             {
                 OSD o = OSDParser.DeserializeJson(json);
                 OSD specVal = JsonGetSpecific(o, specifiers, 0);
+                if (specVal == null) return ScriptBaseClass.JSON_NULL;
                 string ret = specVal.AsString();
                 if (ret == "") return ScriptBaseClass.JSON_NULL;
-                if (specVal == null) return ScriptBaseClass.JSON_NULL;
+                return ret;
             }
             catch (Exception)
             {


### PR DESCRIPTION
Some major updates to the LSL JSON functions to more fully implement the remaining functions. The first 5 sections of the LL JSON test cases all pass, with the non-consequential exception of "2.5" vs "2.50000" in the JSON produced in llList2Json.  

Some testcases still fail; remaining issues are support for the escape character in strings (e.g. especially escaped quotes: \"), and the '[' and ']' characters in strings case the last section of testcases to have issues.  Some other cases of *not* failing some numeric constants that LL tests consider invalid, such as "-0".