### PR TITLE
Release 20151112 - Deadlock and local/temp profile fix.

### DIFF
--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -518,6 +518,9 @@ namespace OpenSim.Region.Framework.Scenes
         {
             Vector3 pos;
             Vector3 oldVelocity;
+
+            ILandObject parcel = Scene.LandChannel.GetLandObject(agentPos.X, agentPos.Y);   // outside the lock
+
             lock (m_posInfo)
             {
                 if ((!forced) && (IsInTransit) && (parent != m_posInfo.Parent))
@@ -526,7 +529,6 @@ namespace OpenSim.Region.Framework.Scenes
                 if (parent == null)
                 {
                     // not seated
-                    ILandObject parcel = Scene.LandChannel.GetLandObject(agentPos.X, agentPos.Y);
                     if (parcel != null)
                     {
                         ParcelPropertiesStatus reason;


### PR DESCRIPTION
Fixed the deadlock reported on the sandboxes (hopefully): Split AbsolutePosition, which involves a leaf lock (m_posInfo) into a separate function that sometimes does and sometimes does not do the extra work involving parcel checks and updates from physics.  Only CheckForSignificantMovement does the full version, and it's safe to call it from that.  This is also a performance optimization to simplify the code for all of the other calls to AbsolutePosition.
Also fixed the handling of forced refreshes for local and temp (bot) profiles. It was forcing data fetches for local users, and failing to recognize existing temp (bot) profiles.