### PR TITLE
Jim/editperms

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -4462,7 +4462,7 @@ namespace InWorldz.Phlox.Engine
             if (sp != null)
                 client = sp.ControllingClient;
 
-            if (!World.Permissions.CanEditObject(m_host.ParentGroup.UUID, client.AgentId))
+            if (!World.Permissions.CanEditObject(m_host.ParentGroup.UUID, client.AgentId, (uint)PermissionMask.Modify))
                 return; // host object is not editable
 
             SceneObjectPart targetPart = World.GetSceneObjectPart((UUID)target);
@@ -4473,7 +4473,7 @@ namespace InWorldz.Phlox.Engine
             if (targetPart.ParentGroup.RootPart.AttachmentPoint != 0)
                 return; // Fail silently if attached
 
-            if (!World.Permissions.CanEditObject(targetPart.ParentGroup.UUID, client.AgentId))
+            if (!World.Permissions.CanEditObject(targetPart.ParentGroup.UUID, client.AgentId, (uint)PermissionMask.Modify))
                 return; // target object is not editable
             if ((targetPart.ParentGroup.RootPart.OwnerMask & (uint)PermissionMask.Modify) != (uint)PermissionMask.Modify)
                 return; // target is no-mod

--- a/OpenSim/Region/CoreModules/World/Permissions/PermissionsModule.cs
+++ b/OpenSim/Region/CoreModules/World/Permissions/PermissionsModule.cs
@@ -952,7 +952,7 @@ namespace OpenSim.Region.CoreModules.World.Permissions
                     Success = true
                 };
             }
-        
+
             return permission;
         }
 
@@ -2139,7 +2139,7 @@ namespace OpenSim.Region.CoreModules.World.Permissions
             if (part.ParentGroup != null) prim = part.ParentGroup.UUID;
 
             // You can reset the scripts in any object you can edit
-            return GenericObjectPermission(agentID, prim, false, (uint)PermissionMask.Move).Success;
+            return GenericObjectPermission(agentID, prim, false, (uint)PermissionMask.Modify).Success;
         }
 
         private bool CanStartScript(SceneObjectPart part, UUID script, UUID agentID, Scene scene)

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -1548,7 +1548,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             if (group != null)
             {
-                if (!Permissions.CanEditObject(group.UUID, remoteClient.AgentId))
+                if (!Permissions.CanEditObject(group.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
                     return;
 
                 // Object itself must be modify to delete items
@@ -4345,7 +4345,7 @@ namespace OpenSim.Region.Framework.Scenes
                 else
                 {   
                     // This is the deed-to-group case.
-                    if (!Permissions.CanEditObject(sog.UUID, remoteClient.AgentId))
+                    if (!Permissions.CanEditObject(sog.UUID, remoteClient.AgentId, (uint)PermissionMask.Transfer))
                         continue;
 
                     if (sog.GroupID != groupID)

--- a/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
@@ -147,7 +147,7 @@ namespace OpenSim.Region.Framework.Scenes
                 group.IsSelected = true;
 
                 // A prim is only tainted if it's allowed to be edited by the person clicking it.
-                if (Permissions.CanEditObject(group.UUID, remoteClient.AgentId)
+                if (Permissions.CanEditObject(group.UUID, remoteClient.AgentId,0)
                     || Permissions.CanMoveObject(group.UUID, remoteClient.AgentId))
                 {
                     EventManager.TriggerParcelPrimCountTainted();
@@ -203,7 +203,7 @@ namespace OpenSim.Region.Framework.Scenes
             if (!isAttachment)
             {
                 if (Permissions.CanEditObject(
-                        part.ParentGroup.UUID, remoteClient.AgentId) 
+                        part.ParentGroup.UUID, remoteClient.AgentId, 0) 
                         || Permissions.CanMoveObject(
                         part.ParentGroup.UUID, remoteClient.AgentId))
                     EventManager.TriggerParcelPrimCountTainted();

--- a/OpenSim/Region/Framework/Scenes/Scene.Permissions.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Permissions.cs
@@ -44,7 +44,7 @@ namespace OpenSim.Region.Framework.Scenes
     public delegate bool TakeObjectHandler(UUID objectID, UUID stealer, Scene scene);
     public delegate bool TakeCopyObjectHandler(UUID objectID, UUID userID, Scene inScene);
     public delegate bool DuplicateObjectHandler(int objectCount, UUID objectID, UUID owner, Scene scene, Vector3 objectPosition);
-    public delegate bool EditObjectHandler(UUID objectID, UUID editorID, Scene scene);
+    public delegate bool EditObjectHandler(UUID objectID, UUID editorID, Scene scene, uint requiredPermissionMask);
     public delegate bool EditObjectInventoryHandler(UUID objectID, UUID editorID, Scene scene);
     public delegate bool MoveObjectHandler(UUID objectID, UUID moverID, Scene scene);
     public delegate bool ObjectEntryHandler(UUID objectID, bool enteringRegion, Vector3 newPoint, Scene scene);
@@ -310,7 +310,7 @@ namespace OpenSim.Region.Framework.Scenes
         #endregion
 
         #region EDIT OBJECT
-        public bool CanEditObject(UUID objectID, UUID editorID)
+        public bool CanEditObject(UUID objectID, UUID editorID, uint requiredPermissionMask)
         {
             EditObjectHandler handler = OnEditObject;
             if (handler != null)
@@ -318,7 +318,7 @@ namespace OpenSim.Region.Framework.Scenes
                 Delegate[] list = handler.GetInvocationList();
                 foreach (EditObjectHandler h in list)
                 {
-                    if (h(objectID, editorID, m_scene) == false)
+                    if (h(objectID, editorID, m_scene, requiredPermissionMask) == false)
                         return false;
                 }
             }

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -621,7 +621,7 @@ namespace OpenSim.Region.Framework.Scenes
                 SceneObjectPart part = m_parentScene.GetSceneObjectPart(primId);
                 if (part != null)
                 {
-                    if (m_parentScene.Permissions.CanEditObject(part.ParentGroup.RootPart.UUID, remoteClient.AgentId))
+                    if (m_parentScene.Permissions.CanEditObject(part.ParentGroup.RootPart.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
                     {
                         part.Undo();
                     }
@@ -636,7 +636,7 @@ namespace OpenSim.Region.Framework.Scenes
                 SceneObjectPart part = m_parentScene.GetSceneObjectPart(primId);
                 if (part != null)
                 {
-                    if (m_parentScene.Permissions.CanEditObject(part.ParentGroup.RootPart.UUID, remoteClient.AgentId))
+                    if (m_parentScene.Permissions.CanEditObject(part.ParentGroup.RootPart.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
                     {
                         part.Redo();
                     }
@@ -1520,7 +1520,7 @@ namespace OpenSim.Region.Framework.Scenes
             SceneObjectGroup group = GetGroupByPrim(localID);
             if (group != null)
             {
-                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId))
+                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
                 {
                     group.Resize(scale, localID);
                 }
@@ -1532,7 +1532,7 @@ namespace OpenSim.Region.Framework.Scenes
             SceneObjectGroup group = GetGroupByPrim(localID);
             if (group != null)
             {
-                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId))
+                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
                 {
                     group.GroupResize(scale, localID);
                 }
@@ -1694,7 +1694,7 @@ namespace OpenSim.Region.Framework.Scenes
             SceneObjectGroup group = GetGroupByPrim(localID);
             if (group != null)
             {
-                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId))
+                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
                 {
                     group.UpdateTextureEntry(localID, texture);
                 }
@@ -1715,7 +1715,7 @@ namespace OpenSim.Region.Framework.Scenes
             SceneObjectPart part = GetPrimByLocalId(localID);
             if (part != null)
             {
-                if (m_parentScene.Permissions.CanEditObject(part.ParentGroup.UUID, remoteClient.AgentId))
+                if (m_parentScene.Permissions.CanEditObject(part.ParentGroup.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
                 {
                     bool VolDetect = false;  // VolumeDetect can't be set via UI and will always be off when a change is made there
                     if (part.IsRootPart())
@@ -1813,7 +1813,7 @@ namespace OpenSim.Region.Framework.Scenes
             SceneObjectGroup group = GetGroupByPrim(primLocalID);
             if (group != null)
             {
-                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId))
+                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
                 {
                     group.SetPartName(Util.CleanString(name), primLocalID);
                     group.HasGroupChanged = true;
@@ -1831,7 +1831,7 @@ namespace OpenSim.Region.Framework.Scenes
             SceneObjectGroup group = GetGroupByPrim(primLocalID);
             if (group != null)
             {
-                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId))
+                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
                 {
                     group.SetPartDescription(Util.CleanString(description), primLocalID);
                     group.GetProperties(remoteClient);
@@ -1845,7 +1845,7 @@ namespace OpenSim.Region.Framework.Scenes
             SceneObjectGroup group = GetGroupByPrim(primLocalID);
             if (group != null)
             {
-                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId))
+                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
                 {
                     SceneObjectPart part = m_parentScene.GetSceneObjectPart(primLocalID);
                     part.ClickAction = Convert.ToByte(clickAction);
@@ -1859,7 +1859,7 @@ namespace OpenSim.Region.Framework.Scenes
             SceneObjectGroup group = GetGroupByPrim(primLocalID);
             if (group != null)
             {
-                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId))
+                if (m_parentScene.Permissions.CanEditObject(group.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
                 {
                     SceneObjectPart part = m_parentScene.GetSceneObjectPart(primLocalID);
                     part.Material = Convert.ToByte(material);
@@ -1874,7 +1874,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             if (group != null)
             {
-                if (m_parentScene.Permissions.CanEditObject(group.UUID, agentID))
+                if (m_parentScene.Permissions.CanEditObject(group.UUID, agentID, (uint)PermissionMask.Modify))
                 {
                     group.UpdateExtraParam(primLocalID, type, inUse, data);
                 }
@@ -1891,7 +1891,7 @@ namespace OpenSim.Region.Framework.Scenes
             SceneObjectGroup group = GetGroupByPrim(primLocalID);
             if (group != null)
             {
-                if (m_parentScene.Permissions.CanEditObject(group.UUID, agentID))
+                if (m_parentScene.Permissions.CanEditObject(group.UUID, agentID, (uint)PermissionMask.Modify))
                 {
                     ObjectShapePacket.ObjectDataBlock shapeData = new ObjectShapePacket.ObjectDataBlock();
                     shapeData.ObjectLocalID = shapeBlock.ObjectLocalID;
@@ -1935,7 +1935,7 @@ namespace OpenSim.Region.Framework.Scenes
                 parentGroup = GetGroupByPrim(parentPrimId);
                 if (parentGroup == null) return;
 
-                if (!m_parentScene.Permissions.CanEditObject(parentGroup.UUID, client.AgentId))
+                if (!m_parentScene.Permissions.CanEditObject(parentGroup.UUID, client.AgentId, (uint)PermissionMask.Modify))
                     return;
                 if ((parentGroup.RootPart.OwnerMask & (uint)PermissionMask.Modify) != (uint)PermissionMask.Modify)
                     return;
@@ -1945,7 +1945,7 @@ namespace OpenSim.Region.Framework.Scenes
                     SceneObjectGroup group = this.GetGroupByPrim(id);
                     if (group.OwnerID != parentGroup.OwnerID)
                         return; // two different owners
-                    if (!m_parentScene.Permissions.CanEditObject(group.UUID, client.AgentId))
+                    if (!m_parentScene.Permissions.CanEditObject(group.UUID, client.AgentId, (uint)PermissionMask.Modify))
                         return;
                     if ((group.RootPart.OwnerMask & (uint)PermissionMask.Modify) != (uint)PermissionMask.Modify)
                         return;
@@ -2030,7 +2030,7 @@ namespace OpenSim.Region.Framework.Scenes
                     SceneObjectPart part = this.GetSceneObjectPart(primID);
                     if (part != null)
                     {
-                        if (!m_parentScene.Permissions.CanEditObject(part.ParentGroup.RootPart.UUID, remoteClient.AgentId))
+                        if (!m_parentScene.Permissions.CanEditObject(part.ParentGroup.RootPart.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
                             continue;
                         if ((part.ParentGroup.RootPart.OwnerMask & (uint)PermissionMask.Modify) != (uint)PermissionMask.Modify)
                             continue;
@@ -2174,7 +2174,7 @@ namespace OpenSim.Region.Framework.Scenes
             // libomv will complain about PrimFlags.JointWheel being
             // deprecated, so we
 #pragma warning disable 0612
-            if (IncludeInSearch && m_parentScene.Permissions.CanEditObject(obj.ParentGroup.UUID, user))
+            if (IncludeInSearch && m_parentScene.Permissions.CanEditObject(obj.ParentGroup.UUID, user, (uint)PermissionMask.Modify))
             {
                 obj.ParentGroup.RootPart.AddFlag(PrimFlags.JointWheel);
                 obj.ParentGroup.HasGroupChanged = true;

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -621,7 +621,7 @@ namespace OpenSim.Region.Framework.Scenes
                 SceneObjectPart part = m_parentScene.GetSceneObjectPart(primId);
                 if (part != null)
                 {
-                    if (m_parentScene.Permissions.CanEditObject(part.ParentGroup.RootPart.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
+                    if (m_parentScene.Permissions.CanEditObject(part.ParentGroup.RootPart.UUID, remoteClient.AgentId, 0))
                     {
                         part.Undo();
                     }
@@ -636,7 +636,7 @@ namespace OpenSim.Region.Framework.Scenes
                 SceneObjectPart part = m_parentScene.GetSceneObjectPart(primId);
                 if (part != null)
                 {
-                    if (m_parentScene.Permissions.CanEditObject(part.ParentGroup.RootPart.UUID, remoteClient.AgentId, (uint)PermissionMask.Modify))
+                    if (m_parentScene.Permissions.CanEditObject(part.ParentGroup.RootPart.UUID, remoteClient.AgentId, 0))
                     {
                         part.Redo();
                     }


### PR DESCRIPTION
Fixed permissions allowing some no-mod objects to sometimes be modified. This fixes Mantis 3115, and also fixes missing server-side permissions checks in some cases for linking and unlinking, removing from contents, deeding objects to group, Undo and Redo, changing prim or object scale, changing prim/object name, description, flags, textures, and materials.  Also includes some optimizations to succeed or fail sooner in the override cases (e.g. god users, or no-mod objects).