### PR TITLE
Change to implicit animation perms for bots

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -4354,6 +4354,17 @@ namespace InWorldz.Phlox.Engine
                                 ScriptBaseClass.PERMISSION_TRACK_CAMERA |
                                 ScriptBaseClass.PERMISSION_TAKE_CONTROLS;
             }
+            else
+            {
+                ScenePresence presence = World.GetScenePresence(agentID);
+                if ((presence != null) && (presence.IsBot) && (!presence.IsChildAgent))
+                {
+                    if (presence.OwnerID == m_host.OwnerID)
+                    {
+                        implicitPerms = ScriptBaseClass.PERMISSION_TRIGGER_ANIMATION;
+                    }
+                }
+            }
 
             return implicitPerms;
         }


### PR DESCRIPTION
This change allows animation perms to be implicitly granted for bots when the object requesting animations is owned by the bot's owner.  This change is to allow bots to be animated by scripted objects that have not been coded to handle bots.

I would like to have extended this so that if a bot is seated on an object, animation perms are implicitly granted for any object owned by the same owner as whatever the bot is sitting on, however that would require me to change an area of the codebase that I have not yet familiarized myself with.