### PR TITLE
Issue 24 purge folder fixed

### DIFF
--- a/InWorldz/InWorldz.Data.Inventory.Cassandra/LegacyMysqlStorageImpl.cs
+++ b/InWorldz/InWorldz.Data.Inventory.Cassandra/LegacyMysqlStorageImpl.cs
@@ -916,13 +916,14 @@ namespace InWorldz.Data.Inventory.Cassandra
         /// <param name="folderId">Id of folder to delete</param>
         public void deleteInventoryFolder(UUID folderID)
         {
+            // Get a flattened list of all subfolders.
             List<InventoryFolderBase> subFolders = getFolderHierarchy(folderID);
 
             //Delete all sub-folders
             foreach (InventoryFolderBase f in subFolders)
             {
                 deleteItemsInFolder(f.ID); // Delete the items,
-                deleteOneFolder(f.ID); // then delete the folde
+                deleteOneFolder(f.ID); // then delete the folder.
             }
 
             //Delete the actual row

--- a/InWorldz/InWorldz.Data.Inventory.Cassandra/LegacyMysqlStorageImpl.cs
+++ b/InWorldz/InWorldz.Data.Inventory.Cassandra/LegacyMysqlStorageImpl.cs
@@ -921,13 +921,14 @@ namespace InWorldz.Data.Inventory.Cassandra
             //Delete all sub-folders
             foreach (InventoryFolderBase f in subFolders)
             {
-                deleteOneFolder(f.ID);
-                deleteItemsInFolder(f.ID);
+                deleteItemsInFolder(f.ID); // Delete the items,
+                deleteOneFolder(f.ID); // then delete the folde
             }
 
             //Delete the actual row
-            deleteOneFolder(folderID);
-            deleteItemsInFolder(folderID);
+            deleteItemsInFolder(folderID); // Delete the items,
+            deleteOneFolder(folderID); // then delete the folder.
+            // The above order is irrelevent when the database doesn't have foreign key contraints, but it's better to do it right anyway.
         }
 
         public List<InventoryItemBase> fetchActiveGestures(UUID avatarID)

--- a/OpenSim/Framework/Communications/Cache/CachedUserInfo.cs
+++ b/OpenSim/Framework/Communications/Cache/CachedUserInfo.cs
@@ -323,12 +323,35 @@ namespace OpenSim.Framework.Communications.Cache
         /// for this user then the request will be queued.
         ///
         /// <param name="folderID"></param>
-        public bool PurgeFolder(InventoryFolderBase folder)
+        public bool PurgeFolderContents(InventoryFolderBase folder)
         {
             try
             {
                 IInventoryProviderSelector inventorySelect = ProviderRegistry.Instance.Get<IInventoryProviderSelector>();
                 inventorySelect.GetProvider(m_userProfile.ID).PurgeFolderContents(folder);
+
+                return true;
+            }
+            catch (InventoryStorageException)
+            {
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// This method will delete the given folder and all the items and folders in it.
+        /// </summary>
+        /// If the inventory service has not yet delievered the inventory
+        /// for this user then the request will be queued.
+        ///
+        /// <param name="folderID"></param>
+        public bool PurgeFolder(InventoryFolderBase folder)
+        {
+            try
+            {
+                IInventoryProviderSelector inventorySelect = ProviderRegistry.Instance.Get<IInventoryProviderSelector>();
+                inventorySelect.GetProvider(m_userProfile.ID).PurgeFolder(folder);
 
                 return true;
             }

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -1476,37 +1476,6 @@ namespace OpenSim.Region.Framework.Scenes
             userInfo.DeleteItem(item);
         }
 
-        /// <summary>
-        /// Removes an inventory folder.  Although there is a packet in the Linden protocol for this, it may be
-        /// legacy and not currently used (purge folder is used to remove folders from trash instead).
-        /// </summary>
-        /// <param name="remoteClient"></param>
-        /// <param name="folderID"></param>
-        private void RemoveInventoryFolder(IClientAPI remoteClient, UUID folderID)
-        {
-            CachedUserInfo userInfo
-                = CommsManager.UserProfileCacheService.GetUserDetails(remoteClient.AgentId);
-
-            if (userInfo == null)
-            {
-                m_log.Warn("[AGENT INVENTORY]: Failed to find user " + remoteClient.AgentId.ToString());
-                return;
-            }
-
-            InventoryItemBase folder = userInfo.FindItem(folderID);
-
-            if (folder != null)
-            {
-                m_log.WarnFormat(
-                        "[AGENT INVENTORY]: Remove folder not implemented in request by {0} {1} for {2}",
-                        remoteClient.Name, remoteClient.AgentId, folderID);
-
-                // doesn't work just yet, commented out. will fix in next patch.
-                // userInfo.DeleteItem(folder);
-            }
-            
-        }
-
         private SceneObjectGroup GetGroupByPrim(uint localID)
         {
             return m_sceneGraph.GetGroupByPrim(localID);

--- a/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
@@ -628,10 +628,10 @@ namespace OpenSim.Region.Framework.Scenes
                         folderID, parentID, remoteClient.Name);
             }
             
-        }      
+        }
         
         /// <summary>
-        /// This should delete all the items and folders in the given directory.
+        /// This should recursively delete all the items and folders in the given directory.
         /// </summary>
         /// <param name="remoteClient"></param>
         /// <param name="folderID"></param>

--- a/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
@@ -667,6 +667,7 @@ namespace OpenSim.Region.Framework.Scenes
                     m_log.ErrorFormat(
                             "[AGENT INVENTORY]: Not purging descendents of {0} for user {1}, folder is not part of a purgeable heirarchy",
                             folderID, remoteClient.Name);
+                    return;
                 }
 
                 m_log.InfoFormat("[AGENT INVENTORY]: Purging descendents of {0} {1} for user {2}", folderID, folder.Name, remoteClient.Name);
@@ -717,6 +718,7 @@ namespace OpenSim.Region.Framework.Scenes
                     m_log.ErrorFormat(
                         "[AGENT INVENTORY]: Not purging descendents of {0} for user {1}, folder is not part of a purgeable heirarchy",
                         folderID, remoteClient.Name);
+                    return;
                 }
 
                 m_log.InfoFormat("[AGENT INVENTORY]: Purging {0} {1} for user {2}", folderID, folder.Name, remoteClient.Name);

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -3096,13 +3096,13 @@ namespace OpenSim.Region.Framework.Scenes
             client.OnUpdateInventoryFolder += HandleUpdateInventoryFolder;
             client.OnMoveInventoryFolder += HandleMoveInventoryFolder;
             client.OnFetchInventoryDescendents += HandleFetchInventoryDescendents;
-            client.OnPurgeInventoryDescendents += HandlePurgeInventoryDescendents;
+            client.OnPurgeInventoryDescendents += HandlePurgeInventoryDescendents; // Called when the user empties the Trash or 'Lost and Found', or purges a folder that has children. If the last case, OnRemoveInventoryFolder is called first for some silly reason.
             client.OnFetchInventory += HandleFetchInventory;
             client.OnUpdateInventoryItem += UpdateInventoryItemAsset;
             client.OnCopyInventoryItem += CopyInventoryItem;
             client.OnMoveInventoryItem += MoveInventoryItem;
             client.OnRemoveInventoryItem += RemoveInventoryItem;
-            client.OnRemoveInventoryFolder += HandlePurgeInventoryFolder;
+            client.OnRemoveInventoryFolder += HandlePurgeInventoryFolder; // Called when the user purges a folder.  If the folder has children OnPurgeInventoryDescendents is also called.
             client.OnRezScript += RezScript;
             client.OnRequestTaskInventory += RequestTaskInventory;
             client.OnRemoveTaskItem += RemoveTaskInventory;

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -3102,7 +3102,7 @@ namespace OpenSim.Region.Framework.Scenes
             client.OnCopyInventoryItem += CopyInventoryItem;
             client.OnMoveInventoryItem += MoveInventoryItem;
             client.OnRemoveInventoryItem += RemoveInventoryItem;
-            client.OnRemoveInventoryFolder += RemoveInventoryFolder;
+            client.OnRemoveInventoryFolder += HandlePurgeInventoryFolder;
             client.OnRezScript += RezScript;
             client.OnRequestTaskInventory += RequestTaskInventory;
             client.OnRemoveTaskItem += RemoveTaskInventory;


### PR DESCRIPTION
Should be ready to go, though I'm pretty sure that the Cassandra method `InventoryStorage::PurgeFolderInternal()` isn't live-tested - the only place it was previously called was from `InventoryStorage::PurgeFolders()` which only seems to be exercised by a unit test: `UnitTests::TestMultiPurgeFolder()`.  There is also a call through the apparently unused method `CheckedInventoryStorage::PurgeFolders()`.