### PR TITLE
Abs pos and misc

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -7714,22 +7714,23 @@ namespace InWorldz.Phlox.Engine
             UUID key = new UUID();
             if (UUID.TryParse(id, out key))
             {
+                Vector3 pos;    // take a copy to avoid double calc
                 ScenePresence presence = World.GetScenePresence(key);
                 if (presence != null) // object is an avatar
                 {
-                    if (m_host.OwnerID
-                        == World.LandChannel.GetLandObject(
-                            presence.AbsolutePosition.X, presence.AbsolutePosition.Y).landData.OwnerID)
+                    pos = presence.AbsolutePosition;
+                    if (m_host.OwnerID == World.LandChannel.GetLandObject(pos.X, pos.Y).landData.OwnerID)
                         return 1;
                 }
                 else // object is not an avatar
                 {
                     SceneObjectPart obj = World.GetSceneObjectPart(key);
                     if (obj != null)
-                        if (m_host.OwnerID
-                            == World.LandChannel.GetLandObject(
-                                obj.AbsolutePosition.X, obj.AbsolutePosition.Y).landData.OwnerID)
+                    {
+                        pos = obj.AbsolutePosition;
+                        if (m_host.OwnerID == World.LandChannel.GetLandObject(pos.X, pos.Y).landData.OwnerID)
                             return 1;
+                    }
                 }
             }
 
@@ -7825,8 +7826,8 @@ namespace InWorldz.Phlox.Engine
                         // if the land is group owned and the object is group owned by the same group
                         // or
                         // if the object is owned by a person with estate access.
-
-                        ILandObject parcel = World.LandChannel.GetLandObject(av.AbsolutePosition.X, av.AbsolutePosition.Y);
+                        Vector3 pos = av.AbsolutePosition;  // take a copy to avoid double calc
+                        ILandObject parcel = World.LandChannel.GetLandObject(pos.X, pos.Y);
                         if (parcel != null)
                         {
                             Scene scene = m_host.ParentGroup.Scene;

--- a/InWorldz/InWorldz.VivoxVoice/VivoxVoiceModule.cs
+++ b/InWorldz/InWorldz.VivoxVoice/VivoxVoiceModule.cs
@@ -656,18 +656,19 @@ namespace InWorldz.VivoxVoice
                 // settings allow voice, then whether parcel allows
                 // voice, if all do retrieve or obtain the parcel
                 // voice channel
-                LandData land = scene.GetLandData(avatar.AbsolutePosition.X, avatar.AbsolutePosition.Y);
+                Vector3 pos = avatar.AbsolutePosition;  // take a copy to avoid double recalc
+                LandData land = scene.GetLandData(pos.X, pos.Y);
                 if (land == null)
                 {
                     // m_log.DebugFormat("[VivoxVoice][PARCELVOICE]: region \"{0}\": avatar\"{1}\" at ({2}): Land parcel not found.",
-                    //                scene.RegionInfo.RegionName, avatarName, avatar.AbsolutePosition.ToString());
+                    //                scene.RegionInfo.RegionName, avatarName, pos.ToString());
                     return EMPTY_RESPONSE;
                 }
 
                 // m_log.DebugFormat("[VivoxVoice][PARCELVOICE]: region \"{0}\": Parcel \"{1}\" ({2}): avatar \"{3}\": request: {4}, path: {5}, param: {6}",
                 //                  scene.RegionInfo.RegionName, land.Name, land.LocalID, avatarName, request, path, param);
                 // m_log.DebugFormat("[VivoxVoice][PARCELVOICE]: avatar \"{0}\": location: {1} {2} {3}",
-                //                   avatarName, avatar.AbsolutePosition.X, avatar.AbsolutePosition.Y, avatar.AbsolutePosition.Z);
+                //                   avatarName, pos.X, pos.Y, avatar.AbsolutePosition.Z);
 
                 // TODO: EstateSettings don't seem to get propagated...
                 if (!scene.RegionInfo.EstateSettings.AllowVoice)

--- a/OpenSim/Framework/Util.cs
+++ b/OpenSim/Framework/Util.cs
@@ -2136,6 +2136,29 @@ namespace OpenSim.Framework
             return newPos;
         }
 
+        public static string LocationURL(string regionName, Vector3 pos, string separator)
+        {
+            int x = (int)pos.X;
+            int y = (int)pos.Y;
+            int z = (int)pos.Z;
+            string region;
+            if (regionName == String.Empty)
+            {
+                region = String.Empty;
+                return x.ToString() + separator + y.ToString() + separator + z.ToString();
+            }
+
+            try
+            {
+                region = Util.EscapeUriDataStringRfc3986(regionName);
+            }
+            catch (Exception)
+            {
+                region = regionName;
+            }
+            return "http://places.inworldz.com/" + region + separator + x.ToString() + separator + y.ToString() + separator + z.ToString();
+        }
+
         public static Vector3 EmergencyPosition()
         {
             return new Vector3(Constants.REGION_VALID_X, Constants.REGION_VALID_Y, Constants.REGION_VALID_Z);

--- a/OpenSim/Region/CoreModules/Agent/BotManager/AvatarFollower.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/AvatarFollower.cs
@@ -283,10 +283,14 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
 
         private void EventManager_OnClientMovement()
         {
+            ScenePresence presence = m_controller.Scene.GetScenePresence(m_description.FollowUUID);
+            if (presence == null)
+                return;
+
+            Vector3 pos = presence.AbsolutePosition;
             lock (m_significantAvatarPositions)
             {
-                ScenePresence presence = m_controller.Scene.GetScenePresence(m_description.FollowUUID);
-                m_significantAvatarPositions.Add(presence.AbsolutePosition);
+                m_significantAvatarPositions.Add(pos);
             }
         }
 

--- a/OpenSim/Region/CoreModules/Avatar/Chat/ChatModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Chat/ChatModule.cs
@@ -459,19 +459,8 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
 
         private string LocationURL(Scene scene, SceneObjectPart part)
         {
-            int x = (int)part.AbsolutePosition.X;
-            int y = (int)part.AbsolutePosition.Y;
-            int z = (int)part.AbsolutePosition.Z;
-            string region;
-            try
-            {
-                region = Util.EscapeUriDataStringRfc3986(scene.RegionInfo.RegionName);
-            }
-            catch (Exception)
-            {
-                region = scene.RegionInfo.RegionName;
-            }
-            return "http://places.inworldz.com/" + region + "/" + x.ToString() + "/" + y.ToString() + "/" + z.ToString();
+            Vector3 pos = part.AbsolutePosition;
+            return Util.LocationURL(scene.RegionInfo.RegionName, pos, "/");
         }
 
         private void DumpPart(IClientAPI client, Scene scene, SceneObjectPart part)

--- a/OpenSim/Region/CoreModules/Avatar/Lure/LureModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Lure/LureModule.cs
@@ -109,12 +109,10 @@ namespace OpenSim.Region.CoreModules.Avatar.Lure
 
             Scene scene = (Scene)(client.Scene);
             ScenePresence presence = scene.GetScenePresence(client.AgentId);
-
+            Vector3 pos = presence.AbsolutePosition;
             UUID dest = Util.BuildFakeParcelID(
                     scene.RegionInfo.RegionHandle,
-                    (uint)presence.AbsolutePosition.X,
-                    (uint)presence.AbsolutePosition.Y,
-                    (uint)presence.AbsolutePosition.Z);
+                    (uint)pos.X, (uint)pos.Y, (uint)pos.Z);
 
             m_log.DebugFormat("TP invite with message {0}", message);
 

--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -1961,7 +1961,8 @@ namespace OpenSim.Region.CoreModules.World.Land
             ScenePresence target_presence = m_scene.GetScenePresence(target); 
             if (target_presence == null) return;
 
-            ILandObject land = GetLandObject(target_presence.AbsolutePosition.X, target_presence.AbsolutePosition.Y);
+            Vector3 pos = target_presence.AbsolutePosition;
+            ILandObject land = GetLandObject(pos.X, pos.Y);
 
             if (m_scene.Permissions.CanEditParcel(client.AgentId, land, GroupPowers.LandEjectAndFreeze))
             {

--- a/OpenSim/Region/Framework/Scenes/EntityBase.cs
+++ b/OpenSim/Region/Framework/Scenes/EntityBase.cs
@@ -208,8 +208,9 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         public virtual Vector3 AbsolutePosition
         {
-            get { return m_posInfo.Position; }
-            set { m_posInfo.Position = value; }
+            get { lock (m_posInfo) { return m_posInfo.Position; } }
+
+            set { lock (m_posInfo) { m_posInfo.Position = value; } }
         }
 
         protected Vector3 m_rotationalvelocity;


### PR DESCRIPTION
Avoid calling the AbsolutePosition recalculation repeatedly just to get .X, .Y, .Z ... It can be an expensive operation to just waste like that. Also factored LocationURL to Util.cs, useful to other code, and also avoids calling the AbsolutePosition calculation three times. Also fixed EntityBase to lock the posInfo before changing or returning it.