### PR TITLE
Zauber halcyon 4

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -12728,6 +12728,13 @@ namespace InWorldz.Phlox.Engine
                         if (value == 255) ret.Add(1f);
                         else ret.Add(0f);
                         break;
+                    case ScriptBaseClass.OBJECT_LAST_OWNER_ID:
+                        ret.Add(UUID.Zero);
+                        break;
+                    case ScriptBaseClass.OBJECT_CLICK_ACTION:
+                        ret.Add(0);
+                        break;
+
                 }
             }
 

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -1446,7 +1446,7 @@ namespace OpenSim.Region.Framework.Scenes
                 if (ent is SceneObjectGroup)
                 {
                     SceneObjectGroup grp = (SceneObjectGroup)ent;
-                    if ((grp.RootPart.GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0)
+                    if ((grp.RootPart.GetEffectiveObjectFlagsFull() & PrimFlags.Scripted) != 0)
                     {
                         //this will cause a clear if the script hasnt run in a while
                         grp.AddScriptLPS(0.0);

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -1446,7 +1446,7 @@ namespace OpenSim.Region.Framework.Scenes
                 if (ent is SceneObjectGroup)
                 {
                     SceneObjectGroup grp = (SceneObjectGroup)ent;
-                    if ((grp.RootPart.GetEffectiveObjectFlagsFull() & PrimFlags.Scripted) != 0)
+                    if (((grp.RootPart.GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0) || grp.RootPart.IsScripted == true)
                     {
                         //this will cause a clear if the script hasnt run in a while
                         grp.AddScriptLPS(0.0);

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1510,6 +1510,7 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 RecalcPrimWeights();
             }
+            RootPart.CheckIsScripted();
         }
 
         /// <summary>
@@ -1534,6 +1535,7 @@ namespace OpenSim.Region.Framework.Scenes
 
                 // Update the ServerWeight/LandImpact
                 RecalcPrimWeights();
+                RootPart.CheckIsScripted();
             }
         }
 
@@ -2100,6 +2102,8 @@ namespace OpenSim.Region.Framework.Scenes
 
                 ScheduleGroupForFullUpdate();
             }
+
+            dupe.RootPart.CheckIsScripted();
 
             return dupe;
         }
@@ -2818,6 +2822,8 @@ namespace OpenSim.Region.Framework.Scenes
 
             this.RootPart.ClearUndoState();
 
+            this.RootPart.CheckIsScripted();
+
             HasGroupChanged = true;
             ScheduleGroupForFullUpdate();
         }
@@ -2919,6 +2925,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             // Update the ServerWeight/LandImpact and StreamingCost
             RecalcPrimWeights();
+            RootPart.CheckIsScripted();
 
             if (sendGroupUpdate)
             {

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -217,7 +217,10 @@ namespace OpenSim.Region.Framework.Scenes
         
         [XmlIgnore]
         public UUID FromItemID = UUID.Zero;
-               
+
+        [XmlIgnore]
+        private bool m_isScripted = false;
+
         /// <value>
         /// The UUID of the user inventory item from which this object was rezzed if this is a root part.  
         /// If UUID.Zero then either this is not a root part or there is no connection with a user inventory item.
@@ -1711,6 +1714,12 @@ namespace OpenSim.Region.Framework.Scenes
 
                 if (flag == PrimFlags.TemporaryOnRez)
                     ResetExpire();
+                if((flag & PrimFlags.Scripted) != 0)
+                {
+                    m_isScripted = true;
+                    if (ParentGroup.RootPart != this)
+                        ParentGroup.RootPart.IsScripted = true;
+                }
             }
         }
 
@@ -2213,20 +2222,6 @@ namespace OpenSim.Region.Framework.Scenes
             return Math.Sqrt(dx * dx + dy * dy + dz * dz);
         }
 
-        public PrimFlags GetEffectiveObjectFlagsFull()
-        {
-            foreach (SceneObjectPart part in ParentGroup.Children.Values)
-            {
-                if (part == null)
-                    continue;
-                if (part == this)
-                    continue;
-                if ((part.GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0)
-                    return _flags | LocalFlags | PrimFlags.Scripted;
-            }
-            return _flags | LocalFlags;
-        }
-
         public PrimFlags GetEffectiveObjectFlags()
         {
             return _flags | LocalFlags;
@@ -2724,7 +2719,7 @@ namespace OpenSim.Region.Framework.Scenes
         {
             DetectedType type = DetectedType.None;
 
-            if (obj.ParentGroup.GroupScriptEvents != Scenes.ScriptEvents.None)
+            if (obj.ParentGroup.GroupScriptEvents != Scenes.ScriptEvents.None || ParentGroup.RootPart.IsScripted == true)
             {
                 type |= DetectedType.Scripted;
             }
@@ -2809,6 +2804,12 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 //m_log.Debug("Removing flag: " + ((PrimFlags)flag).ToString());
                 _flags &= ~flag;
+                if((flag & PrimFlags.Scripted) != 0)
+                {
+                    if (ParentGroup.RootPart != this)
+                        m_isScripted = false;
+                    ParentGroup.RootPart.CheckIsScripted();
+                }
             }
             //m_log.Debug("prev: " + prevflag.ToString() + " curr: " + Flags.ToString());
             //ScheduleFullUpdate();
@@ -3051,6 +3052,8 @@ namespace OpenSim.Region.Framework.Scenes
                 return;
 
             clientFlags &= ~(uint) PrimFlags.CreateSelected;
+            if (IsScripted)
+                clientFlags |= (uint)PrimFlags.Scripted;
 
             if (remoteClient.AgentId == _ownerID)
             {
@@ -3073,6 +3076,8 @@ namespace OpenSim.Region.Framework.Scenes
         public void SendFullUpdateToClientImmediate(IClientAPI remoteClient, Vector3 lPos, uint clientFlags)
         {
             clientFlags &= ~(uint)PrimFlags.CreateSelected;
+            if (IsScripted)
+                clientFlags |= (uint)PrimFlags.Scripted;
 
             if (remoteClient.AgentId == _ownerID)
             {
@@ -4938,6 +4943,41 @@ namespace OpenSim.Region.Framework.Scenes
             if (ParentGroup.FromCrossing) flags |= PhysicsScene.AddPrimShapeFlags.FromCrossing;
 
             return flags;
+        }
+
+        public bool IsScripted
+        {
+            get
+            {
+                if (ParentGroup.RootPart == this && LinkNum != 0)
+                    return m_isScripted;                    
+                else
+                    return ((GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0);
+            }
+            set
+            {
+                m_isScripted = value;
+            }
+        }
+
+        public void CheckIsScripted()
+        {
+            if(ParentGroup.RootPart == this)
+            {
+                foreach (SceneObjectPart part in ParentGroup.Children.Values)
+                {
+                    if (part == null)
+                        continue;
+                    if((part.GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0)
+                    {
+                        this.m_isScripted = true;
+                        return;
+                    }
+                }
+            } else
+            {
+                m_isScripted = (GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0;
+            }
         }
 
         public bool IsPhantom

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -4971,9 +4971,10 @@ namespace OpenSim.Region.Framework.Scenes
                     if((part.GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0)
                     {
                         this.m_isScripted = true;
-                        return;
+                        break;
                     }
                 }
+                this.m_isScripted = false;
             } else
             {
                 m_isScripted = (GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0;

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -2213,18 +2213,23 @@ namespace OpenSim.Region.Framework.Scenes
             return Math.Sqrt(dx * dx + dy * dy + dz * dz);
         }
 
-        public PrimFlags GetEffectiveObjectFlags()
+        public PrimFlags GetEffectiveObjectFlagsFull()
         {
             PrimFlags ChildFlags = 0;
             if (ParentGroup.RootPart == this)
             {
                 foreach (SceneObjectPart part in ParentGroup.Children.Values)
                 {
-                    if(part != this)
+                    if (part != this)
                         ChildFlags |= part.GetEffectiveObjectFlags();
                 }
             }
             return _flags | LocalFlags | ChildFlags;
+        }
+
+        public PrimFlags GetEffectiveObjectFlags()
+        {
+            return _flags | LocalFlags;
         }
 
         public Vector3 GetGeometricCenter()

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -2215,16 +2215,16 @@ namespace OpenSim.Region.Framework.Scenes
 
         public PrimFlags GetEffectiveObjectFlagsFull()
         {
-            PrimFlags ChildFlags = 0;
-            if (ParentGroup.RootPart == this)
+            foreach (SceneObjectPart part in ParentGroup.Children.Values)
             {
-                foreach (SceneObjectPart part in ParentGroup.Children.Values)
-                {
-                    if (part != this)
-                        ChildFlags |= part.GetEffectiveObjectFlags();
-                }
+                if (part == null)
+                    continue;
+                if (part == this)
+                    continue;
+                if ((part.GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0)
+                    return _flags | LocalFlags | PrimFlags.Scripted;
             }
-            return _flags | LocalFlags | ChildFlags;
+            return _flags | LocalFlags;
         }
 
         public PrimFlags GetEffectiveObjectFlags()

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -2215,7 +2215,16 @@ namespace OpenSim.Region.Framework.Scenes
 
         public PrimFlags GetEffectiveObjectFlags()
         {
-            return _flags | LocalFlags;
+            PrimFlags ChildFlags = 0;
+            if (ParentGroup.RootPart == this)
+            {
+                foreach (SceneObjectPart part in ParentGroup.Children.Values)
+                {
+                    if(part != this)
+                        ChildFlags |= part.GetEffectiveObjectFlags();
+                }
+            }
+            return _flags | LocalFlags | ChildFlags;
         }
 
         public Vector3 GetGeometricCenter()

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -4962,8 +4962,13 @@ namespace OpenSim.Region.Framework.Scenes
 
         public void CheckIsScripted()
         {
-            if(ParentGroup.RootPart == this)
+            if(ParentGroup.RootPart == this && this.LinkNum != 0)
             {
+                if((GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0)
+                {
+                    this.m_isScripted = true;
+                    return;
+                }
                 foreach (SceneObjectPart part in ParentGroup.Children.Values)
                 {
                     if (part == null)
@@ -4975,7 +4980,8 @@ namespace OpenSim.Region.Framework.Scenes
                     }
                 }
                 this.m_isScripted = false;
-            } else
+            }
+            else
             {
                 m_isScripted = (GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0;
             }

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/SensorRepeat.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/SensorRepeat.cs
@@ -378,7 +378,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
                     if (part.AttachmentPoint != 0) // Attached so ignore
                         continue;
 
-                    if (part.Inventory.ContainsScripts())
+                    if (part.Inventory.ContainsScripts() || part.IsScripted)
                     {
                         objtype |= ACTIVE | SCRIPTED; // Scripted and active. It COULD have one hidden ...
                     }


### PR DESCRIPTION
This branch contains a fix for an issue where script sensors, Highlights/Beacons, and Top Scripts would only show scripted objects if there were scripts in the root prim, ignoring scripted objects if their scripts were only in the child prim(s) and not in the root prim.  Due to these changes, more scripted objects will be revealed to people using the tools above when they go searching for scripted objects.

Also included is a correction to llGetObjectDetails, where OBJECT_LAST_OWNER_ID and OBJECT_CLICK_ACTION were not handled when the function targeted an avatar.