### PR TITLE
Fixes for objects with scripted child prims

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -12728,6 +12728,12 @@ namespace InWorldz.Phlox.Engine
                         if (value == 255) ret.Add(1f);
                         else ret.Add(0f);
                         break;
+                    case ScriptBaseClass.OBJECT_LAST_OWNER_ID:
+                        ret.Add(UUID.Zero);
+                        break;
+                    case ScriptBaseClass.OBJECT_CLICK_ACTION:
+                        ret.Add(0);
+                        break;
                 }
             }
 

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -1446,7 +1446,8 @@ namespace OpenSim.Region.Framework.Scenes
                 if (ent is SceneObjectGroup)
                 {
                     SceneObjectGroup grp = (SceneObjectGroup)ent;
-                    if ((grp.RootPart.GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0)
+                    //if ((grp.RootPart.GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0)
+                    if(grp.IsScripted)
                     {
                         //this will cause a clear if the script hasnt run in a while
                         grp.AddScriptLPS(0.0);

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -1711,6 +1711,8 @@ namespace OpenSim.Region.Framework.Scenes
 
                 if (flag == PrimFlags.TemporaryOnRez)
                     ResetExpire();
+                if((flag & PrimFlags.Scripted) != 0 && !ParentGroup.IsScripted)
+                    ParentGroup.CheckIsScripted();
             }
         }
 
@@ -2710,7 +2712,7 @@ namespace OpenSim.Region.Framework.Scenes
         {
             DetectedType type = DetectedType.None;
 
-            if (obj.ParentGroup.GroupScriptEvents != Scenes.ScriptEvents.None)
+            if (obj.ParentGroup.GroupScriptEvents != Scenes.ScriptEvents.None || obj.ParentGroup.IsScripted)
             {
                 type |= DetectedType.Scripted;
             }
@@ -2795,6 +2797,8 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 //m_log.Debug("Removing flag: " + ((PrimFlags)flag).ToString());
                 _flags &= ~flag;
+                if ((flag & PrimFlags.Scripted) != 0)
+                    ParentGroup.CheckIsScripted();
             }
             //m_log.Debug("prev: " + prevflag.ToString() + " curr: " + Flags.ToString());
             //ScheduleFullUpdate();
@@ -3037,6 +3041,8 @@ namespace OpenSim.Region.Framework.Scenes
                 return;
 
             clientFlags &= ~(uint) PrimFlags.CreateSelected;
+            if (ParentGroup.IsScripted && ParentGroup.RootPart == this)
+                clientFlags |= (uint)PrimFlags.Scripted;
 
             if (remoteClient.AgentId == _ownerID)
             {
@@ -3059,6 +3065,8 @@ namespace OpenSim.Region.Framework.Scenes
         public void SendFullUpdateToClientImmediate(IClientAPI remoteClient, Vector3 lPos, uint clientFlags)
         {
             clientFlags &= ~(uint)PrimFlags.CreateSelected;
+            if (ParentGroup.IsScripted && ParentGroup.RootPart == this)
+                clientFlags |= (uint)PrimFlags.Scripted;
 
             if (remoteClient.AgentId == _ownerID)
             {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/SensorRepeat.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/SensorRepeat.cs
@@ -378,7 +378,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
                     if (part.AttachmentPoint != 0) // Attached so ignore
                         continue;
 
-                    if (part.Inventory.ContainsScripts())
+                    if (part.Inventory.ContainsScripts() || part.ParentGroup.IsScripted)
                     {
                         objtype |= ACTIVE | SCRIPTED; // Scripted and active. It COULD have one hidden ...
                     }

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/SensorRepeat.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/SensorRepeat.cs
@@ -378,7 +378,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
                     if (part.AttachmentPoint != 0) // Attached so ignore
                         continue;
 
-                    if (part.Inventory.ContainsScripts() || part.ParentGroup.IsScripted)
+                    if (part.ParentGroup.IsScripted || part.Inventory.ContainsScripts())
                     {
                         objtype |= ACTIVE | SCRIPTED; // Scripted and active. It COULD have one hidden ...
                     }


### PR DESCRIPTION
Makes some fixes so that objects which contain scripts in the child prims (but not the root prim) will properly show up as scripted objects.  This allows objects with scripts in the child parts to show up in Top Scripts and script sensors, along with being able to show up in viewer when script beacons or highlights are activated.  Also re-added the fix to GetAgentDetails to recognize OBJECT_LAST_OWNER_ID and OBJECT_CLICK_ACTION.