### PR TITLE
IsGroupMember / Profile / Environment performance fixes

### DIFF
--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -274,20 +274,19 @@ namespace OpenSim.Framework.Communications
             if (name == " ")
                 return null;    // fast exit for no user specified
 
-            UserProfileData testProfile;
+            UserProfileData profile;
             lock (m_userDataLock)
             {
                 // m_userDataByName includes both regular and local UserProfileData entries.
-                if (m_userDataByName.TryGetValue(name, out testProfile))
-                {
-                    // We know the UUID, just use the function above.
-                    uuid = testProfile.ID;
-                    return GetUserProfile(uuid, forceRefresh);  // in case it has expired
-                }
+                if (m_userDataByName.TryGetValue(name, out profile))
+                    uuid = profile.ID;
             }
+            // Now if know the UUID, outside the lock, just use the other function.
+            if (uuid != UUID.Zero)
+                return GetUserProfile(uuid, forceRefresh);  // in case it has expired
 
-            // Not cached, fetch from storage/XMLRPC.
-            UserProfileData profile = m_storage.GetUserProfileData(firstName, lastName);
+            // Not cached, UUID unknown, fetch from storage/XMLRPC by name.
+            profile = m_storage.GetUserProfileData(firstName, lastName);
             lock (m_userDataLock)
             {
                 // Now that it's locked again, ensure the lists have the correct data.

--- a/OpenSim/Region/CoreModules/World/Environment/EnvironmentModule.cs
+++ b/OpenSim/Region/CoreModules/World/Environment/EnvironmentModule.cs
@@ -56,6 +56,9 @@ namespace OpenSim.Region.CoreModules.World.LightShare
         private static readonly string capsName = "EnvironmentSettings";
         private static readonly string capsBase = "/CAPS/0020/";
 
+        // in-memory version to avoid fetching from db all the time.
+        private string environString = null;
+
         #region INonSharedRegionModule
         public void Initialize(IConfigSource source)
         {
@@ -88,6 +91,8 @@ namespace OpenSim.Region.CoreModules.World.LightShare
             scene.RegisterModuleInterface<IEnvironmentModule>(this);
             m_scene = scene;
             regionID = scene.RegionInfo.RegionID;
+
+            GetEnvironmentSettings(UUID.Zero);  // initialize the in-memory settings/cached copy.
         }
 
         public void RegionLoaded(Scene scene)
@@ -114,6 +119,7 @@ namespace OpenSim.Region.CoreModules.World.LightShare
             if (!m_isEnabled)
                 return;
 
+            SetEnvironmentSettings(EnvironmentSettings.EmptySettings(UUID.Zero, regionID), UUID.Zero);
 //            m_scene.SimulationDataService.RemoveRegionEnvironmentSettings(regionUUID);
         }
         #endregion
@@ -135,7 +141,7 @@ namespace OpenSim.Region.CoreModules.World.LightShare
                     delegate(string request, string path, string param,
                             OSHttpRequest httpRequest, OSHttpResponse httpResponse)
                     {
-                        return GetEnvironmentSettings(request, path, param, agentID, caps);
+                        return GetEnvironmentSettings(agentID);
                     }));
 
 
@@ -148,7 +154,7 @@ namespace OpenSim.Region.CoreModules.World.LightShare
                     delegate(string request, string path, string param,
                             OSHttpRequest httpRequest, OSHttpResponse httpResponse)
                     {
-                        string result = SetEnvironmentSettings(request, path, param, agentID, caps);
+                        string result = SetEnvironmentSettings(request, agentID);
                         if (result == null)
                             return string.Empty;
                         return result;
@@ -156,31 +162,39 @@ namespace OpenSim.Region.CoreModules.World.LightShare
         }
         #endregion
 
-        private string GetEnvironmentSettings(string request, string path, string param,
-              UUID agentID, Caps caps)
+        private string GetEnvironmentSettings(UUID agentID)
         {
             m_log.WarnFormat("[{0}]: Environment GET handler for agentID {1}", Name, agentID);
 
             string response = String.Empty;
+            bool error = false;
 
-            try
+            if (environString == null)
             {
-                response = m_scene.StorageManager.DataStore.LoadRegionEnvironmentString(regionID);
-            }
-            catch (Exception e)
-            {
-                m_log.ErrorFormat("[{0}]: Unable to load environment settings for region {1}, Exception: {2} - {3}",
-                    Name, caps.RegionName, e.Message, e.StackTrace);
+                // We'll need to fetch it from the db.
+                try
+                {
+                    response = m_scene.StorageManager.DataStore.LoadRegionEnvironmentString(regionID);
+                }
+                catch (Exception e)
+                {
+                    m_log.ErrorFormat("[{0}]: Unable to load region environment settings, exception: {1} - {2}",
+                        Name, e.Message, e.StackTrace);
+                    response = String.Empty;
+                    error = true;
+                }
             }
 
             if (String.IsNullOrEmpty(response))
                 response = EnvironmentSettings.EmptySettings(UUID.Zero, regionID);
 
+            if (!error)
+                environString = response;
+
             return response;
         }
 
-        private string SetEnvironmentSettings(string request, string path, string param,
-                              UUID agentID, Caps caps)
+        private string SetEnvironmentSettings(string request, UUID agentID)
         {
             LLSDEnvironmentSetResponse setResponse = new LLSDEnvironmentSetResponse();
 
@@ -198,17 +212,16 @@ namespace OpenSim.Region.CoreModules.World.LightShare
             {
                 m_scene.StorageManager.DataStore.StoreRegionEnvironmentString(regionID, request);
                 setResponse.success = true;
-
-                m_log.InfoFormat("[{0}]: New Environment settings has been saved from agentID {1} in region {2}",
-                    Name, agentID, caps.RegionName);
+                environString = request;
+                m_log.InfoFormat("[{0}]: Environment settings updated by user {1}", Name, agentID);
             }
             catch (Exception e)
             {
-                m_log.ErrorFormat("[{0}]: Environment settings has not been saved for region {1}, Exception: {2} - {3}",
-                    Name, caps.RegionName, e.Message, e.StackTrace);
+                m_log.ErrorFormat("[{0}]: Environment settings not been saved for user {1}, Exception: {2} - {3}",
+                    Name, agentID, e.Message, e.StackTrace);
 
                 setResponse.success = false;
-                setResponse.fail_reason = String.Format("Environment Set for region {0} has failed, settings has not been saved.", caps.RegionName);
+                setResponse.fail_reason = String.Format("Environment settings for '{0}' could not be saved.", m_scene.RegionInfo.RegionName);
             }
 
             string response = LLSDHelpers.SerializeLLSDReply(setResponse);

--- a/OpenSim/Region/Framework/Interfaces/IGroupsModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IGroupsModule.cs
@@ -46,6 +46,7 @@ namespace OpenSim.Region.Framework.Interfaces
         GroupProfileData GroupProfileRequest(IClientAPI remoteClient, UUID groupID);
         GroupMembershipData[] GetMembershipData(UUID UserID);
         GroupMembershipData GetMembershipData(UUID GroupID, UUID UserID);
+        List<UUID> GetAgentGroupList(UUID AgentID); // Returns null on error, empty list if not in any groups.
         bool IsAgentInGroup(IClientAPI remoteClient, UUID groupID);
         bool IsAgentInGroup(UUID agentID, UUID groupID);
 

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -3934,6 +3934,120 @@ namespace OpenSim.Region.Framework.Scenes
             return result;
         }
 
+        private class UserMembershipInfo
+        {
+            private static readonly TimeSpan EXPIRY = new TimeSpan(0, 10, 0);
+
+            private List<UUID> mGroupList = null;
+            private DateTime mTimeStamp = DateTime.MinValue;
+
+            public UserMembershipInfo()
+            {
+            }
+            public UserMembershipInfo(List<UUID> groups)
+            {
+                Memberships = groups;
+            }
+
+            public List<UUID> Memberships
+            {
+                get
+                {
+                    lock (this)
+                    {
+                        return new List<UUID>(mGroupList);
+                    }
+                }
+                set
+                {
+                    lock (this)
+                    {
+                        mGroupList = new List<UUID>(value);
+                        mTimeStamp = DateTime.Now;
+                    }
+                }
+            }
+
+            public bool IsExpired
+            {
+                get
+                {
+                    lock (this)
+                    {
+                        return (DateTime.Now > mTimeStamp + EXPIRY);
+                    }
+                }
+            }
+        }
+
+        // This is a cache for IsGroupMember, to ensure FastConfirmGroupMember is fast even if there's no client.
+        private Dictionary<UUID, UserMembershipInfo> _UserGroups = new Dictionary<UUID, UserMembershipInfo>();
+
+        private void UserGroupsSet(UUID agentId, List<UUID> memberships)
+        {
+            lock (_UserGroups)
+            {
+                _UserGroups[agentId] = new UserMembershipInfo(memberships);
+            }
+        }
+
+        public void UserGroupsInvalidate(UUID agentId)
+        {
+            lock (_UserGroups)
+            {
+                _UserGroups.Remove(agentId);
+            }
+        }
+
+        // Dictionary<UUID, List<UUID>> _UserGroups = new Dictionary<UUID, List<UUID>>();
+        public List<UUID> UserGroupsGet(UUID agentId)
+        {
+            List<UUID> groups = null;
+            bool asyncUpdate = false;
+            lock (_UserGroups)
+            {
+                if (!_UserGroups.ContainsKey(agentId))
+                {
+                    // do it the slow hard way
+                    IGroupsModule gm = RequestModuleInterface<IGroupsModule>();
+                    if (gm != null)
+                        groups = gm.GetAgentGroupList(agentId);
+                    if (groups != null)
+                        UserGroupsSet(agentId, groups); 
+                } else
+                {
+                    UserMembershipInfo membership = _UserGroups[agentId];
+                    groups = membership.Memberships;
+                    asyncUpdate = membership.IsExpired;
+                }
+            }
+
+            // Check for async update, but use the current data this time.
+            if (asyncUpdate)
+            {
+                Util.FireAndForget((o) =>
+                {
+                    IGroupsModule gm = RequestModuleInterface<IGroupsModule>();
+                    if (gm != null)
+                    {
+                        groups = gm.GetAgentGroupList(agentId);
+                        if (groups != null) // not error
+                            UserGroupsSet(agentId, groups);
+                    }
+                });
+            }
+            return groups;
+        }
+
+        // Just a quick check to see if it's already cached/known.
+        public bool UserGroupsKnown(UUID agentId)
+        {
+            lock (_UserGroups)
+            {
+                return _UserGroups.ContainsKey(agentId);
+            }
+        }
+
         // Must pass either an LLCV client, or an agent UUID.
         public bool FastConfirmGroupMember(IClientAPI client, UUID agentId, UUID groupId)
         {
@@ -3943,12 +4057,8 @@ namespace OpenSim.Region.Framework.Scenes
                 return client.IsGroupMember(groupId);
             }
 
-            // do it the slow hard way
-            IGroupsModule gm = RequestModuleInterface<IGroupsModule>();
-            if (gm != null)
-                return gm.IsAgentInGroup(agentId, groupId);
-
-            return false;   // can't both be null
+            List<UUID> groups = UserGroupsGet(agentId);
+            return (groups == null) ? false : groups.Contains(groupId);
         }
 
         public bool FastConfirmGroupMember(UUID agentId, UUID groupId)

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -3936,7 +3936,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         private class UserMembershipInfo
         {
-            private static readonly TimeSpan EXPIRY = new TimeSpan(0, 10, 0);
+            private static readonly TimeSpan EXPIRY = new TimeSpan(0, 0, 30);
 
             private List<UUID> mGroupList = null;
             private DateTime mTimeStamp = DateTime.MinValue;

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -251,6 +251,9 @@ namespace OpenSim.Region.Framework.Scenes
                 return false;
             }
 
+            // Prime (cache) the owner's group list.
+            m_parentScene.UserGroupsGet(sceneObject.OwnerID);
+
             foreach (SceneObjectPart part in sceneObject.Children.Values)
             {
                 Vector3 scale = part.Shape.Scale;

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -907,6 +907,9 @@ namespace OpenSim.Region.Framework.Scenes
             m_connection = world.ConnectionManager.GetConnection(this.UUID);
             if (m_connection != null)   // can be null for bots which don't have a LLCV
                 m_connection.ScenePresence = this;
+
+            // Prime (cache) the user's group list.
+            m_scene.UserGroupsGet(this.UUID);
         }
 
         public ScenePresence(IClientAPI client, Scene world, RegionInfo reginfo, AvatarAppearance appearance)

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
@@ -998,6 +998,14 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             return m_groupData.GetAgentGroupMembership(null, agentID, groupID);
         }
 
+        // Returns null on error, empty list if not in any groups.
+        public List<UUID> GetAgentGroupList(UUID agentID)
+        {
+            if (m_debugEnabled) m_log.DebugFormat("[GROUPS]: {0} called", System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            return m_groupData.GetAgentGroupList(null, agentID);
+        }
+
         public void UpdateGroupInfo(IClientAPI remoteClient, UUID groupID, string charter, bool showInList, UUID insigniaID, int membershipFee, bool openEnrollment, bool allowPublish, bool maturePublish)
         {
             if (m_debugEnabled) m_log.DebugFormat("[GROUPS]: {0} called", System.Reflection.MethodBase.GetCurrentMethod().Name);

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/IGroupDataProvider.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/IGroupDataProvider.cs
@@ -71,6 +71,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         GroupMembershipData GetAgentGroupMembership(GroupRequestID requestID, UUID AgentID, UUID GroupID);
         List<GroupMembershipData> GetAgentGroupMemberships(GroupRequestID requestID, UUID AgentID);
+        List<UUID> GetAgentGroupList(GroupRequestID requestID, UUID AgentID); // Returns null on error, empty list if not in any groups.
         bool IsAgentInGroup(UUID groupID, UUID agentID);
 
         bool AddGroupNotice(GroupRequestID requestID, UUID groupID, UUID noticeID, string fromName, string subject, string message, byte[] binaryBucket);

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/NativeGroupDataProvider.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/NativeGroupDataProvider.cs
@@ -1480,6 +1480,31 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             }
         }
 
+        // Returns null on error, empty list if not in any groups.
+        public List<UUID> GetAgentGroupList(GroupRequestID requestID, UUID AgentID)
+        {
+            List<UUID> groups = new List<UUID>();
+
+            using (ISimpleDB db = GetConnection())
+            {
+                if (db == null)
+                    return null;    // signal error
+
+                string query = " SELECT osgroupmembership.GroupID FROM osgroupmembership WHERE osgroupmembership.AgentID = ?agentID";
+
+                Dictionary<string, object> parms = new Dictionary<string, object>();
+                parms.Add("?agentID", AgentID);
+
+                List<Dictionary<string, string>> results = db.QueryWithResults(query, parms);
+                foreach (Dictionary<string, string> result in results)
+                {
+                    groups.Add(new UUID(result["GroupID"]));
+                }
+            }
+
+            return groups;
+        }
+
         public bool AddGroupNotice(GroupRequestID requestID, OpenMetaverse.UUID groupID, OpenMetaverse.UUID noticeID, string fromName, string subject, string message, byte[] binaryBucket)
         {
             if (!this.TestForPower(requestID, requestID.AgentID, groupID, (ulong)GroupPowers.SendNotices))

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/XmlRpcGroupData.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/XmlRpcGroupData.cs
@@ -469,6 +469,29 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             return memberships;
         }
 
+        // Returns null on error, empty list if not in any groups.
+        public List<UUID> GetAgentGroupList(GroupRequestID requestID, UUID AgentID)
+        {
+            Hashtable param = new Hashtable();
+            param["AgentID"] = AgentID.ToString();
+
+            Hashtable respData = XmlRpcCall(requestID, "groups.getAgentGroupMemberships", param);
+
+            if (respData.Contains("error"))
+                return null;
+
+            List<UUID> groups = new List<UUID>();
+            foreach (object membership in respData.Values)
+            {
+                Hashtable data = (Hashtable)membership;
+                UUID groupID = new UUID((string)data["GroupID"]);
+
+                groups.Add(groupID);
+            }
+
+            return groups;
+        }
+
         public bool IsAgentInGroup(UUID groupID, UUID agentID)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Several significant performance penalties have been eliminated, especially on crossings. These are in the areas of parcel crossing checks for users and objects (checking if the user or prim owner are denied entry), user profile fetching inside a lock, and unconditional database fetches each time the environment settings were needed (including on crossings).