### PR TITLE
Jim/regionaccess2 -  Crossing improvements and restricted parcel access fixes

### DIFF
--- a/InWorldz/InWorldz.PhysxPhysics/PhysxCharacter.cs
+++ b/InWorldz/InWorldz.PhysxPhysics/PhysxCharacter.cs
@@ -398,6 +398,11 @@ namespace InWorldz.PhysxPhysics
             
         }
 
+        public override void ForceAboveParcel(float height)
+        {
+
+        }
+
         public override void DelinkFromParent(OpenMetaverse.Vector3 newWorldPos, OpenMetaverse.Quaternion newWorldRot)
         {
             

--- a/InWorldz/InWorldz.PhysxPhysics/PhysxPrim.cs
+++ b/InWorldz/InWorldz.PhysxPhysics/PhysxPrim.cs
@@ -855,6 +855,24 @@ namespace InWorldz.PhysxPhysics
             ));
         }
 
+        public override void ForceAboveParcel(float height)
+        {
+            _scene.QueueCommand(
+                new Commands.GenericSyncCmd(this,
+                    (PhysxScene scene) =>
+                    {
+                        OpenMetaverse.Vector3 newPos = _position;
+                        //place this object back above the parcel
+                        newPos.Z = height;
+
+                        if (_dynActor != null)
+                        {
+                            _dynActor.GlobalPose = PhysUtil.PositionToMatrix(newPos, _rotation);
+                        }
+                    }
+             ));
+        }
+
         public override IMaterial GetMaterial()
         {
             lock (_properties)

--- a/OpenSim/Framework/Communications/Clients/RegionClient.cs
+++ b/OpenSim/Framework/Communications/Clients/RegionClient.cs
@@ -640,7 +640,7 @@ namespace OpenSim.Framework.Communications.Clients
         }
 
         public CreateObject2Ret DoCreateObject2Call(RegionInfo region, UUID sogId, byte[] sogBytes, bool allowScriptCrossing,
-            Vector3 pos, bool isAttachment, int numAvatarsToExpect, long nonceID)
+            Vector3 pos, bool isAttachment, long nonceID, List<UUID> avatars)
         {
             ulong regionHandle = GetRegionHandle(region.RegionHandle);
             string uri = "http://" + region.ExternalHostName + ":" + region.HttpPort + "/object2/" + sogId + "/" + regionHandle.ToString() + "/";
@@ -653,7 +653,18 @@ namespace OpenSim.Framework.Communications.Clients
             objectCreateRequest.Headers["authorization"] = GenerateAuthorization();
             objectCreateRequest.Headers["x-nonce-id"] = nonceID.ToString();
 
-            ObjectPostMessage message = new ObjectPostMessage { NumAvatars = numAvatarsToExpect, Pos = pos, Sog = sogBytes };
+            Guid[] avatarsArray;
+            if (avatars == null)
+                avatarsArray = null;
+            else
+            {
+                int count = 0;
+                avatarsArray = new Guid[avatars.Count];
+                foreach (UUID id in avatars)
+                    avatarsArray[count++] = id.Guid;
+            }
+
+            ObjectPostMessage message = new ObjectPostMessage { NumAvatars = avatarsArray.Length, Pos = pos, Sog = sogBytes, Avatars = avatarsArray };
 
             try
             { 

--- a/OpenSim/Framework/Communications/Messages/ObjectPostMessage.cs
+++ b/OpenSim/Framework/Communications/Messages/ObjectPostMessage.cs
@@ -60,6 +60,12 @@ namespace OpenSim.Framework.Communications.Messages
         [ProtoMember(3)]
         public int NumAvatars;
 
+        /// <summary>
+        /// Number of avatars to expect that are coming in riding on this prim
+        /// </summary>
+        [ProtoMember(4)]
+        public Guid[] Avatars;
+
         static ObjectPostMessage()
         {
             ProtoBuf.Serializer.PrepareSerializer<ObjectPostMessage>();

--- a/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/LocalInterregionComms.cs
+++ b/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/LocalInterregionComms.cs
@@ -120,7 +120,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
                 if (s.RegionInfo.RegionHandle == regionHandle)
                 {
                     // If this is intended as a root agent entry into the region, check whether it's authorized (e.g. not banned).
-                    if (authorize && !s.AuthorizeUser(aCircuit.AgentID, aCircuit.FirstName, aCircuit.LastName, aCircuit.ClientVersion, out reason))
+                    if (authorize && !s.AuthorizeUserInRegion(aCircuit.AgentID, aCircuit.FirstName, aCircuit.LastName, aCircuit.ClientVersion, out reason))
                         return false;
 
                     //                    m_log.DebugFormat("[LOCAL COMMS]: Found region {0} to send SendCreateChildAgent", regionHandle);
@@ -224,7 +224,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
          * Object-related communications 
          */
 
-        public bool SendCreateObject(ulong regionHandle, SceneObjectGroup sog, bool isLocalCall, Vector3 posInOtherRegion,
+        public bool SendCreateObject(ulong regionHandle, SceneObjectGroup sog, List<UUID> avatars, bool isLocalCall, Vector3 posInOtherRegion,
             bool isAttachment)
         {
             foreach (Scene s in m_sceneList)
@@ -242,12 +242,12 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
                         // We need to make a local copy of the object
                         ISceneObject sogClone = sog.CloneForNewScene();
                         sogClone.SetState(sog.GetStateSnapshot(true), s.RegionInfo.RegionID);
-                        return s.IncomingCreateObject(sogClone);
+                        return s.IncomingCreateObject(sogClone, avatars);
                     }
                     else
                     {
                         // Use the object as it came through the wire
-                        return s.IncomingCreateObject(sog);
+                        return s.IncomingCreateObject(sog, avatars);
                     }
                 }
             }

--- a/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/RESTInterregionComms.cs
+++ b/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/RESTInterregionComms.cs
@@ -91,9 +91,8 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
 
 
                 IConfig startupConfig = config.Configs["Communications"];
-                
-                if ((startupConfig == null) 
-                    || (startupConfig != null) 
+                if ((startupConfig == null)
+                    || (startupConfig != null)
                     && (startupConfig.GetString("InterregionComms", "RESTComms") == "RESTComms"))
                 {
                     m_log.Info("[REST COMMS]: Enabling InterregionComms RESTComms module");
@@ -101,8 +100,6 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
 
                     InitOnce(scene);
                 }
-
-                
             }
 
             if (!m_enabled)
@@ -149,7 +146,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
 
         protected virtual void AddHTTPHandlers()
         {
-            m_aScene.CommsManager.HttpServer.AddHTTPHandler("/agent/",  AgentHandler);
+            m_aScene.CommsManager.HttpServer.AddHTTPHandler("/agent/", AgentHandler);
             m_aScene.CommsManager.HttpServer.AddHTTPHandler("/object/", ObjectHandler);
 
             //new handlers for the Thoosa/protobuf creation messages
@@ -326,7 +323,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
             return System.Threading.Interlocked.Increment(ref m_nonceID);
         }
 
-        public bool SendCreateObject(ulong regionHandle, SceneObjectGroup sog, bool isLocalCall, Vector3 posInOtherRegion,
+        public bool SendCreateObject(ulong regionHandle, SceneObjectGroup sog, List<UUID> avatars, bool isLocalCall, Vector3 posInOtherRegion,
             bool isAttachment)
         {
             int createObjectStart = Environment.TickCount;
@@ -334,7 +331,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
             try
             {
                 // Try local first
-                if (m_localBackend.SendCreateObject(regionHandle, sog, true, posInOtherRegion, isAttachment))
+                if (m_localBackend.SendCreateObject(regionHandle, sog, avatars, true, posInOtherRegion, isAttachment))
                 {
                     //m_log.Debug("[REST COMMS]: LocalBackEnd SendCreateObject succeeded");
                     return true;
@@ -351,7 +348,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
 
                         long nonceID = NextNonceID();
 
-                        RegionClient.CreateObject2Ret ret = m_regionClient.DoCreateObject2Call(regInfo, sog.UUID, sogBytes, true, posInOtherRegion, isAttachment, sog.AvatarsToExpect, nonceID);
+                        RegionClient.CreateObject2Ret ret = m_regionClient.DoCreateObject2Call(regInfo, sog.UUID, sogBytes, true, posInOtherRegion, isAttachment, nonceID, avatars);
 
                         if (ret == RegionClient.CreateObject2Ret.Ok)
                             return true;
@@ -746,7 +743,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
                 }
             }
             // This is the meaning of POST object
-            bool result = m_localBackend.SendCreateObject(regionhandle, sog, false, pos, args["pos"] == null);
+            bool result = m_localBackend.SendCreateObject(regionhandle, sog, null, false, pos, args["pos"] == null);
 
             responsedata["int_response_code"] = 200;
             responsedata["str_response_string"] = result.ToString();
@@ -893,10 +890,18 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
                 sog.AbsolutePosition = Util.GetValidRegionXYZ(message.Pos.Value);
             }
 
-            sog.AvatarsToExpect = message.NumAvatars;
+            List<UUID> avatarIDs = new List<UUID>();
+            if (message.Avatars == null)
+                sog.AvatarsToExpect = message.NumAvatars;
+            else
+            {
+                sog.AvatarsToExpect = message.Avatars.Length;
+                foreach (Guid id in message.Avatars)
+                    avatarIDs.Add(new UUID(id));
+            }
 
             // This is the meaning of POST object
-            bool result = m_localBackend.SendCreateObject(regionHandle, sog, false, message.Pos.HasValue ? message.Pos.Value : Vector3.Zero, message.Pos.HasValue);
+            bool result = m_localBackend.SendCreateObject(regionHandle, sog, avatarIDs, false, message.Pos.HasValue ? message.Pos.Value : Vector3.Zero, message.Pos.HasValue);
 
             if (result)
             {

--- a/OpenSim/Region/CoreModules/World/Land/LandChannel.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandChannel.cs
@@ -180,6 +180,14 @@ namespace OpenSim.Region.CoreModules.World.Land
             }
         }
 
+        public void RemoveAvatarFromParcel(UUID userID)
+        {
+            if (m_landManagementModule != null)
+            {
+                m_landManagementModule.RemoveAvatarFromParcel(userID);
+            }
+        }
+
         public void UpdateLandPrimCounts()
         {
             if (m_landManagementModule != null)

--- a/OpenSim/Region/CoreModules/World/Land/LandObject.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandObject.cs
@@ -448,15 +448,18 @@ namespace OpenSim.Region.CoreModules.World.Land
         }
 
         // Returns false and reason == ParcelPropertiesStatus.ParcelSelected if access is allowed, otherwise reason enum.
-        public bool DenyParcelAccess(SceneObjectGroup group, out ParcelPropertiesStatus reason)
+        public bool DenyParcelAccess(SceneObjectGroup group, bool checkSitters, out ParcelPropertiesStatus reason)
         {
-            List<ScenePresence> sitters = group.GetSittingAvatars();
-            foreach (ScenePresence sp in sitters)
+            if (checkSitters)
             {
-                if (sp.UUID == group.OwnerID)
-                    continue;   // checked separately below
-                if (DenyParcelAccess(sp.UUID, out reason))
-                    return false;
+                List<ScenePresence> sitters = group.GetSittingAvatars();
+                foreach (ScenePresence sp in sitters)
+                {
+                    if (sp.UUID == group.OwnerID)
+                        continue;   // checked separately below
+                    if (DenyParcelAccess(sp.UUID, out reason))
+                        return false;
+                }
             }
 
             return DenyParcelAccess(group.OwnerID, out reason);
@@ -533,6 +536,51 @@ namespace OpenSim.Region.CoreModules.World.Land
 
             // no other land restrictions
             return false;
+        }
+
+        private readonly float AVATAR_BOUNCE = 10.0f;
+        public void RemoveAvatarFromParcel(UUID userID)
+        {
+            ScenePresence sp = m_scene.GetScenePresence(userID);
+            EntityBase.PositionInfo posInfo = sp.GetPosInfo();
+
+            if (posInfo.Parent != null)
+            {
+                // can't find the prim seated on, stand up
+                sp.StandUp(null, false, true);
+
+                // fall through to unseated avatar code.
+            }
+
+            // If they are moving, stop them.  This updates the physics object as well.
+            sp.Velocity = Vector3.Zero;
+
+            Vector3 pos = sp.AbsolutePosition;  // may have changed from posInfo by StandUp above.
+
+            ParcelPropertiesStatus reason2;
+            if (!sp.lastKnownAllowedPosition.Equals(Vector3.Zero))
+            {
+                pos = sp.lastKnownAllowedPosition;
+            }
+            else
+            {
+                // Still a forbidden parcel, they must have been above the limit or entering region for the first time.
+                // Let's put them up higher, over the restricted parcel.
+                // We could add 50m to avatar.Scene.Heightmap[x,y] but then we need subscript checks, etc.
+                // For now, this is simple and safer than TPing them home.
+                pos.Z += 50.0f;
+            }
+
+            ILandObject parcel = m_scene.LandChannel.GetLandObject(pos.X, pos.Y);
+            if (parcel.DenyParcelAccess(sp.UUID, out reason2))
+            {
+                float minZ = LandChannel.BAN_LINE_SAFETY_HEIGHT + AVATAR_BOUNCE;
+                if (pos.Z < minZ)
+                    pos.Z = minZ;
+            }
+
+            // Now force the non-sitting avatar to a position above the parcel
+            sp.Teleport(pos);   // this is really just a move
         }
 
         public void sendLandUpdateToClient(IClientAPI remote_client, int sequence_id, bool snap_selection)

--- a/OpenSim/Region/CoreModules/World/Land/LandObject.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandObject.cs
@@ -447,6 +447,21 @@ namespace OpenSim.Region.CoreModules.World.Land
             return false;
         }
 
+        // Returns false and reason == ParcelPropertiesStatus.ParcelSelected if access is allowed, otherwise reason enum.
+        public bool DenyParcelAccess(SceneObjectGroup group, out ParcelPropertiesStatus reason)
+        {
+            List<ScenePresence> sitters = group.GetSittingAvatars();
+            foreach (ScenePresence sp in sitters)
+            {
+                if (sp.UUID == group.OwnerID)
+                    continue;   // checked separately below
+                if (DenyParcelAccess(sp.UUID, out reason))
+                    return false;
+            }
+
+            return DenyParcelAccess(group.OwnerID, out reason);
+        }
+
         public bool isBannedFromLand(UUID avatar)
         {
             if (m_scene.Permissions.BypassPermissions())

--- a/OpenSim/Region/Framework/Interfaces/IInterregionComms.cs
+++ b/OpenSim/Region/Framework/Interfaces/IInterregionComms.cs
@@ -25,12 +25,13 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using OpenMetaverse;
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Framework.Communications.Messages;
-using System.Threading.Tasks;
-using System;
 
 namespace OpenSim.Region.Framework.Interfaces
 {
@@ -122,7 +123,7 @@ namespace OpenSim.Region.Framework.Interfaces
         /// <param name="sog"></param>
         /// <param name="isLocalCall"></param>
         /// <returns></returns>
-        bool SendCreateObject(ulong regionHandle, SceneObjectGroup sog, bool isLocalCall, Vector3 posInOtherRegion, bool isAttachment);
+        bool SendCreateObject(ulong regionHandle, SceneObjectGroup sog, List<UUID> avatars, bool isLocalCall, Vector3 posInOtherRegion, bool isAttachment);
 
         /// <summary>
         /// Create an object from the user's inventory in the destination region. 

--- a/OpenSim/Region/Framework/Interfaces/ILandChannel.cs
+++ b/OpenSim/Region/Framework/Interfaces/ILandChannel.cs
@@ -77,6 +77,7 @@ namespace OpenSim.Region.Framework.Interfaces
         void SetParcelOtherCleanTime(IClientAPI remoteClient, int localID, int otherCleanTime);
         void RefreshParcelInfo(IClientAPI remoteClient, bool force);
         float GetBanHeight();
+        void RemoveAvatarFromParcel(UUID userID);
 
         // Region support for Plus parcel web updates
         LandData ClaimPlusParcel(UUID parcelID, UUID userID);

--- a/OpenSim/Region/Framework/Interfaces/ILandObject.cs
+++ b/OpenSim/Region/Framework/Interfaces/ILandObject.cs
@@ -52,7 +52,7 @@ namespace OpenSim.Region.Framework.Interfaces
         void sendLandProperties(int sequence_id, bool snap_selection, int request_result, IClientAPI remote_client);
         void updateLandProperties(LandUpdateArgs args, IClientAPI remote_client);
         bool DenyParcelAccess(UUID avatar, out ParcelPropertiesStatus reason);
-        bool DenyParcelAccess(SceneObjectGroup group, out ParcelPropertiesStatus reason);
+        bool DenyParcelAccess(SceneObjectGroup group, bool checkSitters, out ParcelPropertiesStatus reason);
         bool isBannedFromLand(UUID avatar);
         bool isRestrictedFromLand(UUID avatar);
         void sendLandUpdateToClient(IClientAPI remote_client, int sequence_id, bool snap_selection);

--- a/OpenSim/Region/Framework/Interfaces/ILandObject.cs
+++ b/OpenSim/Region/Framework/Interfaces/ILandObject.cs
@@ -52,6 +52,7 @@ namespace OpenSim.Region.Framework.Interfaces
         void sendLandProperties(int sequence_id, bool snap_selection, int request_result, IClientAPI remote_client);
         void updateLandProperties(LandUpdateArgs args, IClientAPI remote_client);
         bool DenyParcelAccess(UUID avatar, out ParcelPropertiesStatus reason);
+        bool DenyParcelAccess(SceneObjectGroup group, out ParcelPropertiesStatus reason);
         bool isBannedFromLand(UUID avatar);
         bool isRestrictedFromLand(UUID avatar);
         void sendLandUpdateToClient(IClientAPI remote_client, int sequence_id, bool snap_selection);

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2756,6 +2756,11 @@ namespace OpenSim.Region.Framework.Scenes
 
                 grp.AvatarsToExpect = grp.NumAvatarsSeated();
                 List<ScenePresence> avatars = grp.GetSittingAvatars();
+                List<UUID> avatarIDs = new List<UUID>();
+                foreach (var avatar in avatars)
+                {
+                    avatarIDs.Add(avatar.UUID);
+                }
 
                 //marks the sitting avatars in transit, and waits for this group to be sent
                 //before sending the avatars over to the neighbor region
@@ -2764,7 +2769,7 @@ namespace OpenSim.Region.Framework.Scenes
                 if (!grp.IsAttachment)
                     m_log.InfoFormat("{0}: Sending create for prim group {1} {2} {3} with {4} users", RegionInfo.RegionName, grp.Name, grp.UUID, grp.LocalId, grp.AvatarsToExpect);
 
-                success = m_interregionCommsOut.SendCreateObject(newRegionHandle, grp, true, posInOtherRegion, isAttachment);
+                success = m_interregionCommsOut.SendCreateObject(newRegionHandle, grp, avatarIDs, true, posInOtherRegion, isAttachment);
 
                 if (success)
                 {
@@ -2881,7 +2886,7 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
-        public bool IncomingCreateObject(ISceneObject sog)
+        public bool IncomingCreateObject(ISceneObject sog, List<UUID> avatars)
         {
             SceneObjectGroup newObject;
             try
@@ -2897,7 +2902,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             string reason = "error";
             // Check this *before* calling TriggerIncomingAvatarsOnGroup
-            if (!this.AuthorizeUserObject(newObject.OwnerID, newObject, out reason))
+            if (!this.AuthorizeUserObject(newObject, avatars, out reason))
             {
                 newObject.AvatarsToExpect = 0;
                 m_log.ErrorFormat("[SCENE]: Denied adding scene object {0} in {1}: {2}", sog.UUID.ToString(), RegionInfo.RegionName, reason);
@@ -3001,7 +3006,7 @@ namespace OpenSim.Region.Framework.Scenes
                     if (!allowed)
                     {
                         // We failed to gain access to this restricted region via product access
-                        m_log.WarnFormat("[CONNECTION BEGIN]: Denied prim crossing to {0} because region is restricted", RegionInfo.RegionName);
+                        m_log.WarnFormat("[SCENE]: Denied prim crossing to {0} because region is restricted", RegionInfo.RegionName);
                         return false;
                     }
                 }
@@ -3811,7 +3816,7 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 // Don't disable this log message - it's too helpful
                 m_log.InfoFormat(
-                    "[CONNECTION BEGIN]: Incoming {0} agent {1} {2} {3} (circuit code {4}): {5}",
+                    "[SCENE]: Incoming {0} agent {1} {2} {3} (circuit code {4}): {5}",
                     (agent.child ? "child" : "root"), agent.FirstName, agent.LastName,
                     agent.AgentID, agent.CircuitCode, agent.ClientVersion);
 
@@ -3819,9 +3824,9 @@ namespace OpenSim.Region.Framework.Scenes
 
                 if (isInitialLogin)
                 {
-                    if (!AuthorizeUser(agent.AgentID, agent.FirstName, agent.LastName, agent.ClientVersion, out reason))
+                    if (!AuthorizeUserInRegion(agent.AgentID, agent.FirstName, agent.LastName, agent.ClientVersion, out reason))
                     {
-                        m_log.WarnFormat("[CONNECTION BEGIN]: Region {0} not authorizing incoming {1} agent {2} {3} {4}: {5}",
+                        m_log.WarnFormat("[SCENE]: Region {0} not authorizing incoming {1} agent {2} {3} {4}: {5}",
                                             RegionInfo.RegionName, (agent.child ? "child" : "root"),
                                             agent.FirstName, agent.LastName, agent.AgentID, reason);
                         return false;
@@ -3829,7 +3834,7 @@ namespace OpenSim.Region.Framework.Scenes
                 }
 
                 m_log.InfoFormat(
-                    "[CONNECTION BEGIN]: Region {0} authorized incoming {1} agent {2} {3} {4} (circuit code {5})",
+                    "[SCENE]: Region {0} authorized incoming {1} agent {2} {3} {4} (circuit code {5})",
                     RegionInfo.RegionName, (agent.child ? "child" : "root"), agent.FirstName, agent.LastName,
                     agent.AgentID, agent.CircuitCode);
 
@@ -3856,7 +3861,7 @@ namespace OpenSim.Region.Framework.Scenes
                             }
                             //                      agent.startpos.Z = LandChannel.GetBanHeight() + 50.0f;
                             // Fail the new startpos (connection to this parcel/region)
-                            m_log.WarnFormat("[CONNECTION BEGIN]: Region {0} refusing incoming {1} agent {2} {3} {4}: {5}",
+                            m_log.WarnFormat("[SCENE]: Region {0} refusing incoming {1} agent {2} {3} {4}: {5}",
                                                 RegionInfo.RegionName, (agent.child ? "child" : "root"),
                                                 agent.FirstName, agent.LastName, agent.AgentID, reason);
                             return false;
@@ -3878,7 +3883,7 @@ namespace OpenSim.Region.Framework.Scenes
                 }
                 catch (Connection.ConnectionAlreadyEstablishedException e)
                 {
-                    m_log.WarnFormat("[CONNECTION BEGIN]: Agent {0} is already connected, forcing disconnect", agent.FullName);
+                    m_log.WarnFormat("[SCENE]: Agent {0} is already connected, forcing disconnect", agent.FullName);
                     e.ExistingConnection.Terminate(true);
 
                     //this should now succeed
@@ -3893,18 +3898,18 @@ namespace OpenSim.Region.Framework.Scenes
                     // If this is a login operation, store that in the user info for the initial attachment rez.
                     if (isInitialLogin && !agent.child)
                     {
-                        m_log.Debug("[CONNECTION BEGIN]: SetNeedsInitialAttachmentRez TRUE");
+                        m_log.Debug("[SCENE]: SetNeedsInitialAttachmentRez TRUE");
                         ScenePresence.SetNeedsInitialAttachmentRez(agent.AgentID);
                     }
                     else
                     {
-                        m_log.Debug("[CONNECTION BEGIN]: SetNeedsInitialAttachmentRez FALSE");
+                        m_log.Debug("[SCENE]: SetNeedsInitialAttachmentRez FALSE");
                         ScenePresence.SetNoLongerNeedsInitialAttachmentRez(agent.AgentID);
                     }
                 }
                 else
                 {
-                    m_log.WarnFormat("[CONNECTION BEGIN]: Region {0} could not find profile for incoming {1} agent {2} {3} {4}",
+                    m_log.WarnFormat("[SCENE]: Region {0} could not find profile for incoming {1} agent {2} {3} {4}",
                                         RegionInfo.RegionName, (agent.child ? "child" : "root"),
                                         agent.FirstName, agent.LastName, agent.AgentID);
                 }
@@ -3922,7 +3927,7 @@ namespace OpenSim.Region.Framework.Scenes
             reason = String.Empty;
 
             bool result = CommsManager.UserService.VerifySession(agent.AgentID, agent.SessionID);
-            m_log.Debug("[CONNECTION BEGIN]: User authentication returned " + result);
+            m_log.Debug("[SCENE]: User authentication returned " + result);
             if (!result)
                 reason = String.Format("Failed to authenticate user {0} {1}, access denied.", agent.FirstName, agent.LastName);
 
@@ -3946,88 +3951,62 @@ namespace OpenSim.Region.Framework.Scenes
         }
 
 
-        public virtual bool AuthorizeUserObject(UUID agentId, SceneObjectGroup sog, out string reason)
+        public virtual bool AuthorizeUserObject(SceneObjectGroup sog, List<UUID> avatars, out string reason)
         {
             reason = String.Empty;
-
             if (!m_strictAccessControl) return true;
 
-            try
+            if (!AuthorizeUserInRegion(sog.OwnerID, "", "", null, out reason))
             {
-                if (Permissions.IsGod(agentId)) return true;
-            }
-            catch (UserProfileException e)
-            {
-                m_log.WarnFormat("[CONNECTION BEGIN]: Object owned by {0} was denied access to the region due to an exception {1}", agentId, e);
-                reason = String.Format("Unable to load your user profile/inventory. Try again later.");
+                m_log.WarnFormat("[SCENE]: Object denied entry at {0} because user {1} does not have region access.", RegionInfo.RegionName, sog.OwnerID);
+                reason = String.Format("Object owner does not have access to {0}.", RegionInfo.RegionName);
                 return false;
             }
 
-            if (IsBlacklistedUser(agentId))
+            Vector3 pos = sog.AbsolutePosition;
+            ILandObject land = LandChannel.GetLandObject(pos.X, pos.Y);
+            if (!AuthorizeUserInParcel(sog.OwnerID, "", "", land, pos, out reason))
             {
-                m_log.WarnFormat("[CONNECTION BEGIN]: Object denied access at {0} because user {1} is blacklisted", RegionInfo.RegionName, agentId);
-                reason = String.Format("Object owner is blacklisted on that region.");
+                m_log.WarnFormat("[SCENE]: Object denied entry at {0} because user {1} does not have parcel access.", RegionInfo.RegionName, sog.OwnerID);
+                reason = String.Format("Object owner {0} does not have access to that parcel.", sog.OwnerID);
                 return false;
             }
 
-            if (m_regInfo.EstateSettings.IsBanned(agentId))
+            if (avatars != null)
             {
-                m_log.WarnFormat("[CONNECTION BEGIN]: Object denied access at {0} because user {1} is banned", RegionInfo.RegionName, agentId);
-                reason = "Object owner is banned from that region.";
-                return false;
-            }
-
-            // Avoid the profile lookup when we don't need it.
-            if (m_regInfo.ProductAccess != ProductAccessUse.Anyone)
-            {
-                bool allowed = false;
-                // Region has access restricted to certain user types, i.e. Plus
-                if (IsGodUser(agentId))
-                    allowed = true;
-                else
-                if (m_regInfo.ProductAccessAllowed(ProductAccessUse.PlusOnly))
+                foreach (UUID agentID in avatars)
                 {
-                    // At least this call is limited to restricted regions only,
-                    // and we'll cache this for immediate re-use.
-                    UserProfileData profile = CommsManager.UserService.GetUserProfile(agentId);
-                    if (profile != null)
-                        if (m_regInfo.UserHasProductAccess(profile))
-                            allowed = true;
-                }
+                    // optimization for case where the owner is one of the sitters
+                    if (agentID == sog.OwnerID)
+                        continue;   // we already checked above
 
-                if (!allowed)
-                {
-                    // We failed to gain access to this restricted region via product access
-                    m_log.WarnFormat("[CONNECTION BEGIN]: Object denied access at {0} because region is restricted", RegionInfo.RegionName);
-                    reason = "Object owner is not authorized for that region.";
-                    return false;
+                    if (!AuthorizeUserInRegion(agentID, "", "", null, out reason))
+                    {
+                        m_log.WarnFormat("[SCENE]: Object denied entry at {0} because user {1} does not have region access.", RegionInfo.RegionName, agentID);
+                        reason = String.Format("User {0} does not have access to {1}.", agentID, RegionInfo.RegionName);
+                        return false;
+                    }
+
+                    if (!AuthorizeUserInParcel(agentID, "", "", land, pos, out reason))
+                    {
+                        m_log.WarnFormat("[SCENE]: Object denied entry at {0} because sitter {1} {2}", RegionInfo.RegionName, agentID, reason);
+                        reason = String.Format("Object entry denied: sitter {0} does not have access to that parcel.", agentID);
+                        return false;
+                    }
                 }
             }
 
-            if (m_regInfo.EstateSettings.PublicAccess)
-                return true;
-
-            if (m_regInfo.EstateSettings.HasAccess(agentId))
-                return true;
-
-            IGroupsModule gm = RequestModuleInterface<IGroupsModule>();
-            ScenePresence sp = GetScenePresence(agentId);
-            IClientAPI client = (sp != null) ? sp.ControllingClient : null;
-
-            foreach (UUID groupId in m_regInfo.EstateSettings.EstateGroups)
-            {
-                if (FastConfirmGroupMember(client, gm, agentId, groupId))
-                    return true;
-            }
-
-            m_log.WarnFormat("[CONNECTION BEGIN]: Object denied access at {0} because user {1} does not have access to the region", RegionInfo.RegionName, agentId);
-            reason = String.Format("Object owner is not on the access list for that region.");
-            return false;
+            // If we make it here, the object and all sitters are authorized
+            return true;
         }
 
-        public virtual bool AuthorizeUser(UUID agentId, string firstName, string lastName, string clientVersion, out string reason)
+        // If it helps for higher performance beyond logins, pass null for firstName, lastName and clientversion.
+        public virtual bool AuthorizeUserInRegion(UUID agentId, string firstName, string lastName, string clientVersion, out string reason)
         {
             reason = String.Empty;
+            string userName = "user";
+            if ((firstName != null) && (lastName != null))
+                userName = firstName + " " + lastName;
 
             if (!m_strictAccessControl) return true;
 
@@ -4037,7 +4016,7 @@ namespace OpenSim.Region.Framework.Scenes
             }
             catch (UserProfileException e)
             {
-                m_log.WarnFormat("[CONNECTION BEGIN]: User {0} ({1} {2}) was denied access to the region due to an exception {3}", agentId, firstName, lastName, e);
+                m_log.WarnFormat("[SCENE]: User {0} ({1}) was denied access to the region due to an exception {2}", agentId, userName, e);
 
                 reason = String.Format("Unable to load your user profile/inventory. Try again later.");
                 return false;
@@ -4045,33 +4024,36 @@ namespace OpenSim.Region.Framework.Scenes
 
             if (this.m_sceneGraph.GetRootAgentCount() + 1 > m_maxRootAgents)
             {
-                m_log.WarnFormat("[CONNECTION BEGIN]: User {0} ({1} {2}) was denied access to the region because it was full", agentId, firstName, lastName);
+                m_log.WarnFormat("[SCENE]: User {0} ({1}) was denied access to the region because it was full", agentId, userName);
                 reason = "Region is full";
                 return false;
             }
 
             if (IsBlacklistedUser(agentId))
             {
-                m_log.WarnFormat("[CONNECTION BEGIN]: Denied access to: {0} ({1} {2}) at {3} because the user is blacklisted",
-                                    agentId, firstName, lastName, RegionInfo.RegionName);
-                reason = String.Format("{0} {1} is blacklisted on that region", firstName, lastName);
+                m_log.WarnFormat("[SCENE]: Denied access to: {0} ({1}) at {2} because the user is blacklisted",
+                                    agentId, userName, RegionInfo.RegionName);
+                reason = String.Format("{0} is blacklisted on that region", userName);
                 return false;
             }
 
             if (m_regInfo.EstateSettings.IsBanned(agentId))
             {
-                m_log.WarnFormat("[CONNECTION BEGIN]: Denied access to: {0} ({1} {2}) at {3} because the user is on the banlist",
-                                agentId, firstName, lastName, RegionInfo.RegionName);
-                reason = String.Format("{0} {1} is banned from that region", firstName, lastName);
+                m_log.WarnFormat("[SCENE]: Denied access to: {0} ({1}) at {2} because the user is on the banlist",
+                                agentId, userName, RegionInfo.RegionName);
+                reason = String.Format("{0} is banned from that region", userName);
                 return false;
             }
 
-            if (!EventManager.TriggerOnAuthorizeUser(agentId, firstName, lastName, clientVersion, ref reason))
+            if (clientVersion != null)  // if authorizing for login, not crossing
             {
-                //module denied entry
-                m_log.WarnFormat("[CONNECTION BEGIN]: Denied access to: {0} ({1} {2}) at {3} because of a module: {4}",
-                                agentId, firstName, lastName, RegionInfo.RegionName, reason);
-                return false;
+                if (!EventManager.TriggerOnAuthorizeUser(agentId, firstName, lastName, clientVersion, ref reason))
+                {
+                    //module denied entry
+                    m_log.WarnFormat("[SCENE]: Denied access to: {0} ({1} {2}) at {3} because of a module: {4}",
+                                    agentId, firstName, lastName, RegionInfo.RegionName, reason);
+                    return false;
+                }
             }
 
             // Avoid the profile lookup when we don't need it.
@@ -4095,8 +4077,8 @@ namespace OpenSim.Region.Framework.Scenes
                 if (!allowed)
                 {
                     // We failed to gain access to this restricted region via product access
-                    m_log.WarnFormat("[CONNECTION BEGIN]: Denied access to: {0} ({1} {2}) at {3} because region is restricted.",
-                            agentId, firstName, lastName, RegionInfo.RegionName, reason);
+                    m_log.WarnFormat("[SCENE]: Denied access to: {0} ({1} {2}) at {3} because region is restricted.",
+                            agentId, userName, RegionInfo.RegionName, reason);
                     reason = String.Format("Access to {0} is restricted", RegionInfo.RegionName);
                     return false;
                 }
@@ -4112,7 +4094,7 @@ namespace OpenSim.Region.Framework.Scenes
             if (gm == null)
             {
                 reason = "Groups module error";
-                m_log.WarnFormat("[CONNECTION BEGIN]: Denied access to: {0} ({1} {2}) at {3}: {4}",
+                m_log.WarnFormat("[SCENE]: Denied access to: {0} ({1} {2}) at {3}: {4}",
                                 agentId, firstName, lastName, RegionInfo.RegionName, reason);
                 return false;
             }
@@ -4126,10 +4108,39 @@ namespace OpenSim.Region.Framework.Scenes
                     return true;
             }
 
-            m_log.WarnFormat("[CONNECTION BEGIN]: Denied access to: {0} ({1} {2}) at {3} because the user does not have region access",
+            m_log.WarnFormat("[SCENE]: Denied access to: {0} ({1} {2}) at {3} because the user does not have region access",
                             agentId, firstName, lastName, RegionInfo.RegionName);
             reason = String.Format("{0} {1} does not have access to region: {2}", firstName, lastName, RegionInfo.RegionName);
             return false;
+        }
+
+        // If it helps for higher performance beyond logins, pass null for firstName and lastName.
+        // This does not check region entry access.  (Call AuthorizeUserInRegion separately.)
+        public virtual bool AuthorizeUserInParcel(UUID agentID, string firstName, string lastName, ILandObject land, Vector3 pos, out string reason)
+        {
+            reason = String.Empty;
+            string userName = "user";
+            if ((firstName != null) && (lastName != null))
+                userName = firstName + " " + lastName;
+
+            // Check land parcel access
+            if (land != null)
+            {
+                ParcelPropertiesStatus denyReason;
+                if ((pos.Z < LandChannel.GetBanHeight()) && (land.DenyParcelAccess(agentID, out denyReason)))
+                {
+                    string who;
+                    if ((firstName != null) && (lastName != null))
+                        who = firstName + " " + lastName;
+                    else
+                        who = agentID.ToString();
+
+                    reason = String.Format("{0} denied access to destination parcel", who);
+                    m_log.WarnFormat("[SCENE]: {0}", reason);
+                    return false;
+                }
+            }
+            return true;
         }
 
         public void HandleLogOffUserFromGrid(UUID AvatarID, UUID RegionSecret, string message)
@@ -4269,7 +4280,14 @@ namespace OpenSim.Region.Framework.Scenes
                     return ChildAgentUpdate2Response.Error;
                 }
 
-                if (!AuthorizeUser(data.AgentID, SP.Firstname, SP.Lastname, null, out reason))
+                if (!AuthorizeUserInRegion(data.AgentID, SP.Firstname, SP.Lastname, null, out reason))
+                {
+                    SP.ControllingClient.SendAlertMessage("Could not enter region '" + RegionInfo.RegionName + "': " + reason);
+                    return ChildAgentUpdate2Response.AccessDenied;
+                }
+
+                ILandObject land = LandChannel.GetLandObject(data.Position.X, data.Position.Y);
+                if (!AuthorizeUserInParcel(data.AgentID, SP.Firstname, SP.Lastname, land, data.Position, out reason))
                 {
                     SP.ControllingClient.SendAlertMessage("Could not enter region '" + RegionInfo.RegionName + "': " + reason);
                     return ChildAgentUpdate2Response.AccessDenied;
@@ -4686,9 +4704,9 @@ namespace OpenSim.Region.Framework.Scenes
             m_sceneGridService.SendChildAgentDataUpdate(cadu, presence);
         }
 
-        #endregion
+#endregion
 
-        #region Other Methods
+#region Other Methods
 
         public void SetObjectCapacity(int objects)
         {
@@ -4734,7 +4752,7 @@ namespace OpenSim.Region.Framework.Scenes
             m_sceneGridService.RemoveUserFriend(ownerID, ExfriendID);
         }
 
-        #endregion
+#endregion
 
         public void HandleObjectPermissionsUpdate(IClientAPI controller, UUID agentID, UUID sessionID, byte field, uint localId, uint mask, byte set)
         {
@@ -4829,7 +4847,7 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
-        #region Script Handling Methods
+#region Script Handling Methods
 
         /// <summary>
         /// Console command handler to send script command to script engine.
@@ -4869,9 +4887,9 @@ namespace OpenSim.Region.Framework.Scenes
             return m_sceneGridService.RequestClosestRegion(name);
         }
 
-        #endregion
+#endregion
 
-        #region Script Engine
+#region Script Engine
 
         private List<ScriptEngineInterface> ScriptEngines = new List<ScriptEngineInterface>();
         private AvatarTransit.AvatarTransitController m_transitController;
@@ -4969,9 +4987,9 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
-        #endregion
+#endregion
 
-        #region SceneGraph wrapper methods
+#region SceneGraph wrapper methods
 
         /// <summary>
         ///
@@ -5204,7 +5222,7 @@ namespace OpenSim.Region.Framework.Scenes
             return m_sceneGraph.GetEntities();
         }
 
-        #endregion
+#endregion
 
         public void RegionHandleRequest(IClientAPI client, UUID regionID)
         {

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -4699,6 +4699,26 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
+        public void ForceAboveParcel(float height)
+        {
+            if (!IsDeleted)
+            {
+                PhysicsActor physActor = RootPart.PhysActor;
+                if (physActor != null)
+                {
+                    physActor.ForceAboveParcel(height);
+                }
+                else
+                {
+                    //object is phantom. brute force
+                    Vector3 pos = AbsolutePosition;
+                    pos.Z = height;
+                    AbsolutePosition = pos;
+                }
+            }
+        }
+
+
         /// <summary>
         /// Prepares an attachment for rezzing by setting the appropriate attachment points
         /// as well as the group position and restoring appropriate parameters

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -626,8 +626,19 @@ namespace OpenSim.Region.Framework.Scenes
                     ParcelPropertiesStatus reason;
                     if (NewParcel.DenyParcelAccess(this, out reason))
                     {
-                        val = currentPos;           // undo the position change
-                        physicsTriggered = false;   // forced update
+                        if (physicsTriggered)
+                        {
+                            bool wasSelected = this.IsSelected;
+                            this.IsSelected = true; // force kinematic
+
+                            this.SetVelocity(Vector3.Zero, false);
+                            m_rootPart.SetGroupPosition(val, false, false); // not physicsTriggered
+
+                            if (!wasSelected) this.IsSelected = false;  // restore kinematic state
+                            return; // it was a physical move, we're done.
+                        }
+
+                        val = currentPos;           // force undo the position change and continue
                     }
                 }
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -612,9 +612,24 @@ namespace OpenSim.Region.Framework.Scenes
             else
             {
                 // Find the current parcel before we update the position.
-                Vector3 currentPos = AbsolutePosition;
+                Vector3 currentPos = RootPart.GroupPositionNoUpdate;
                 if (CurrentParcel == null)
                     CurrentParcel = m_scene.LandChannel.GetLandObject(currentPos.X, currentPos.Y);
+
+                ILandObject NewParcel = m_scene.LandChannel.GetLandObject(val.X, val.Y);
+                if (NewParcel == null)
+                    return; // Just don't allow it to change to something invalid
+
+                if ((NewParcel != null) && (val.Z < m_scene.LandChannel.GetBanHeight()))
+                {
+                    // Possibly entering a restricted parcel.
+                    ParcelPropertiesStatus reason;
+                    if (NewParcel.DenyParcelAccess(this, out reason))
+                    {
+                        val = currentPos;           // undo the position change
+                        physicsTriggered = false;   // forced update
+                    }
+                }
 
                 // Update the position.
                 m_rootPart.SetGroupPosition(val, false, physicsTriggered);
@@ -623,16 +638,12 @@ namespace OpenSim.Region.Framework.Scenes
                 if ((m_scene != null) && !IsAttachment)
                 {
                     //check for changing of parcel
-                    ILandObject NewParcel = m_scene.LandChannel.GetLandObject(val.X, val.Y);
-                    if (NewParcel != null)
+                    if ((CurrentParcel != null) && (val != currentPos))
                     {
-                        if ((CurrentParcel != null) && (val != currentPos))
+                        if (NewParcel.landData.LocalID != CurrentParcel.landData.LocalID)
                         {
-                            if (NewParcel.landData.LocalID != CurrentParcel.landData.LocalID)
-                            {
-                                m_scene.EventManager.TriggerGroupCrossedToNewParcel(this, CurrentParcel, NewParcel);
-                                CurrentParcel = NewParcel;
-                            }
+                            m_scene.EventManager.TriggerGroupCrossedToNewParcel(this, CurrentParcel, NewParcel);
+                            CurrentParcel = NewParcel;
                         }
                     }
                 }
@@ -914,9 +925,9 @@ namespace OpenSim.Region.Framework.Scenes
 
         //public UUID FromAssetId { get; set; }
 
-        #endregion
+#endregion
 
-        #region Constructors
+#region Constructors
 
         /// <summary>
         /// Constructor
@@ -1278,7 +1289,7 @@ namespace OpenSim.Region.Framework.Scenes
             return returnresult;
         }
 
-        #endregion
+#endregion
 
         /// <summary>
         /// Used to set absolute positioning without crossing the prim into a new scene in case of negative values
@@ -1827,7 +1838,7 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
-        #region Events
+#region Events
 
         private static SceneObjectGroup CopyObjectForBackup(SceneObjectGroup group)
         {
@@ -1925,9 +1936,9 @@ namespace OpenSim.Region.Framework.Scenes
             return false;
         }
 
-        #endregion
+#endregion
 
-        #region Client Updating
+#region Client Updating
 
         public void SendFullUpdateToClient(IClientAPI remoteClient)
         {
@@ -2019,9 +2030,9 @@ namespace OpenSim.Region.Framework.Scenes
         }
 
 
-        #endregion
+#endregion
 
-        #region Copying
+#region Copying
 
 
         public SceneObjectGroup Copy(UUID cAgentID, UUID cGroupID, bool userExposed, bool serializePhysicsState)
@@ -2478,9 +2489,9 @@ namespace OpenSim.Region.Framework.Scenes
             part.GroupID = cGroupID;
         }
 
-        #endregion
+#endregion
 
-        #region Scheduling
+#region Scheduling
 
         public override void Update()
         {
@@ -2611,9 +2622,9 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
-        #endregion
+#endregion
 
-        #region SceneGroupPart Methods
+#region SceneGroupPart Methods
 
         /// <summary>
         /// Get the child part by LinkNum
@@ -2706,9 +2717,9 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
-        #endregion
+#endregion
 
-        #region Packet Handlers
+#region Packet Handlers
 
         /// <summary>
         /// Link the prims in otherGroup to this group
@@ -3365,9 +3376,9 @@ namespace OpenSim.Region.Framework.Scenes
             return rc;
         }
 
-        #endregion
+#endregion
 
-        #region Shape
+#region Shape
 
         /// <summary>
         ///
@@ -3382,9 +3393,9 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
-        #endregion
+#endregion
 
-        #region Resize
+#region Resize
 
         /// <summary>
         /// Resize the given part
@@ -3577,9 +3588,9 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
-        #endregion
+#endregion
 
-        #region Position
+#region Position
 
         /// <summary>
         /// Move this scene object
@@ -3589,6 +3600,9 @@ namespace OpenSim.Region.Framework.Scenes
         {
             if (InTransit)
                 return; // discard the update while in transit
+
+            if (pos == AbsolutePosition)
+                return; // nothing to do
 
             if (SaveUpdate)
             {
@@ -3712,9 +3726,9 @@ namespace OpenSim.Region.Framework.Scenes
             m_rootPart.SetGroupPosition(offset, true, false);
         }
 
-        #endregion
+#endregion
 
-        #region Rotation
+#region Rotation
 
         /// <summary>
         ///
@@ -3863,7 +3877,7 @@ namespace OpenSim.Region.Framework.Scenes
             m_rootPart.ScheduleTerseUpdate();
         }
 
-        #endregion
+#endregion
 
         public int RegisterTargetWaypoint(Vector3 target, float tolerance)
         {
@@ -4219,7 +4233,7 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
-        #region ISceneObject
+#region ISceneObject
 
         public virtual ISceneObject CloneForNewScene()
         {
@@ -4275,7 +4289,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             SetFromItemID(uuid);
         }
-        #endregion
+#endregion
 
         private void TrackLocalId(SceneObjectPart part, uint localId)
         {
@@ -4705,15 +4719,9 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 Vector3 pos = AbsolutePosition;
                 pos.Z = height;
-                AbsolutePosition = pos;
-#if false   // This is done indirectly by AbsolutePosition...
-                PhysicsActor physActor = RootPart.PhysActor;
-                if (physActor != null)
-                    physActor.ForceAboveParcel(height);
-#endif
+                AbsolutePosition = pos; // AbsolutePosition setter takes care of all cases
             }
         }
-
 
         /// <summary>
         /// Prepares an attachment for rezzing by setting the appropriate attachment points

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -4703,18 +4703,14 @@ namespace OpenSim.Region.Framework.Scenes
         {
             if (!IsDeleted)
             {
+                Vector3 pos = AbsolutePosition;
+                pos.Z = height;
+                AbsolutePosition = pos;
+#if false   // This is done indirectly by AbsolutePosition...
                 PhysicsActor physActor = RootPart.PhysActor;
                 if (physActor != null)
-                {
                     physActor.ForceAboveParcel(height);
-                }
-                else
-                {
-                    //object is phantom. brute force
-                    Vector3 pos = AbsolutePosition;
-                    pos.Z = height;
-                    AbsolutePosition = pos;
-                }
+#endif
             }
         }
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -849,6 +849,14 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
+        public Vector3 GroupPositionNoUpdate
+        {
+            get
+            {
+                return m_groupPosition;
+            }
+        }
+
         /// <summary>
         /// The local position of this group according to the parent coordinate system
         /// Like GroupPosition except never based on the attached avatar position.

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1253,11 +1253,11 @@ namespace OpenSim.Region.Framework.Scenes
             if (m_physicsActor != null)
                 isFlying = m_physicsActor.Flying;
 
-            Velocity = Vector3.Zero;
             Box boundingBox = GetBoundingBox(false);
             float zmin = (float)Scene.Heightmap.CalculateHeightAt(pos.X, pos.Y);
             if (pos.Z < zmin + (boundingBox.Extent.Z / 2))
                 pos.Z = zmin + (boundingBox.Extent.Z / 2);
+            Velocity = Vector3.Zero;
             AbsolutePosition = pos;
 
             SendTerseUpdateToAllClients();

--- a/OpenSim/Region/Physics/BasicPhysicsPlugin/BasicPhysicsPlugin.cs
+++ b/OpenSim/Region/Physics/BasicPhysicsPlugin/BasicPhysicsPlugin.cs
@@ -486,6 +486,11 @@ namespace OpenSim.Region.Physics.BasicPhysicsPlugin
         {
         }
 
+        public override void ForceAboveParcel(float height)
+        {
+
+        }
+
         public override void UnSubscribeEvents()
         {
 

--- a/OpenSim/Region/Physics/Manager/PhysicsActor.cs
+++ b/OpenSim/Region/Physics/Manager/PhysicsActor.cs
@@ -185,6 +185,8 @@ namespace OpenSim.Region.Physics.Manager
 
         public abstract void CrossingFailure();
 
+        public abstract void ForceAboveParcel(float height);
+
         public abstract void LinkToNewParent(PhysicsActor obj, OpenMetaverse.Vector3 localPos, OpenMetaverse.Quaternion localRot);
 
         public abstract void DelinkFromParent(Vector3 newWorldPosition, Quaternion newWorldRotation);


### PR DESCRIPTION
Fairly major changes, first to make the object2 post message aware of seated avatar (IDs) for crossing pre-checks.  Avatars and objects are not allowed to begin a crossing if the destination parcel is not accessible to the object owner and all seated avatars.

Also, within a regions, parcel border crossings are now recognized, and for banned avatars, owners of objects, and passengers, both avatars and non-physical objects are just stopped dead at the parcel border.  For physical objects, we cannot prevent entry so they are instead returned to the owner after unseating the riders at the parcel border.  This fixes lots of problems where the avatars were allowed in if they pushed hard enough, physical objects (including vehicles) were always allowed in, and sometimes only the objects were tested rather than objects and their passengers.

Also some problems with using the seated avatar position (near 0,0,0) as an absolute position, and cases where the wrong location was used to do parcel checks.