### PR TITLE
Add a DateTime field to CacheEntry and code to Cache to use it and a …

### DIFF
--- a/InWorldz/InWorldz.Data.Assets.Stratus/Cache/Cache.cs
+++ b/InWorldz/InWorldz.Data.Assets.Stratus/Cache/Cache.cs
@@ -29,6 +29,7 @@
  */
 
 using System;
+using System.Threading;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -43,6 +44,13 @@ namespace InWorldz.Data.Assets.Stratus.Cache
     /// </summary>
     internal class Cache
     {
+        /// <summary>
+        /// A system timer and interval values used to age the cache;
+        /// </summary>
+        private System.Threading.Timer _expiry_timer = null;
+        private uint _expiry = 0;
+        private uint _maxAge = 0;
+
         /// <summary>
         /// We dont make the cache exactly the same size as the buffer pool. This tries to make sure
         /// we always have some room left in the buffer pool and that we're not constantly swapping
@@ -63,7 +71,6 @@ namespace InWorldz.Data.Assets.Stratus.Cache
             Config.Constants.MAX_CACHEABLE_ASSET_SIZE / 2, //note: if you change this size unit tests will need to be updated
             Config.Constants.MAX_CACHEABLE_ASSET_SIZE 
         };
-
 
         private LRUCache<UUID, CacheEntry> _assetCache;
         private ByteBufferPool _bufferPool;
@@ -90,8 +97,32 @@ namespace InWorldz.Data.Assets.Stratus.Cache
             }
         }
 
-        public Cache()
+        /// <summary>
+        /// Construct a cache object with no expiration. Simple LRU behaviour.
+        /// </summary>
+        public Cache() : this(0, 0)
         {
+        }
+
+        /// <summary>
+        /// Initialize the cache, specifying the maximum age in milliseconds 
+        /// that an entry can be in the cache, and an expiry time in milliseconds
+        /// indicating how frequently to scan for items past maxAge. If an item 
+        /// hasnt been accessed in > maxAge milliseconds it's a candidate for removal.
+        /// </summary>
+        public Cache(uint maxAge, uint expiryInterval)
+        {
+            /// If an expiration value was specified set an interval timer we'll 
+            /// use to age the cache.  
+            _maxAge = maxAge;
+            _expiry = expiryInterval;
+
+            if ((_maxAge > 0) && (_expiry > 0))
+            {
+                // Create a timer and set the interval to _expiry.
+                _expiry_timer = new Timer(OnTimedEvent, null, _expiry, Timeout.Infinite);
+            }
+
             _assetCache = new LRUCache<UUID, CacheEntry>(Config.Settings.Instance.CFCacheSize, true);
             _assetCache.OnItemPurged += _assetCache_OnItemPurged;
 
@@ -113,7 +144,10 @@ namespace InWorldz.Data.Assets.Stratus.Cache
 
             Buffer.BlockCopy(data, 0, cacheData, 0, data.Length);
 
-            _assetCache.Add(assetId, new CacheEntry { Data = cacheData, Size = data.Length }, cacheData.Length);
+            lock (_assetCache)
+            {
+                _assetCache.Add(assetId, new CacheEntry { Data = cacheData, Size = data.Length, LastAccess = DateTime.Now }, cacheData.Length);
+            }
         }
 
         public void CacheAssetData(UUID assetId, Stream data)
@@ -128,22 +162,59 @@ namespace InWorldz.Data.Assets.Stratus.Cache
                 data.CopyTo(outStream);
             }
 
-            _assetCache.Add(assetId, new CacheEntry { Data = cacheData, Size = dataLen }, cacheData.Length);
+            lock (_assetCache)
+            {
+                _assetCache.Add(assetId, new CacheEntry { Data = cacheData, Size = dataLen, LastAccess = DateTime.Now }, cacheData.Length);
+            }
         }
 
         public void CacheAssetData(UUID assetId, StratusAsset asset)
         {
-            _assetCache.Add(assetId, new CacheEntry { FullAsset = asset }, asset.Data.Length);
+            lock (_assetCache)
+            {
+                _assetCache.Add(assetId, new CacheEntry { FullAsset = asset, LastAccess = DateTime.Now }, asset.Data.Length);
+            }
         }
 
         public bool TryGetAsset(UUID assetId, out CacheEntry cachedAsset)
         {
-            return _assetCache.TryGetValue(assetId, out cachedAsset);
+            if (_assetCache.TryGetValue(assetId, out cachedAsset) == true)
+            {
+                cachedAsset.LastAccess = DateTime.Now;
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         public bool HasAsset(UUID assetId)
         {
-            return _assetCache.Contains(assetId);
+            lock (_assetCache)
+            {
+                return _assetCache.Contains(assetId);
+            }
+        }
+            
+        private void OnTimedEvent(Object state)
+        {
+            var entries = new List<UUID>();
+
+            lock (_assetCache)
+            {
+                foreach(KeyValuePair<UUID, CacheEntry> entry in _assetCache)
+                {
+                    var age = DateTime.Now - entry.Value.LastAccess;
+                    if (age.TotalMilliseconds > (double)_maxAge)
+                        entries.Add(entry.Key);
+                }               
+
+                foreach (var entry in entries)
+                    _assetCache.Remove(entry);
+            }
+            
+            _expiry_timer.Change(_expiry, Timeout.Infinite);
         }
     }
 }

--- a/InWorldz/InWorldz.Data.Assets.Stratus/Cache/CacheEntry.cs
+++ b/InWorldz/InWorldz.Data.Assets.Stratus/Cache/CacheEntry.cs
@@ -46,6 +46,11 @@ namespace InWorldz.Data.Assets.Stratus.Cache
         public int Size;
 
         /// <summary>
+        /// Record the DateTime value when this item was last accessed
+        /// </summary>
+        public DateTime LastAccess;
+
+        /// <summary>
         /// Serialized asset data. These blocks are allocated by the ByteBufferPool
         /// </summary>
         public byte[] Data;

--- a/InWorldz/InWorldz.Data.Assets.Stratus/Tests/AssetCacheTests.cs
+++ b/InWorldz/InWorldz.Data.Assets.Stratus/Tests/AssetCacheTests.cs
@@ -32,6 +32,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using NUnit.Framework;
 
 
@@ -178,6 +179,23 @@ namespace InWorldz.Data.Assets.Stratus.Tests
             Cache.CacheEntry cachedAsset;
             Assert.IsTrue(cache.TryGetAsset(id, out cachedAsset));
             Assert.AreEqual(id.Guid, cachedAsset.FullAsset.Id);
+        }
+
+        [Test]
+        public void TestAgedItemRemovedFromCache()
+        {
+            Cache.Cache cache = new Cache.Cache(1000, 2000);
+
+            byte[] assetData = new byte[] { 0x1, 0x2, 0x3, 0x4 };
+            OpenMetaverse.UUID id = OpenMetaverse.UUID.Random();
+
+            cache.CacheAssetData(id, assetData);
+
+            Thread.Sleep(5000);
+
+            Cache.CacheEntry entry;
+            Assert.IsFalse(cache.TryGetAsset(id, out entry));
+            Assert.IsNull(entry);
         }
     }
 }


### PR DESCRIPTION
Pull request for initial aged cache implementation.  There are 2 constructors so other than locking the current implementation will work as it already does.  The client code needs to be updated to specify a timer interval and max age to enable the aging behavior.

Room to optimize here but this is functional including a test.