### PR TITLE
Ll get agent info flying sitting fix

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -7005,12 +7005,6 @@ namespace InWorldz.Phlox.Engine
                     flags |= ScriptBaseClass.AGENT_SCRIPTED;
             }
 
-            if ((agent.AgentControlFlags & (uint)AgentManager.ControlFlags.AGENT_CONTROL_FLY) != 0)
-            {
-                flags |= ScriptBaseClass.AGENT_FLYING;
-                flags |= ScriptBaseClass.AGENT_IN_AIR; // flying always implies in-air, even if colliding with e.g. a wall
-            }
-
             if ((agent.AgentControlFlags & (uint)AgentManager.ControlFlags.AGENT_CONTROL_AWAY) != 0)
             {
                 flags |= ScriptBaseClass.AGENT_AWAY;
@@ -7061,6 +7055,17 @@ namespace InWorldz.Phlox.Engine
             if (agent.Animations.DefaultAnimation.AnimID == AnimationSet.Animations.AnimsUUID["SIT_GROUND_CONSTRAINED"])
             {
                 flags |= ScriptBaseClass.AGENT_SITTING;
+            }
+
+            //Workaround for issue where AGENT_FLYING is sometimes set while sitting
+            //Since a seated avatar cannot be flying or in the air, do not set the flags if agent is seated
+            if((flags & ScriptBaseClass.AGENT_SITTING) == 0)
+            {
+                if ((agent.AgentControlFlags & (uint)AgentManager.ControlFlags.AGENT_CONTROL_FLY) != 0)
+                {
+                    flags |= ScriptBaseClass.AGENT_FLYING;
+                    flags |= ScriptBaseClass.AGENT_IN_AIR; // flying always implies in-air, even if colliding with e.g. a wall
+                }
             }
 
             // not colliding implies in air. Note: flying also implies in-air, even if colliding (see above)


### PR DESCRIPTION
Applies a workaround to an issue that caused llGetAgentInfo to indicate that an avatar was flying when they were sitting, triggered by the avatar trying to sit while they are flying, and then llGetAgentInfo being called upon the CHANGED_ANIMATION trigger firing in the changed event.