### PR TITLE
A few more gitignore entries for monodevelop debug files and nant bui…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,12 @@
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
+*.mdb 
+*.mdp
+
+# Nant
+*.dll.build
+*.exe.build
 
 # Build results
 [Dd]ebug/


### PR DESCRIPTION
Add a few more files to .gitignore.  mdb and mdb files for Monodevelop debugging and dont include nant *.build files generated from prebuild in Thirdparty.
