### PR TITLE
Made the object2 post message aware of seated avatar (IDs).

### DIFF
--- a/OpenSim/Framework/Communications/Clients/RegionClient.cs
+++ b/OpenSim/Framework/Communications/Clients/RegionClient.cs
@@ -640,10 +640,11 @@ namespace OpenSim.Framework.Communications.Clients
         }
 
         public CreateObject2Ret DoCreateObject2Call(RegionInfo region, UUID sogId, byte[] sogBytes, bool allowScriptCrossing,
-            Vector3 pos, bool isAttachment, int numAvatarsToExpect, long nonceID)
+            Vector3 pos, bool isAttachment, long nonceID, List<UUID> avatars)
         {
             ulong regionHandle = GetRegionHandle(region.RegionHandle);
-            string uri = "http://" + region.ExternalHostName + ":" + region.HttpPort + "/object2/" + sogId + "/" + regionHandle.ToString() + "/";
+            string method = "/object2/";
+            string uri = "http://" + region.ExternalHostName + ":" + region.HttpPort + method + sogId + "/" + regionHandle.ToString() + "/";
 
             HttpWebRequest objectCreateRequest = (HttpWebRequest)WebRequest.Create(uri);
             objectCreateRequest.Method = "POST";
@@ -653,7 +654,18 @@ namespace OpenSim.Framework.Communications.Clients
             objectCreateRequest.Headers["authorization"] = GenerateAuthorization();
             objectCreateRequest.Headers["x-nonce-id"] = nonceID.ToString();
 
-            ObjectPostMessage message = new ObjectPostMessage { NumAvatars = numAvatarsToExpect, Pos = pos, Sog = sogBytes };
+            Guid[] avatarsArray;
+            if (avatars == null)
+                avatarsArray = null;
+            else
+            {
+                int count = 0;
+                avatarsArray = new Guid[avatars.Count];
+                foreach (UUID id in avatars)
+                    avatarsArray[count++] = id.Guid;
+            }
+
+            ObjectPostMessage message = new ObjectPostMessage { NumAvatars = avatarsArray.Length, Pos = pos, Sog = sogBytes, Avatars = avatarsArray };
 
             try
             { 

--- a/OpenSim/Framework/Communications/Messages/ObjectPostMessage.cs
+++ b/OpenSim/Framework/Communications/Messages/ObjectPostMessage.cs
@@ -60,6 +60,12 @@ namespace OpenSim.Framework.Communications.Messages
         [ProtoMember(3)]
         public int NumAvatars;
 
+        /// <summary>
+        /// Number of avatars to expect that are coming in riding on this prim
+        /// </summary>
+        [ProtoMember(4)]
+        public Guid[] Avatars;
+
         static ObjectPostMessage()
         {
             ProtoBuf.Serializer.PrepareSerializer<ObjectPostMessage>();

--- a/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/LocalInterregionComms.cs
+++ b/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/LocalInterregionComms.cs
@@ -120,7 +120,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
                 if (s.RegionInfo.RegionHandle == regionHandle)
                 {
                     // If this is intended as a root agent entry into the region, check whether it's authorized (e.g. not banned).
-                    if (authorize && !s.AuthorizeUser(aCircuit.AgentID, aCircuit.FirstName, aCircuit.LastName, aCircuit.ClientVersion, out reason))
+                    if (authorize && !s.AuthorizeUserInRegion(aCircuit.AgentID, aCircuit.FirstName, aCircuit.LastName, aCircuit.ClientVersion, out reason))
                         return false;
 
                     //                    m_log.DebugFormat("[LOCAL COMMS]: Found region {0} to send SendCreateChildAgent", regionHandle);
@@ -224,7 +224,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
          * Object-related communications 
          */
 
-        public bool SendCreateObject(ulong regionHandle, SceneObjectGroup sog, bool isLocalCall, Vector3 posInOtherRegion,
+        public bool SendCreateObject(ulong regionHandle, SceneObjectGroup sog, List<UUID> avatars, bool isLocalCall, Vector3 posInOtherRegion,
             bool isAttachment)
         {
             foreach (Scene s in m_sceneList)
@@ -242,12 +242,12 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
                         // We need to make a local copy of the object
                         ISceneObject sogClone = sog.CloneForNewScene();
                         sogClone.SetState(sog.GetStateSnapshot(true), s.RegionInfo.RegionID);
-                        return s.IncomingCreateObject(sogClone);
+                        return s.IncomingCreateObject(sogClone, avatars);
                     }
                     else
                     {
                         // Use the object as it came through the wire
-                        return s.IncomingCreateObject(sog);
+                        return s.IncomingCreateObject(sog, avatars);
                     }
                 }
             }

--- a/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/RESTInterregionComms.cs
+++ b/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/RESTInterregionComms.cs
@@ -91,9 +91,9 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
 
 
                 IConfig startupConfig = config.Configs["Communications"];
-                
-                if ((startupConfig == null) 
-                    || (startupConfig != null) 
+
+                if ((startupConfig == null)
+                    || (startupConfig != null)
                     && (startupConfig.GetString("InterregionComms", "RESTComms") == "RESTComms"))
                 {
                     m_log.Info("[REST COMMS]: Enabling InterregionComms RESTComms module");
@@ -101,8 +101,6 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
 
                     InitOnce(scene);
                 }
-
-                
             }
 
             if (!m_enabled)
@@ -149,7 +147,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
 
         protected virtual void AddHTTPHandlers()
         {
-            m_aScene.CommsManager.HttpServer.AddHTTPHandler("/agent/",  AgentHandler);
+            m_aScene.CommsManager.HttpServer.AddHTTPHandler("/agent/", AgentHandler);
             m_aScene.CommsManager.HttpServer.AddHTTPHandler("/object/", ObjectHandler);
 
             //new handlers for the Thoosa/protobuf creation messages
@@ -326,7 +324,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
             return System.Threading.Interlocked.Increment(ref m_nonceID);
         }
 
-        public bool SendCreateObject(ulong regionHandle, SceneObjectGroup sog, bool isLocalCall, Vector3 posInOtherRegion,
+        public bool SendCreateObject(ulong regionHandle, SceneObjectGroup sog, List<UUID> avatars, bool isLocalCall, Vector3 posInOtherRegion,
             bool isAttachment)
         {
             int createObjectStart = Environment.TickCount;
@@ -334,7 +332,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
             try
             {
                 // Try local first
-                if (m_localBackend.SendCreateObject(regionHandle, sog, true, posInOtherRegion, isAttachment))
+                if (m_localBackend.SendCreateObject(regionHandle, sog, avatars, true, posInOtherRegion, isAttachment))
                 {
                     //m_log.Debug("[REST COMMS]: LocalBackEnd SendCreateObject succeeded");
                     return true;
@@ -351,7 +349,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
 
                         long nonceID = NextNonceID();
 
-                        RegionClient.CreateObject2Ret ret = m_regionClient.DoCreateObject2Call(regInfo, sog.UUID, sogBytes, true, posInOtherRegion, isAttachment, sog.AvatarsToExpect, nonceID);
+                        RegionClient.CreateObject2Ret ret = m_regionClient.DoCreateObject2Call(regInfo, sog.UUID, sogBytes, true, posInOtherRegion, isAttachment, nonceID, avatars);
 
                         if (ret == RegionClient.CreateObject2Ret.Ok)
                             return true;
@@ -746,7 +744,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
                 }
             }
             // This is the meaning of POST object
-            bool result = m_localBackend.SendCreateObject(regionhandle, sog, false, pos, args["pos"] == null);
+            bool result = m_localBackend.SendCreateObject(regionhandle, sog, null, false, pos, args["pos"] == null);
 
             responsedata["int_response_code"] = 200;
             responsedata["str_response_string"] = result.ToString();
@@ -893,10 +891,18 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
                 sog.AbsolutePosition = Util.GetValidRegionXYZ(message.Pos.Value);
             }
 
-            sog.AvatarsToExpect = message.NumAvatars;
+            List<UUID> avatarIDs = new List<UUID>();
+            if (message.Avatars == null)
+                sog.AvatarsToExpect = message.NumAvatars;
+            else
+            {
+                sog.AvatarsToExpect = message.Avatars.Length;
+                foreach (Guid id in message.Avatars)
+                    avatarIDs.Add(new UUID(id));
+            }
 
             // This is the meaning of POST object
-            bool result = m_localBackend.SendCreateObject(regionHandle, sog, false, message.Pos.HasValue ? message.Pos.Value : Vector3.Zero, message.Pos.HasValue);
+            bool result = m_localBackend.SendCreateObject(regionHandle, sog, avatarIDs, false, message.Pos.HasValue ? message.Pos.Value : Vector3.Zero, message.Pos.HasValue);
 
             if (result)
             {

--- a/OpenSim/Region/Framework/Interfaces/IInterregionComms.cs
+++ b/OpenSim/Region/Framework/Interfaces/IInterregionComms.cs
@@ -25,12 +25,13 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using OpenMetaverse;
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Framework.Communications.Messages;
-using System.Threading.Tasks;
-using System;
 
 namespace OpenSim.Region.Framework.Interfaces
 {
@@ -122,7 +123,7 @@ namespace OpenSim.Region.Framework.Interfaces
         /// <param name="sog"></param>
         /// <param name="isLocalCall"></param>
         /// <returns></returns>
-        bool SendCreateObject(ulong regionHandle, SceneObjectGroup sog, bool isLocalCall, Vector3 posInOtherRegion, bool isAttachment);
+        bool SendCreateObject(ulong regionHandle, SceneObjectGroup sog, List<UUID> avatars, bool isLocalCall, Vector3 posInOtherRegion, bool isAttachment);
 
         /// <summary>
         /// Create an object from the user's inventory in the destination region. 

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1253,11 +1253,11 @@ namespace OpenSim.Region.Framework.Scenes
             if (m_physicsActor != null)
                 isFlying = m_physicsActor.Flying;
 
-            Velocity = Vector3.Zero;
             Box boundingBox = GetBoundingBox(false);
             float zmin = (float)Scene.Heightmap.CalculateHeightAt(pos.X, pos.Y);
             if (pos.Z < zmin + (boundingBox.Extent.Z / 2))
                 pos.Z = zmin + (boundingBox.Extent.Z / 2);
+            Velocity = Vector3.Zero;
             AbsolutePosition = pos;
 
             SendTerseUpdateToAllClients();


### PR DESCRIPTION
This is part 1 of a set of fixes and performance improvements to come related to parcel/region checks and user profile caching.

This allows additional crossing pre-checks previously only done on the
object owner UUID.  Does not introduce new cases, just more of the same.
(Used to be able to gain region access by sitting on someone else's
prim, or as passenger on someone else's vehicle. But after crossing,
error handling was horrible.)  Also consolodated region and parcel
checks, removing duplicate specific code (that was sometimes
different/incomplete).