### PR TITLE
More implicit animation perms for bots

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -4363,6 +4363,11 @@ namespace InWorldz.Phlox.Engine
                     {
                         implicitPerms = ScriptBaseClass.PERMISSION_TRIGGER_ANIMATION;
                     }
+                    ScenePresence.PositionInfo info = presence.GetPosInfo();
+                    if(info.Parent != null && info.Parent.ObjectOwner == m_host.OwnerID)
+                    {
+                        implicitPerms = ScriptBaseClass.PERMISSION_TRIGGER_ANIMATION;
+                    }
                 }
             }
 

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -4365,12 +4365,12 @@ namespace InWorldz.Phlox.Engine
                     }
                     else
                     {
-						ScenePresence.PositionInfo info = presence.GetPosInfo();
-						if(info.Parent != null && info.Parent.ObjectOwner == m_host.OwnerID)
-						{
-							implicitPerms = ScriptBaseClass.PERMISSION_TRIGGER_ANIMATION;
-						}
-					}
+                        ScenePresence.PositionInfo info = presence.GetPosInfo();
+                        if(info.Parent != null && info.Parent.ObjectOwner == m_host.OwnerID)
+                        {
+                            implicitPerms = ScriptBaseClass.PERMISSION_TRIGGER_ANIMATION;
+                        }
+                    }
                 }
             }
 

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -4363,11 +4363,14 @@ namespace InWorldz.Phlox.Engine
                     {
                         implicitPerms = ScriptBaseClass.PERMISSION_TRIGGER_ANIMATION;
                     }
-                    ScenePresence.PositionInfo info = presence.GetPosInfo();
-                    if(info.Parent != null && info.Parent.ObjectOwner == m_host.OwnerID)
+                    else
                     {
-                        implicitPerms = ScriptBaseClass.PERMISSION_TRIGGER_ANIMATION;
-                    }
+						ScenePresence.PositionInfo info = presence.GetPosInfo();
+						if(info.Parent != null && info.Parent.ObjectOwner == m_host.OwnerID)
+						{
+							implicitPerms = ScriptBaseClass.PERMISSION_TRIGGER_ANIMATION;
+						}
+					}
                 }
             }
 


### PR DESCRIPTION
Another change to GetImplicitPermissions to allow bots to work with scripts that haven't been coded to account for bots.  Basically, if an avatar is seated on an object, then animation perm requests are implicitly granted from any objects owned by whomever owns the seat.