### PR TITLE
Dev/mdickson/rendermaterials classes

### DIFF
--- a/OpenSim/Framework/RenderMaterials.cs
+++ b/OpenSim/Framework/RenderMaterials.cs
@@ -1,0 +1,380 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using OpenMetaverse;
+using OpenMetaverse.StructuredData;
+
+namespace OpenSim.Framework
+{
+    /// <summary>
+    /// A single textured face. Don't instantiate this class yourself, use the
+    /// methods in RenderMaterials
+    /// </summary>
+    public class RenderMaterial : ICloneable
+    {
+        public enum eDiffuseAlphaMode : byte
+        {
+            DIFFUSE_ALPHA_MODE_NONE = 0,
+            DIFFUSE_ALPHA_MODE_BLEND = 1,
+            DIFFUSE_ALPHA_MODE_MASK = 2,
+            DIFFUSE_ALPHA_MODE_EMISSIVE = 3,
+            DIFFUSE_ALPHA_MODE_DEFAULT = 4
+        };
+
+        public enum eShaderCount : byte
+        {
+            SHADER_COUNT = 16,
+            ALPHA_SHADER_COUNT = 4
+        };
+
+        public const string  MATERIALS_CAP_NORMAL_MAP_FIELD            = "NormMap";
+        public const string  MATERIALS_CAP_NORMAL_MAP_OFFSET_X_FIELD   = "NormOffsetX";
+        public const string  MATERIALS_CAP_NORMAL_MAP_OFFSET_Y_FIELD   = "NormOffsetY";
+        public const string  MATERIALS_CAP_NORMAL_MAP_REPEAT_X_FIELD   = "NormRepeatX";
+        public const string  MATERIALS_CAP_NORMAL_MAP_REPEAT_Y_FIELD   = "NormRepeatY";
+        public const string  MATERIALS_CAP_NORMAL_MAP_ROTATION_FIELD   = "NormRotation";
+
+        public const string  MATERIALS_CAP_SPECULAR_MAP_FIELD          = "SpecMap";
+        public const string  MATERIALS_CAP_SPECULAR_MAP_OFFSET_X_FIELD = "SpecOffsetX";
+        public const string  MATERIALS_CAP_SPECULAR_MAP_OFFSET_Y_FIELD = "SpecOffsetY";
+        public const string  MATERIALS_CAP_SPECULAR_MAP_REPEAT_X_FIELD = "SpecRepeatX";
+        public const string  MATERIALS_CAP_SPECULAR_MAP_REPEAT_Y_FIELD = "SpecRepeatY";
+        public const string  MATERIALS_CAP_SPECULAR_MAP_ROTATION_FIELD = "SpecRotation";
+
+        public const string  MATERIALS_CAP_SPECULAR_COLOR_FIELD        = "SpecColor";
+        public const string  MATERIALS_CAP_SPECULAR_EXP_FIELD          = "SpecExp";
+        public const string  MATERIALS_CAP_ENV_INTENSITY_FIELD         = "EnvIntensity";
+        public const string  MATERIALS_CAP_ALPHA_MASK_CUTOFF_FIELD     = "AlphaMaskCutoff";
+        public const string  MATERIALS_CAP_DIFFUSE_ALPHA_MODE_FIELD    = "DiffuseAlphaMode";
+
+        public const byte    DEFAULT_SPECULAR_LIGHT_EXPONENT = ((byte)(0.2f * 255));
+        public const byte    DEFAULT_ENV_INTENSITY = 0;
+
+        public static Color4 DEFAULT_SPECULAR_LIGHT_COLOR = new Color4 (255, 255, 255, 255);
+
+        private RenderMaterial DefaultMaterial;
+
+#region Properties
+
+        public UUID NormalID {
+            get;
+            set;
+        }
+
+        public float NormalOffsetX {
+            get;
+            set;
+        }
+
+        public float NormalOffsetY {
+            get;
+            set;
+        }
+
+        public float NormalRepeatX {
+            get;
+            set;
+        }
+
+        public float NormalRepeatY {
+            get;
+            set;
+        }
+
+        public float NormalRotation {
+            get;
+            set;
+        }
+
+        public UUID SpecularID {
+            get;
+            set;
+        }
+
+        public float SpecularOffsetX {
+            get;
+            set;
+        }
+
+        public float SpecularOffsetY {
+            get;
+            set;
+        }
+
+        public float SpecularRepeatX {
+            get;
+            set;
+        }
+
+        public float SpecularRepeatY {
+            get;
+            set;
+        }
+
+        public float SpecularRotation {
+            get;
+            set;
+        }
+
+        public Color4 SpecularLightColor {
+            get;
+            set;
+        }
+
+        public byte SpecularLightExponent {
+            get;
+            set;
+        }
+
+        public byte EnvironmentIntensity {
+            get;
+            set;
+        }
+
+        public byte DiffuseAlphaMode {
+            get;
+            set;
+        }
+
+        public byte AlphaMaskCutoff {
+            get;
+            set;
+        }
+
+#endregion Properties
+
+        public RenderMaterial ()
+        {
+            NormalOffsetX = 0.0f;
+            NormalOffsetY = 0.0f;
+            NormalRepeatX = 1.0f;
+            NormalRepeatY = 1.0f;
+            NormalRotation = 0.0f;
+            SpecularOffsetX = 0.0f;
+            SpecularOffsetY = 0.0f;
+            SpecularRepeatX = 1.0f;
+            SpecularRepeatY = 1.0f;
+            SpecularRotation = 0.0f;
+            SpecularLightColor = DEFAULT_SPECULAR_LIGHT_COLOR;
+            SpecularLightExponent = (byte)DEFAULT_SPECULAR_LIGHT_EXPONENT;
+            EnvironmentIntensity = (byte)DEFAULT_ENV_INTENSITY;
+            DiffuseAlphaMode = (byte)eDiffuseAlphaMode.DIFFUSE_ALPHA_MODE_BLEND;
+            AlphaMaskCutoff = 0;
+        }
+
+        public RenderMaterial(RenderMaterial defaultMaterial)
+        {
+            DefaultMaterial = defaultMaterial;
+        }
+
+        public override bool Equals (object obj)
+        {
+            if (obj == null)
+                return false;
+            if (ReferenceEquals (this, obj))
+                return true;
+            if (obj.GetType () != typeof(RenderMaterial))
+                return false;
+            
+            RenderMaterial other = (RenderMaterial)obj;
+            return  NormalID == other.NormalID && 
+                NormalOffsetX == other.NormalOffsetX && 
+                NormalOffsetY == other.NormalOffsetY && 
+                NormalRepeatX == other.NormalRepeatX && 
+                NormalRepeatY == other.NormalRepeatY && 
+                NormalRotation == other.NormalRotation && 
+                SpecularID == other.SpecularID && 
+                SpecularOffsetX == other.SpecularOffsetX && 
+                SpecularOffsetY == other.SpecularOffsetY && 
+                SpecularRepeatX == other.SpecularRepeatX && 
+                SpecularRepeatY == other.SpecularRepeatY && 
+                SpecularRotation == other.SpecularRotation && 
+                SpecularLightColor == other.SpecularLightColor && 
+                SpecularLightExponent == other.SpecularLightExponent && 
+                EnvironmentIntensity == other.EnvironmentIntensity && 
+                DiffuseAlphaMode == other.DiffuseAlphaMode && 
+                AlphaMaskCutoff == other.AlphaMaskCutoff;
+        }
+
+        public override int GetHashCode ()
+        {
+            unchecked {
+                return 
+                    NormalID.GetHashCode () ^ 
+                    NormalOffsetX.GetHashCode () ^ 
+                    NormalOffsetY.GetHashCode () ^ 
+                    NormalRepeatX.GetHashCode () ^ 
+                    NormalRepeatY.GetHashCode () ^ 
+                    NormalRotation.GetHashCode () ^ 
+                    SpecularID.GetHashCode () ^ 
+                    SpecularOffsetX.GetHashCode () ^ 
+                    SpecularOffsetY.GetHashCode () ^ 
+                    SpecularRepeatX.GetHashCode () ^ 
+                    SpecularRepeatY.GetHashCode () ^ 
+                    SpecularRotation.GetHashCode () ^ 
+                    SpecularLightColor.GetHashCode () ^ 
+                    SpecularLightExponent.GetHashCode () ^
+                    EnvironmentIntensity.GetHashCode () ^ 
+                    DiffuseAlphaMode.GetHashCode () ^ 
+                    AlphaMaskCutoff.GetHashCode ();
+            }
+        }
+
+        public override string ToString ()
+        {
+            return string.Format ("[RenderMaterial: NormalID={0}, NormalOffsetX={1}, NormalOffsetY={2}, NormalRepeatX={3}, NormalRepeatY={4}, NormalRotation={5}, SpecularID={6}, SpecularOffsetX={7}, SpecularOffsetY={8}, SpecularRepeatX={9}, SpecularRepeatY={10}, SpecularRotation={11}, SpecularLightColor={12}, SpecularLightExponent={13}, EnvironmentIntensity={14}, DiffuseAlphaMode={15}, AlphaMaskCutoff={16}]", 
+                NormalID, NormalOffsetX, NormalOffsetY, NormalRepeatX, NormalRepeatY, NormalRotation, SpecularID, SpecularOffsetX, SpecularOffsetY, SpecularRepeatX, SpecularRepeatY, SpecularRotation, SpecularLightColor, SpecularLightExponent, EnvironmentIntensity, DiffuseAlphaMode, AlphaMaskCutoff);
+        }
+
+        public object Clone ()
+        {
+            RenderMaterial ret = (RenderMaterial)this.MemberwiseClone ();
+            ret.NormalID = new UUID (this.NormalID);
+            ret.SpecularID = new UUID (this.SpecularID);
+            ret.SpecularLightColor = new Color4 (ret.SpecularLightColor);
+            return ret;
+        }
+
+        public OSD GetOSD ()
+        {
+            OSDMap material_data = new OSDMap (17);
+
+            material_data[MATERIALS_CAP_NORMAL_MAP_FIELD] = OSD.FromUUID(NormalID);
+            material_data [MATERIALS_CAP_NORMAL_MAP_OFFSET_X_FIELD] = OSD.FromReal (NormalOffsetX);
+            material_data [MATERIALS_CAP_NORMAL_MAP_OFFSET_Y_FIELD] = OSD.FromReal (NormalOffsetY);
+            material_data [MATERIALS_CAP_NORMAL_MAP_REPEAT_X_FIELD] = OSD.FromReal (NormalRepeatX);
+            material_data [MATERIALS_CAP_NORMAL_MAP_REPEAT_Y_FIELD] = OSD.FromReal (NormalRepeatY);
+            material_data [MATERIALS_CAP_NORMAL_MAP_ROTATION_FIELD] = OSD.FromReal (NormalRotation);
+
+            material_data [MATERIALS_CAP_SPECULAR_MAP_FIELD] = OSD.FromUUID (SpecularID);
+            material_data [MATERIALS_CAP_SPECULAR_MAP_OFFSET_X_FIELD] = OSD.FromReal (SpecularOffsetX);
+            material_data [MATERIALS_CAP_SPECULAR_MAP_OFFSET_Y_FIELD] = OSD.FromReal (SpecularOffsetY);
+            material_data [MATERIALS_CAP_SPECULAR_MAP_REPEAT_X_FIELD] = OSD.FromReal (SpecularRepeatX);
+            material_data [MATERIALS_CAP_SPECULAR_MAP_REPEAT_Y_FIELD] = OSD.FromReal (SpecularRepeatY);
+            material_data [MATERIALS_CAP_SPECULAR_MAP_ROTATION_FIELD] = OSD.FromReal (SpecularRotation);
+
+            material_data [MATERIALS_CAP_SPECULAR_COLOR_FIELD] = OSD.FromColor4 (SpecularLightColor);
+            material_data [MATERIALS_CAP_SPECULAR_EXP_FIELD] = OSD.FromInteger ((int)SpecularLightExponent);
+            material_data [MATERIALS_CAP_ENV_INTENSITY_FIELD] = OSD.FromInteger ((int)EnvironmentIntensity);
+            material_data [MATERIALS_CAP_DIFFUSE_ALPHA_MODE_FIELD] = OSD.FromInteger ((int)DiffuseAlphaMode);
+            material_data [MATERIALS_CAP_ALPHA_MASK_CUTOFF_FIELD] = OSD.FromInteger ((int)AlphaMaskCutoff);
+
+            return material_data;
+        }
+
+        public static RenderMaterial FromOSD (OSD osd)
+        {
+            OSDMap map = osd as OSDMap;
+            RenderMaterial material = new RenderMaterial ();
+
+            material.NormalID = map [MATERIALS_CAP_NORMAL_MAP_FIELD].AsUUID ();
+            material.NormalOffsetX = (float)map [MATERIALS_CAP_NORMAL_MAP_OFFSET_X_FIELD].AsReal ();
+            material.NormalOffsetY = (float)map [MATERIALS_CAP_NORMAL_MAP_OFFSET_Y_FIELD].AsReal ();
+            material.NormalRepeatX = (float)map [MATERIALS_CAP_NORMAL_MAP_REPEAT_X_FIELD].AsReal ();
+            material.NormalRepeatY = (float)map [MATERIALS_CAP_NORMAL_MAP_REPEAT_Y_FIELD].AsReal ();
+            material.NormalRotation = (float)map [MATERIALS_CAP_NORMAL_MAP_ROTATION_FIELD].AsReal ();
+
+            material.SpecularID = map [MATERIALS_CAP_SPECULAR_MAP_FIELD].AsUUID ();
+            material.SpecularOffsetX = (float)map [MATERIALS_CAP_SPECULAR_MAP_OFFSET_X_FIELD].AsReal ();
+            material.SpecularOffsetY = (float)map [MATERIALS_CAP_SPECULAR_MAP_OFFSET_Y_FIELD].AsReal ();
+            material.SpecularRepeatX = (float)map [MATERIALS_CAP_SPECULAR_MAP_REPEAT_X_FIELD].AsReal ();
+            material.SpecularRepeatY = (float)map [MATERIALS_CAP_SPECULAR_MAP_REPEAT_Y_FIELD].AsReal ();
+            material.SpecularRotation = (float)map [MATERIALS_CAP_SPECULAR_MAP_ROTATION_FIELD].AsReal ();
+
+            material.SpecularLightColor = map [MATERIALS_CAP_SPECULAR_COLOR_FIELD].AsColor4 ();
+            material.SpecularLightExponent = (byte)map [MATERIALS_CAP_SPECULAR_EXP_FIELD].AsInteger ();
+            material.EnvironmentIntensity = (byte)map [MATERIALS_CAP_ENV_INTENSITY_FIELD].AsInteger ();
+            material.DiffuseAlphaMode = (byte)map [MATERIALS_CAP_DIFFUSE_ALPHA_MODE_FIELD].AsInteger ();
+            material.AlphaMaskCutoff = (byte)map [MATERIALS_CAP_ALPHA_MASK_CUTOFF_FIELD].AsInteger ();
+
+            return material;
+        }
+    }
+
+    /// <summary>
+    /// Represents all of the materials faces for an object
+    /// </summary>
+    /// <remarks>Grid objects have infinite faces, with each face
+    /// using the properties of the default face unless set otherwise. So if
+    /// you have a RenderMaterial with a default texture uuid of X, and face 18
+    /// has a texture UUID of Y, every face would be textured with X except for
+    /// face 18 that uses Y. In practice however, primitives utilize a maximum
+    /// of nine faces</remarks>
+    public class RenderMaterials
+    {
+        public Dictionary<String, RenderMaterial> Materials;
+
+        public RenderMaterials()
+        {
+            Materials = new Dictionary<String, RenderMaterial> ();
+        }
+
+        /// <summary>
+        /// Constructor that creates the RenderMaterial class from a byte array
+        /// </summary>
+        /// <param name="data">Byte array containing the RenderMaterial field</param>
+        /// <param name="pos">Starting position of the RenderMaterial field in 
+        /// the byte array</param>
+        /// <param name="length">Length of the RenderMaterial field, in bytes</param>
+        public RenderMaterials (byte[] data, int pos, int length)
+        {
+            FromBytes (data, pos, length);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public OSD GetOSD ()
+        {
+            OSDArray array = new OSDArray ();
+            return array;
+        }
+
+        public static RenderMaterials FromOSD (OSD osd)
+        {
+            if (osd.Type == OSDType.Array) {
+                OSDArray array = (OSDArray)osd;
+            }
+
+            return new RenderMaterials ();
+        }
+
+        private void FromBytes (byte[] data, int pos, int length)
+        {
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public byte[] GetBytes ()
+        {
+            return Utils.EmptyBytes;
+
+
+        }
+
+        public override int GetHashCode ()
+        {
+            int hashcode = 0;
+            foreach (var mat in Materials.Values) {
+                hashcode ^= mat.GetHashCode ();
+            }
+
+            return hashcode;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString ()
+        {
+            string output = String.Empty;
+            return output;
+        }
+
+    }
+}
+

--- a/OpenSim/Framework/Tests/RenderMaterialsTests.cs
+++ b/OpenSim/Framework/Tests/RenderMaterialsTests.cs
@@ -40,6 +40,19 @@ namespace OpenSim.Framework.Tests
             Assert.That (matFromOSD.DiffuseAlphaMode, Is.EqualTo((byte)RenderMaterial.eDiffuseAlphaMode.DIFFUSE_ALPHA_MODE_BLEND));
             Assert.That (matFromOSD.AlphaMaskCutoff, Is.EqualTo(0));
         }
+
+		[Test]
+		public void T001_ToFromBinaryTest()
+		{
+			RenderMaterial mat = new RenderMaterial ();
+			RenderMaterials mats = new RenderMaterials ();
+			String key = mats.AddMaterial (mat);
+
+			byte[] bytes = mats.GetBytes ();
+			RenderMaterials newmats = new RenderMaterials (bytes, 0, bytes.Length);
+			RenderMaterial newmat = newmats.GetMaterial (key);
+			Assert.That (mat, Is.EqualTo(newmat));
+		}
     }
 }
 

--- a/OpenSim/Framework/Tests/RenderMaterialsTests.cs
+++ b/OpenSim/Framework/Tests/RenderMaterialsTests.cs
@@ -46,11 +46,12 @@ namespace OpenSim.Framework.Tests
 		{
 			RenderMaterial mat = new RenderMaterial ();
 			RenderMaterials mats = new RenderMaterials ();
-			String key = mats.AddMaterial (mat);
+            String key = UUID.Random().ToString();
+            mats.Materials.Add(key, mat);
 
-			byte[] bytes = mats.GetBytes ();
-			RenderMaterials newmats = new RenderMaterials (bytes, 0, bytes.Length);
-			RenderMaterial newmat = newmats.GetMaterial (key);
+			byte[] bytes = mats.ToBytes ();
+            RenderMaterials newmats = RenderMaterials.FromBytes(bytes, 0);
+            RenderMaterial newmat = newmats.Materials[key];
 			Assert.That (mat, Is.EqualTo(newmat));
 		}
     }

--- a/OpenSim/Framework/Tests/RenderMaterialsTests.cs
+++ b/OpenSim/Framework/Tests/RenderMaterialsTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using OpenSim.Framework;
+using OpenMetaverse;
+using OpenMetaverse.StructuredData;
+
+namespace OpenSim.Framework.Tests
+{
+    [TestFixture]
+    public class RenderMaterialsTests
+    {
+        [TestFixtureSetUp]
+        public void Init()
+        {
+        }
+
+        [Test]
+        public void T000_OSDFromToTest()
+        {
+            RenderMaterial mat = new RenderMaterial ();
+            OSD map = mat.GetOSD ();
+            RenderMaterial matFromOSD = RenderMaterial.FromOSD (map);
+            Assert.That (mat, Is.EqualTo (matFromOSD));
+            Assert.That (matFromOSD.NormalID, Is.EqualTo (UUID.Zero));
+            Assert.That (matFromOSD.NormalOffsetX, Is.EqualTo (0.0f));
+            Assert.That (matFromOSD.NormalOffsetY, Is.EqualTo(0.0f));
+            Assert.That (matFromOSD.NormalRepeatX, Is.EqualTo(1.0f));
+            Assert.That (matFromOSD.NormalRepeatY, Is.EqualTo(1.0f));
+            Assert.That (matFromOSD.NormalRotation, Is.EqualTo(0.0f));
+            Assert.That (matFromOSD.SpecularOffsetX, Is.EqualTo(0.0f));
+            Assert.That (matFromOSD.SpecularOffsetY, Is.EqualTo(0.0f));
+            Assert.That (matFromOSD.SpecularRepeatX, Is.EqualTo(1.0f));
+            Assert.That (matFromOSD.SpecularRepeatY, Is.EqualTo(1.0f));
+            Assert.That (matFromOSD.SpecularRotation, Is.EqualTo(0.0f));
+            Assert.That (matFromOSD.SpecularLightColor, Is.EqualTo(RenderMaterial.DEFAULT_SPECULAR_LIGHT_COLOR));
+            Assert.That (matFromOSD.SpecularLightExponent, Is.EqualTo(RenderMaterial.DEFAULT_SPECULAR_LIGHT_EXPONENT));
+            Assert.That (matFromOSD.EnvironmentIntensity, Is.EqualTo(RenderMaterial.DEFAULT_ENV_INTENSITY));
+            Assert.That (matFromOSD.DiffuseAlphaMode, Is.EqualTo((byte)RenderMaterial.eDiffuseAlphaMode.DIFFUSE_ALPHA_MODE_BLEND));
+            Assert.That (matFromOSD.AlphaMaskCutoff, Is.EqualTo(0));
+        }
+    }
+}
+

--- a/prebuild.xml
+++ b/prebuild.xml
@@ -72,6 +72,42 @@
       </Files>
     </Project>
 
+   <Project frameworkVersion="v4_5" name="OpenSim.Framework.Tests" path="OpenSim/Framework/Tests" type="Library">
+      <Configuration name="Debug" platform="x64">
+        <Options>
+          <OutputPath>../../bin/</OutputPath>
+        </Options>
+      </Configuration>
+      <Configuration name="Release" platform="x64">
+        <Options>
+          <OutputPath>../../bin/</OutputPath>
+        </Options>
+      </Configuration>
+
+      <ReferencePath>../../bin/</ReferencePath>
+      <Reference name="System"/>
+      <Reference name="System.Core"/>
+      <Reference name="System.Xml"/>
+      <Reference name="System.Data"/>
+      <Reference name="System.Web"/>
+      <Reference name="OpenMetaverseTypes" path="../../../bin/"/>
+      <Reference name="OpenMetaverse" path="../../../bin/"/>
+      <Reference name="OpenMetaverse.StructuredData" path="../../../bin/"/>
+      <Reference name="XmlRpcCS" path="../../../bin/"/>
+      <Reference name="Nini" path="../../../bin/"/>
+      <Reference name="log4net" path="../../../bin/"/>
+      <Reference name="nunit.framework" path="../../../bin/"/>
+      <Reference name="Mono.Addins" path="../../../bin/"/>
+      <Reference name="C5" path="../../../bin/"/>
+      <Reference name="BclExtras35" path="../../../bin/"/>
+      <Reference name="protobuf-net" path="../../../bin/"/>
+      <Reference name="OpenSim.Framework" path="../../../bin/"/>
+      <Files>
+        <Match pattern="*.cs" recurse="true"/>
+      </Files>
+    </Project>
+
+
     <Project frameworkVersion="v4_5" name="OpenSim.Framework.Servers.HttpServer" path="OpenSim/Framework/Servers/HttpServer" type="Library">
       <Configuration name="Debug" platform="x64">
         <Options>

--- a/runprebuild.sh
+++ b/runprebuild.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # mono bin/Prebuild.exe /target nant
-mono bin/Prebuild.exe /target vs2012
+mono bin/Prebuild.exe /target vs2015


### PR DESCRIPTION
Base classes used for RenderMaterials support.  Includes getter/setters for individual parameters.  Also test cases for serialization as OSD which is needed by the CAP and a binary serialization which may be useful for SQLifying the data.