### PR TITLE
Fixed regression in #35 which caused InventoryKey to return NULL_KEY for all wildcard (-1) searches.

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -626,7 +626,7 @@ namespace InWorldz.Phlox.Engine
                 {
                     if (inv.Value.Name == name)
                     {
-                        if (inv.Value.Type != type || type == -1)
+                        if ((inv.Value.Type != type) && (type != -1))
                             return UUID.Zero;
 
                         return inv.Value.AssetID;


### PR DESCRIPTION
Reported by Yichard as a breakage in llPlaySound when an inventory name
was specified, but affects any function that takes an inventory name.