### PR TITLE
Updated Release branch: IsGroupMember / Profile / Environment performance fixes

### DIFF
--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -274,20 +274,19 @@ namespace OpenSim.Framework.Communications
             if (name == " ")
                 return null;    // fast exit for no user specified
 
-            UserProfileData testProfile;
+            UserProfileData profile;
             lock (m_userDataLock)
             {
                 // m_userDataByName includes both regular and local UserProfileData entries.
-                if (m_userDataByName.TryGetValue(name, out testProfile))
-                {
-                    // We know the UUID, just use the function above.
-                    uuid = testProfile.ID;
-                    return GetUserProfile(uuid, forceRefresh);  // in case it has expired
-                }
+                if (m_userDataByName.TryGetValue(name, out profile))
+                    uuid = profile.ID;
             }
+            // Now if know the UUID, outside the lock, just use the other function.
+            if (uuid != UUID.Zero)
+                return GetUserProfile(uuid, forceRefresh);  // in case it has expired
 
-            // Not cached, fetch from storage/XMLRPC.
-            UserProfileData profile = m_storage.GetUserProfileData(firstName, lastName);
+            // Not cached, UUID unknown, fetch from storage/XMLRPC by name.
+            profile = m_storage.GetUserProfileData(firstName, lastName);
             lock (m_userDataLock)
             {
                 // Now that it's locked again, ensure the lists have the correct data.

--- a/OpenSim/Framework/Communications/UserProfileManagerData.cs
+++ b/OpenSim/Framework/Communications/UserProfileManagerData.cs
@@ -83,7 +83,7 @@ namespace OpenSim.Framework.Communications
         // Fetches a profile from the db via XMLRPC
         public UserProfileData GetUserProfileData(string fname, string lname)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetUserProfileData plugin request for {0} {1}", fname, lname);
+            // m_log.DebugFormat("[USERSTORAGE]: GetUserProfileData plugin request for {0} {1}", fname, lname);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 UserProfileData profile = plugin.GetUserByName(fname, lname);
@@ -95,7 +95,7 @@ namespace OpenSim.Framework.Communications
         }
         public UserProfileData GetUserProfileData(UUID uuid)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetUserProfileData plugin request for {0}", uuid);
+            // m_log.DebugFormat("[USERSTORAGE]: GetUserProfileData plugin request for {0}", uuid);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 UserProfileData profile = plugin.GetUserByUUID(uuid);
@@ -108,7 +108,7 @@ namespace OpenSim.Framework.Communications
 
         public UserProfileData GetUserProfileData(Uri uri)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetUserProfileData plugin request for {0}", uri.ToString());
+            // m_log.DebugFormat("[USERSTORAGE]: GetUserProfileData plugin request for {0}", uri.ToString());
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 UserProfileData profile = plugin.GetUserByUri(uri);
@@ -121,7 +121,7 @@ namespace OpenSim.Framework.Communications
 
         public virtual UserAgentData GetAgentData(UUID uuid)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetAgentData plugin request for {0}", uuid);
+            // m_log.DebugFormat("[USERSTORAGE]: GetAgentData plugin request for {0}", uuid);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 UserAgentData agent = plugin.GetAgentByUUID(uuid);
@@ -143,7 +143,7 @@ namespace OpenSim.Framework.Communications
 
         public void AddUser(UserProfileData profile)
         {
-            m_log.DebugFormat("[USERSTORAGE]: AddUser plugin request for {0} {1}", profile.ID, profile.Name);
+            // m_log.DebugFormat("[USERSTORAGE]: AddUser plugin request for {0} {1}", profile.ID, profile.Name);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -159,7 +159,7 @@ namespace OpenSim.Framework.Communications
 
         public bool AddNewUserAgent(UserAgentData agent)
         {
-            m_log.DebugFormat("[USERSTORAGE]: AddNewUserAgent plugin request for {0}", agent.ProfileID);
+            // m_log.DebugFormat("[USERSTORAGE]: AddNewUserAgent plugin request for {0}", agent.ProfileID);
             bool result = false;
             foreach (IUserDataPlugin plugin in m_plugins)
             {
@@ -178,7 +178,7 @@ namespace OpenSim.Framework.Communications
 
         public void ResetAttachments(UUID uuid)
         {
-            m_log.DebugFormat("[USERSTORAGE]: ResetAttachments plugin request for {0}", uuid);
+            // m_log.DebugFormat("[USERSTORAGE]: ResetAttachments plugin request for {0}", uuid);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 plugin.ResetAttachments(uuid);
@@ -200,7 +200,7 @@ namespace OpenSim.Framework.Communications
 
         public virtual List<AvatarPickerAvatar> GenerateAgentPickerRequestResponse(UUID queryID, string query)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GenerateAgentPickerRequestResponse plugin request: {0}", queryID);
+            // m_log.DebugFormat("[USERSTORAGE]: GenerateAgentPickerRequestResponse plugin request: {0}", queryID);
             List<AvatarPickerAvatar> allPickerList = new List<AvatarPickerAvatar>();
             
             foreach (IUserDataPlugin plugin in m_plugins)
@@ -223,7 +223,7 @@ namespace OpenSim.Framework.Communications
         
         public virtual bool UpdateUserProfileData(UserProfileData profile)
         {
-            m_log.DebugFormat("[USERSTORAGE]: UpdateUserProfileData plugin request for {0} {1}", profile.ID, profile.Name);
+            // m_log.DebugFormat("[USERSTORAGE]: UpdateUserProfileData plugin request for {0} {1}", profile.ID, profile.Name);
             bool result = false;
 
             foreach (IUserDataPlugin plugin in m_plugins)
@@ -277,7 +277,7 @@ namespace OpenSim.Framework.Communications
         /// <returns>Agent profiles</returns>
         public UserAgentData GetUserAgentData(UUID uuid)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetUserAgentData plugin request for {0}", uuid);
+            // m_log.DebugFormat("[USERSTORAGE]: GetUserAgentData plugin request for {0}", uuid);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -302,7 +302,7 @@ namespace OpenSim.Framework.Communications
         /// <returns>A user agent</returns>
         public UserAgentData GetUserAgentData(string name)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetUserAgentData plugin request for {0}", name);
+            // m_log.DebugFormat("[USERSTORAGE]: GetUserAgentData plugin request for {0}", name);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -328,7 +328,7 @@ namespace OpenSim.Framework.Communications
         /// <returns>A user agent</returns>
         public UserAgentData GetUserAgentData(string fname, string lname)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetUserAgentData plugin request for {0} {1}", fname, lname);
+            // m_log.DebugFormat("[USERSTORAGE]: GetUserAgentData plugin request for {0} {1}", fname, lname);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -348,7 +348,7 @@ namespace OpenSim.Framework.Communications
 
         public virtual List<FriendListItem> GetUserFriendList(UUID ownerID)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetUserFriendList plugin request for {0}", ownerID);
+            // m_log.DebugFormat("[USERSTORAGE]: GetUserFriendList plugin request for {0}", ownerID);
             List<FriendListItem> allFriends = new List<FriendListItem>();
             
             foreach (IUserDataPlugin plugin in m_plugins)
@@ -370,7 +370,7 @@ namespace OpenSim.Framework.Communications
 
         public virtual Dictionary<UUID, FriendRegionInfo> GetFriendRegionInfos (List<UUID> uuids)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetFriendRegionInfos plugin request");
+            // m_log.DebugFormat("[USERSTORAGE]: GetFriendRegionInfos plugin request");
             //Dictionary<UUID, FriendRegionInfo> allFriendRegions = new Dictionary<UUID, FriendRegionInfo>();
 
             foreach (IUserDataPlugin plugin in m_plugins)
@@ -392,7 +392,7 @@ namespace OpenSim.Framework.Communications
 
         public void StoreWebLoginKey(UUID uuid, UUID webLoginKey)
         {
-            m_log.DebugFormat("[USERSTORAGE]: StoreWebLoginKey plugin request for {0}", uuid);
+            // m_log.DebugFormat("[USERSTORAGE]: StoreWebLoginKey plugin request for {0}", uuid);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -408,7 +408,7 @@ namespace OpenSim.Framework.Communications
         
         public virtual void AddNewUserFriend(UUID friendlistowner, UUID friend, uint perms)
         {
-            m_log.DebugFormat("[USERSTORAGE]: AddNewUserFriend plugin request for {0}", friendlistowner);
+            // m_log.DebugFormat("[USERSTORAGE]: AddNewUserFriend plugin request for {0}", friendlistowner);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -424,7 +424,7 @@ namespace OpenSim.Framework.Communications
 
         public virtual void RemoveUserFriend(UUID friendlistowner, UUID friend)
         {
-            m_log.DebugFormat("[USERSTORAGE]: RemoveUserFriend plugin request for {0}", friendlistowner);
+            // m_log.DebugFormat("[USERSTORAGE]: RemoveUserFriend plugin request for {0}", friendlistowner);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -440,7 +440,7 @@ namespace OpenSim.Framework.Communications
 
         public virtual void UpdateUserFriendPerms(UUID friendlistowner, UUID friend, uint perms)
         {
-            m_log.DebugFormat("[USERSTORAGE]: UpdateUserFriendPerms plugin request for {0}", friendlistowner);
+            // m_log.DebugFormat("[USERSTORAGE]: UpdateUserFriendPerms plugin request for {0}", friendlistowner);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -463,7 +463,7 @@ namespace OpenSim.Framework.Communications
         /// <returns></returns>
         public virtual AvatarAppearance GetUserAppearance(UUID uuid)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetUserAppearance plugin request for {0}", uuid);
+            // m_log.DebugFormat("[USERSTORAGE]: GetUserAppearance plugin request for {0}", uuid);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -489,7 +489,7 @@ namespace OpenSim.Framework.Communications
         /// <returns></returns>
         public virtual AvatarAppearance GetBotOutfit(UUID uuid, string outfitName)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetBotOutfit plugin request for {0}", uuid);
+            // m_log.DebugFormat("[USERSTORAGE]: GetBotOutfit plugin request for {0}", uuid);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -509,7 +509,7 @@ namespace OpenSim.Framework.Communications
 
         public virtual void UpdateUserAppearance(UUID uuid, AvatarAppearance appearance)
         {
-            m_log.DebugFormat("[USERSTORAGE]: UpdateUserAppearance plugin request for {0}", uuid);
+            // m_log.DebugFormat("[USERSTORAGE]: UpdateUserAppearance plugin request for {0}", uuid);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -525,7 +525,7 @@ namespace OpenSim.Framework.Communications
 
         public virtual void AddOrUpdateBotOutfit(UUID uuid, string outfitName, AvatarAppearance appearance)
         {
-            m_log.DebugFormat("[USERSTORAGE]: AddOrUpdateBotOutfit plugin request for {0}", uuid);
+            // m_log.DebugFormat("[USERSTORAGE]: AddOrUpdateBotOutfit plugin request for {0}", uuid);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -541,7 +541,7 @@ namespace OpenSim.Framework.Communications
 
         public virtual void RemoveBotOutfit(UUID uuid, string outfitName)
         {
-            m_log.DebugFormat("[USERSTORAGE]: RemoveBotOutfit plugin request for {0}", uuid);
+            // m_log.DebugFormat("[USERSTORAGE]: RemoveBotOutfit plugin request for {0}", uuid);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -557,7 +557,7 @@ namespace OpenSim.Framework.Communications
 
         public virtual List<string> GetBotOutfitsByOwner(UUID uuid)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetBotOutfitsByOwner plugin request for {0}", uuid);
+            // m_log.DebugFormat("[USERSTORAGE]: GetBotOutfitsByOwner plugin request for {0}", uuid);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -578,7 +578,7 @@ namespace OpenSim.Framework.Communications
 
         public void SaveUserPreferences(UserPreferencesData userPrefs)
         {
-            m_log.DebugFormat("[USERSTORAGE]: SaveUserPreferences plugin request for {0}", userPrefs.UserId);
+            // m_log.DebugFormat("[USERSTORAGE]: SaveUserPreferences plugin request for {0}", userPrefs.UserId);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -594,7 +594,7 @@ namespace OpenSim.Framework.Communications
 
         public UserPreferencesData RetrieveUserPreferences(UUID uuid)
         {
-            m_log.DebugFormat("[USERSTORAGE]: RetrieveUserPreferences plugin request for {0}", uuid);
+            // m_log.DebugFormat("[USERSTORAGE]: RetrieveUserPreferences plugin request for {0}", uuid);
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -618,7 +618,7 @@ namespace OpenSim.Framework.Communications
 
         public virtual List<CachedAgentArgs> GetCachedBakedTextures(List<CachedAgentArgs> request)
         {
-            m_log.DebugFormat("[USERSTORAGE]: GetCachedBakedTextures plugin request");
+            // m_log.DebugFormat("[USERSTORAGE]: GetCachedBakedTextures plugin request");
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try
@@ -637,7 +637,7 @@ namespace OpenSim.Framework.Communications
 
         public virtual void SetCachedBakedTextures(Dictionary<UUID, UUID> request)
         {
-            m_log.DebugFormat("[USERSTORAGE]: SetCachedBakedTextures plugin request");
+            // m_log.DebugFormat("[USERSTORAGE]: SetCachedBakedTextures plugin request");
             foreach (IUserDataPlugin plugin in m_plugins)
             {
                 try

--- a/OpenSim/Region/CoreModules/World/Environment/EnvironmentModule.cs
+++ b/OpenSim/Region/CoreModules/World/Environment/EnvironmentModule.cs
@@ -56,6 +56,9 @@ namespace OpenSim.Region.CoreModules.World.LightShare
         private static readonly string capsName = "EnvironmentSettings";
         private static readonly string capsBase = "/CAPS/0020/";
 
+        // in-memory version to avoid fetching from db all the time.
+        private string environString = null;
+
         #region INonSharedRegionModule
         public void Initialize(IConfigSource source)
         {
@@ -88,6 +91,8 @@ namespace OpenSim.Region.CoreModules.World.LightShare
             scene.RegisterModuleInterface<IEnvironmentModule>(this);
             m_scene = scene;
             regionID = scene.RegionInfo.RegionID;
+
+            GetEnvironmentSettings(UUID.Zero);  // initialize the in-memory settings/cached copy.
         }
 
         public void RegionLoaded(Scene scene)
@@ -114,6 +119,7 @@ namespace OpenSim.Region.CoreModules.World.LightShare
             if (!m_isEnabled)
                 return;
 
+            SetEnvironmentSettings(EnvironmentSettings.EmptySettings(UUID.Zero, regionID), UUID.Zero);
 //            m_scene.SimulationDataService.RemoveRegionEnvironmentSettings(regionUUID);
         }
         #endregion
@@ -135,7 +141,7 @@ namespace OpenSim.Region.CoreModules.World.LightShare
                     delegate(string request, string path, string param,
                             OSHttpRequest httpRequest, OSHttpResponse httpResponse)
                     {
-                        return GetEnvironmentSettings(request, path, param, agentID, caps);
+                        return GetEnvironmentSettings(agentID);
                     }));
 
 
@@ -148,7 +154,7 @@ namespace OpenSim.Region.CoreModules.World.LightShare
                     delegate(string request, string path, string param,
                             OSHttpRequest httpRequest, OSHttpResponse httpResponse)
                     {
-                        string result = SetEnvironmentSettings(request, path, param, agentID, caps);
+                        string result = SetEnvironmentSettings(request, agentID);
                         if (result == null)
                             return string.Empty;
                         return result;
@@ -156,31 +162,39 @@ namespace OpenSim.Region.CoreModules.World.LightShare
         }
         #endregion
 
-        private string GetEnvironmentSettings(string request, string path, string param,
-              UUID agentID, Caps caps)
+        private string GetEnvironmentSettings(UUID agentID)
         {
             m_log.WarnFormat("[{0}]: Environment GET handler for agentID {1}", Name, agentID);
 
             string response = String.Empty;
+            bool error = false;
 
-            try
+            if (environString == null)
             {
-                response = m_scene.StorageManager.DataStore.LoadRegionEnvironmentString(regionID);
-            }
-            catch (Exception e)
-            {
-                m_log.ErrorFormat("[{0}]: Unable to load environment settings for region {1}, Exception: {2} - {3}",
-                    Name, caps.RegionName, e.Message, e.StackTrace);
+                // We'll need to fetch it from the db.
+                try
+                {
+                    response = m_scene.StorageManager.DataStore.LoadRegionEnvironmentString(regionID);
+                }
+                catch (Exception e)
+                {
+                    m_log.ErrorFormat("[{0}]: Unable to load region environment settings, exception: {1} - {2}",
+                        Name, e.Message, e.StackTrace);
+                    response = String.Empty;
+                    error = true;
+                }
             }
 
             if (String.IsNullOrEmpty(response))
                 response = EnvironmentSettings.EmptySettings(UUID.Zero, regionID);
 
+            if (!error)
+                environString = response;
+
             return response;
         }
 
-        private string SetEnvironmentSettings(string request, string path, string param,
-                              UUID agentID, Caps caps)
+        private string SetEnvironmentSettings(string request, UUID agentID)
         {
             LLSDEnvironmentSetResponse setResponse = new LLSDEnvironmentSetResponse();
 
@@ -198,17 +212,16 @@ namespace OpenSim.Region.CoreModules.World.LightShare
             {
                 m_scene.StorageManager.DataStore.StoreRegionEnvironmentString(regionID, request);
                 setResponse.success = true;
-
-                m_log.InfoFormat("[{0}]: New Environment settings has been saved from agentID {1} in region {2}",
-                    Name, agentID, caps.RegionName);
+                environString = request;
+                m_log.InfoFormat("[{0}]: Environment settings updated by user {1}", Name, agentID);
             }
             catch (Exception e)
             {
-                m_log.ErrorFormat("[{0}]: Environment settings has not been saved for region {1}, Exception: {2} - {3}",
-                    Name, caps.RegionName, e.Message, e.StackTrace);
+                m_log.ErrorFormat("[{0}]: Environment settings not been saved for user {1}, Exception: {2} - {3}",
+                    Name, agentID, e.Message, e.StackTrace);
 
                 setResponse.success = false;
-                setResponse.fail_reason = String.Format("Environment Set for region {0} has failed, settings has not been saved.", caps.RegionName);
+                setResponse.fail_reason = String.Format("Environment settings for '{0}' could not be saved.", m_scene.RegionInfo.RegionName);
             }
 
             string response = LLSDHelpers.SerializeLLSDReply(setResponse);

--- a/OpenSim/Region/Framework/Interfaces/IGroupsModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IGroupsModule.cs
@@ -46,6 +46,7 @@ namespace OpenSim.Region.Framework.Interfaces
         GroupProfileData GroupProfileRequest(IClientAPI remoteClient, UUID groupID);
         GroupMembershipData[] GetMembershipData(UUID UserID);
         GroupMembershipData GetMembershipData(UUID GroupID, UUID UserID);
+        List<UUID> GetAgentGroupList(UUID AgentID); // Returns null on error, empty list if not in any groups.
         bool IsAgentInGroup(IClientAPI remoteClient, UUID groupID);
         bool IsAgentInGroup(UUID agentID, UUID groupID);
 

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -3934,8 +3934,8 @@ namespace OpenSim.Region.Framework.Scenes
             return result;
         }
 
-        // Must pass either an LLCV client, or a groups module 'gm'.
-        public bool FastConfirmGroupMember(IClientAPI client, IGroupsModule gm, UUID agentId, UUID groupId)
+        // Must pass either an LLCV client, or an agent UUID.
+        public bool FastConfirmGroupMember(IClientAPI client, UUID agentId, UUID groupId)
         {
             if (client != null)
             {
@@ -3944,12 +3944,28 @@ namespace OpenSim.Region.Framework.Scenes
             }
 
             // do it the slow hard way
+            IGroupsModule gm = RequestModuleInterface<IGroupsModule>();
             if (gm != null)
                 return gm.IsAgentInGroup(agentId, groupId);
 
             return false;   // can't both be null
         }
 
+        public bool FastConfirmGroupMember(UUID agentId, UUID groupId)
+        {
+            ScenePresence sp = GetScenePresence(agentId);
+            IClientAPI client = (sp == null) ? null : sp.ControllingClient;
+
+            return FastConfirmGroupMember(client, agentId, groupId);
+        }
+
+        public bool FastConfirmGroupMember(ScenePresence sp, UUID groupId)
+        {
+            if (sp == null) // must not be null
+                return false;
+
+            return FastConfirmGroupMember(sp.ControllingClient, sp.UUID, groupId);
+        }
 
         public virtual bool AuthorizeUserObject(SceneObjectGroup sog, List<UUID> avatars, out string reason)
         {
@@ -4104,7 +4120,7 @@ namespace OpenSim.Region.Framework.Scenes
             foreach (UUID groupId in m_regInfo.EstateSettings.EstateGroups)
             {
                 // check agent.Id in group
-                if (FastConfirmGroupMember(client, gm, agentId, groupId))
+                if (FastConfirmGroupMember(client, agentId, groupId))
                     return true;
             }
 

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -251,6 +251,9 @@ namespace OpenSim.Region.Framework.Scenes
                 return false;
             }
 
+            // Prime (cache) the owner's group list.
+            m_parentScene.UserGroupsGet(sceneObject.OwnerID);
+
             foreach (SceneObjectPart part in sceneObject.Children.Values)
             {
                 Vector3 scale = part.Shape.Scale;

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -907,6 +907,9 @@ namespace OpenSim.Region.Framework.Scenes
             m_connection = world.ConnectionManager.GetConnection(this.UUID);
             if (m_connection != null)   // can be null for bots which don't have a LLCV
                 m_connection.ScenePresence = this;
+
+            // Prime (cache) the user's group list.
+            m_scene.UserGroupsGet(this.UUID);
         }
 
         public ScenePresence(IClientAPI client, Scene world, RegionInfo reginfo, AvatarAppearance appearance)

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
@@ -998,6 +998,14 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             return m_groupData.GetAgentGroupMembership(null, agentID, groupID);
         }
 
+        // Returns null on error, empty list if not in any groups.
+        public List<UUID> GetAgentGroupList(UUID agentID)
+        {
+            if (m_debugEnabled) m_log.DebugFormat("[GROUPS]: {0} called", System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            return m_groupData.GetAgentGroupList(null, agentID);
+        }
+
         public void UpdateGroupInfo(IClientAPI remoteClient, UUID groupID, string charter, bool showInList, UUID insigniaID, int membershipFee, bool openEnrollment, bool allowPublish, bool maturePublish)
         {
             if (m_debugEnabled) m_log.DebugFormat("[GROUPS]: {0} called", System.Reflection.MethodBase.GetCurrentMethod().Name);

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
@@ -844,6 +844,10 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public bool IsAgentInGroup(IClientAPI remoteClient, UUID groupID)
         {
+            // Use the known in-memory group membership data if available before going to db.
+            if (remoteClient != null)
+                remoteClient.IsGroupMember(groupID);
+
             return m_groupData.IsAgentInGroup(groupID, remoteClient.AgentId);
         }
 

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/IGroupDataProvider.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/IGroupDataProvider.cs
@@ -71,6 +71,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         GroupMembershipData GetAgentGroupMembership(GroupRequestID requestID, UUID AgentID, UUID GroupID);
         List<GroupMembershipData> GetAgentGroupMemberships(GroupRequestID requestID, UUID AgentID);
+        List<UUID> GetAgentGroupList(GroupRequestID requestID, UUID AgentID); // Returns null on error, empty list if not in any groups.
         bool IsAgentInGroup(UUID groupID, UUID agentID);
 
         bool AddGroupNotice(GroupRequestID requestID, UUID groupID, UUID noticeID, string fromName, string subject, string message, byte[] binaryBucket);

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/NativeGroupDataProvider.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/NativeGroupDataProvider.cs
@@ -30,7 +30,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using OpenMetaverse;
 using log4net;
 using System.Reflection;
@@ -45,27 +44,50 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         private ConnectionFactory _connectionFactory;
 
-        private static readonly ILog _log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        private ISimpleDB GetConnection()
+        {
+            if (_connectionFactory == null) return null;
+
+            try
+            {
+                return _connectionFactory.GetConnection();
+            }
+            catch (MySql.Data.MySqlClient.MySqlException e)
+            {
+                m_log.Info("[GROUPS]: MySQL connection exception: " + e.ToString());
+            }
+            return null;
+        }
 
         public NativeGroupDataProvider(ConnectionFactory connectionFactory)
         {
             _connectionFactory = connectionFactory;
 
-            _log.Info("[FlexiGroups] Testing database connection");
+            m_log.Info("[GROUPS]: Testing database connection");
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                {
+                    m_log.Info("[GROUPS]: Testing connection failed.");
+                    return;
+                }
             }
 
-            _log.Info("[FlexiGroups] Testing connection succeeded");
+            m_log.Info("[GROUPS]: Testing connection succeeded");
         }
 
         #region IGroupDataProvider Members
 
         public OpenMetaverse.UUID CreateGroup(GroupRequestID requestID, string name, string charter, bool showInList, OpenMetaverse.UUID insigniaID, int membershipFee, bool openEnrollment, bool allowPublish, bool maturePublish, OpenMetaverse.UUID founderID)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return UUID.Zero;
+
                 UUID groupID = UUID.Random();
                 UUID ownerRoleID = UUID.Random();
                 
@@ -139,12 +161,15 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
         {
             if (!TestForPower(requestID, requestID.AgentID, groupID, (ulong)GroupPowers.ChangeIdentity))
             {
-                _log.WarnFormat("[GROUPS]: {0} No permission to change group options", requestID.AgentID);
+                m_log.WarnFormat("[GROUPS]: {0} No permission to change group options", requestID.AgentID);
                 return;
             }
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return;
+
                 string query
                     = "UPDATE osgroup " +
                         "SET " +
@@ -175,8 +200,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public OpenSim.Framework.GroupRecord GetGroupRecord(GroupRequestID requestID, OpenMetaverse.UUID GroupID, string GroupName)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return null;
+
                 string query =  " SELECT osgroup.GroupID, osgroup.Name, Charter, InsigniaID, FounderID, MembershipFee, " +
                                     "OpenEnrollment, ShowInList, AllowPublish, MaturePublish, OwnerRoleID " +
                                 " , count(osrole.RoleID) as GroupRolesCount, count(osgroupmembership.AgentID) as GroupMembershipCount " + 
@@ -212,8 +240,8 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                 }
 
                 // string trace = Environment.StackTrace;
-                // _log.WarnFormat("[FlexiGroups] GetGroupRecord: Could not find exact match for {0} '{1}':", GroupID, GroupName);
-                // _log.Warn(trace);
+                // m_log.WarnFormat("[GROUPS]: GetGroupRecord: Could not find exact match for {0} '{1}':", GroupID, GroupName);
+                // m_log.Warn(trace);
                 return null;
             }
         }
@@ -241,8 +269,13 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public List<OpenSim.Framework.DirGroupsReplyData> FindGroups(GroupRequestID requestID, string search)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            List<OpenSim.Framework.DirGroupsReplyData> replyData = new List<OpenSim.Framework.DirGroupsReplyData>();
+
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return replyData;
+
                 string query = " SELECT osgroup.GroupID, osgroup.Name, count(osgroupmembership.AgentID) as Members " +
                                 " FROM osgroup " +
                                     "LEFT JOIN osgroupmembership ON (osgroup.GroupID = osgroupmembership.GroupID) " +
@@ -258,15 +291,13 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                 parms.Add("?likeSearch", "%" + search + "%");
 
                 List<Dictionary<string, string>> results = db.QueryWithResults(query, parms);
-
-                List<OpenSim.Framework.DirGroupsReplyData> replyData = new List<OpenSim.Framework.DirGroupsReplyData>();
                 foreach (Dictionary<string, string> result in results)
                 {
                     replyData.Add(MapGroupReplyDataFromResult(result));
                 }
-
-                return replyData;
             }
+
+            return replyData;
         }
 
         private OpenSim.Framework.DirGroupsReplyData MapGroupReplyDataFromResult(Dictionary<string, string> result)
@@ -281,8 +312,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public List<OpenSim.Framework.GroupMembersData> GetGroupMembers(GroupRequestID requestID, OpenMetaverse.UUID GroupID, bool ownersOnly)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return new List<OpenSim.Framework.GroupMembersData>();
+
                 string query = " SELECT osgroupmembership.AgentID" +
                                 " , osgroupmembership.Contribution, osgroupmembership.ListInProfile, osgroupmembership.AcceptNotices" +
                                 " , osgroupmembership.SelectedRoleID, osrole.Title" +
@@ -361,13 +395,16 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             {
                 if (!TestForPower(requestID, requestID.AgentID, groupID, (ulong)GroupPowers.CreateRole))
                 {
-                    _log.WarnFormat("[GROUPS]: {0} No permission to add group roles", requestID.AgentID);
+                    m_log.WarnFormat("[GROUPS]: {0} No permission to add group roles", requestID.AgentID);
                     return;
                 }
             }
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return;
+
                 string query
                     =   "INSERT INTO osrole (GroupID, RoleID, Name, Description, Title, Powers) " +
                         "VALUES(?groupID, ?roleID, ?name, ?desc, ?title, ?powers)";
@@ -389,7 +426,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
         {
             if (!TestForPower(requestID, requestID.AgentID, groupID, (ulong)GroupPowers.RoleProperties))
             {
-                _log.WarnFormat("[GROUPS]: {0} No permission to change group roles", requestID.AgentID);
+                m_log.WarnFormat("[GROUPS]: {0} No permission to change group roles", requestID.AgentID);
                 return;
             }
 
@@ -422,9 +459,10 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             parms.Add("?groupID", groupID);
             parms.Add("?roleID", roleID);
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
-                db.QueryNoResults(query, parms);
+                if (db != null)
+                    db.QueryNoResults(query, parms);
             }
         }
 
@@ -432,12 +470,15 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
         {
             if (!TestForPower(requestID, requestID.AgentID, groupID, (ulong)GroupPowers.DeleteRole))
             {
-                _log.WarnFormat("[GROUPS]: {0} No permission to remove group roles", requestID.AgentID);
+                m_log.WarnFormat("[GROUPS]: {0} No permission to remove group roles", requestID.AgentID);
                 return;
             }
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return;
+
                 Dictionary<string, object> parms = new Dictionary<string,object>();
                 parms.Add("?groupID", groupID);
                 parms.Add("?roleID", roleID);
@@ -456,8 +497,13 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public List<OpenSim.Framework.GroupRolesData> GetGroupRoles(GroupRequestID requestID, OpenMetaverse.UUID GroupID)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            List<OpenSim.Framework.GroupRolesData> foundRoles = new List<OpenSim.Framework.GroupRolesData>();
+
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return foundRoles;
+
                 string query 
                     =   " SELECT osrole.RoleID, osrole.Name, osrole.Title, osrole.Description, osrole.Powers, " +
                             " count(osgrouprolemembership.AgentID) as Members " +
@@ -471,14 +517,14 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                 parms.Add("?groupID", GroupID);
 
                 List<Dictionary<string, string>> results = db.QueryWithResults(query, parms);
-                List<OpenSim.Framework.GroupRolesData> foundRoles = new List<OpenSim.Framework.GroupRolesData>();
                 foreach (Dictionary<string, string> result in results)
                 {
                     foundRoles.Add(this.MapGroupRolesDataFromResult(result));
                 }
 
-                return foundRoles;
             }
+
+            return foundRoles;
         }
 
         private OpenSim.Framework.GroupRolesData MapGroupRolesDataFromResult(Dictionary<string, string> result)
@@ -510,8 +556,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             parms.Add("?roleID", RoleID);
 
             List<UUID> roleMembersData = new List<UUID>();
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return roleMembersData;
+
                 List<Dictionary<string, string>> results = db.QueryWithResults(query, parms);
                 foreach (Dictionary<string, string> result in results)
                     roleMembersData.Add(new UUID(result["AgentID"]));
@@ -530,18 +579,21 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
             Dictionary<string, object> parms = new Dictionary<string, object>();
             parms.Add("?groupID", GroupID);
+            List<OpenSim.Framework.GroupRoleMembersData> foundMembersData = new List<OpenSim.Framework.GroupRoleMembersData>();
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return foundMembersData;
+
                 List<Dictionary<string, string>> results = db.QueryWithResults(query, parms);
-                List<OpenSim.Framework.GroupRoleMembersData> foundMembersData = new List<OpenSim.Framework.GroupRoleMembersData>();
                 foreach (Dictionary<string, string> result in results)
                 {
                     foundMembersData.Add(this.MapFoundMembersDataFromResult(result));
                 }
-
-                return foundMembersData;
             }
+
+            return foundMembersData;
         }
 
         private OpenSim.Framework.GroupRoleMembersData MapFoundMembersDataFromResult(Dictionary<string, string> result)
@@ -588,7 +640,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             if (isAgentMemberResults.Count == 0)
             {
                 //this shouldnt happen
-                _log.Error("[GROUPS]: IsAgentMemberOfGroup: Expected at least one record");
+                m_log.Error("[GROUPS]: IsAgentMemberOfGroup: Expected at least one record");
                 return false;
             }
             if (Convert.ToInt32(isAgentMemberResults[0]["isMember"]) > 0)
@@ -600,8 +652,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public bool IsAgentInGroup(UUID groupID, UUID agentID)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return false;
+
                 return IsAgentMemberOfGroup(db, agentID, groupID);
             }
         }
@@ -618,8 +673,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             parms.Add("?roleID", RoleID);
             parms.Add("?agentID", AgentID);
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return false;
+
                 List<Dictionary<string, string>> results = db.QueryWithResults(query, parms);
                 if (results.Count == 0)
                 {
@@ -669,17 +727,20 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             {
                 if (!AgentCanJoinGroup(requestID, AgentID, GroupID, RoleID))
                 {
-                    _log.WarnFormat("[GROUPS]: {0} No permission to join group {1}", AgentID, GroupID);
+                    m_log.WarnFormat("[GROUPS]: {0} No permission to join group {1}", AgentID, GroupID);
                     return false;
                 }
             }
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return false;
+
                 uint numGroups = GetAgentGroupCount(AgentID);
                 if (numGroups >= Constants.MaxGroups)
                 {
-                    _log.WarnFormat("[GROUPS]: {0} Already in {1} groups, cannot join group {2}", AgentID, numGroups, GroupID);
+                    m_log.WarnFormat("[GROUPS]: {0} Already in {1} groups, cannot join group {2}", AgentID, numGroups, GroupID);
                     return false;
                 }
 
@@ -714,13 +775,13 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                 // Sorry Dave, I can't allow you to remove yourself if you are the only owner.
                 if (groupOwners.Count < 2)
                 {
-                    _log.WarnFormat("[GROUPS]: {0} Cannot remove the only owner {1} in group {2}", RequesterID, AgentID, GroupID);
+                    m_log.WarnFormat("[GROUPS]: {0} Cannot remove the only owner {1} in group {2}", RequesterID, AgentID, GroupID);
                     return (int)Constants.GenericReturnCodes.PERMISSION;
                 }
                 // An owner can only be removed by themselves...
                 if (RequesterID != AgentID)
                 {
-                    _log.WarnFormat("[GROUPS]: {0} Cannot remove owner {1} of group {2}", RequesterID, AgentID, GroupID);
+                    m_log.WarnFormat("[GROUPS]: {0} Cannot remove owner {1} of group {2}", RequesterID, AgentID, GroupID);
                     return (int)Constants.GenericReturnCodes.PERMISSION;
                 }
             }
@@ -730,16 +791,19 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             {
                 if (!this.TestForPower(requestID, RequesterID, GroupID, (ulong)GroupPowers.Eject))
                 {
-                    _log.WarnFormat("[GROUPS]: {0} No permission to remove {1} from group {2}", RequesterID, AgentID, GroupID);
+                    m_log.WarnFormat("[GROUPS]: {0} No permission to remove {1} from group {2}", RequesterID, AgentID, GroupID);
                     return (int)Constants.GenericReturnCodes.PERMISSION;
                 }
             }
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return (int)Constants.GenericReturnCodes.ERROR;
+
                 if (!IsAgentMemberOfGroup(db, AgentID, GroupID))
                 {
-                    _log.WarnFormat("[GROUPS]: {0} Cannot remove non-member {1} from group {2}", requestID.AgentID, AgentID, GroupID);
+                    m_log.WarnFormat("[GROUPS]: {0} Cannot remove non-member {1} from group {2}", requestID.AgentID, AgentID, GroupID);
                     return (int)Constants.GenericReturnCodes.PERMISSION;
                 }
 
@@ -773,7 +837,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
         {
             if (!this.TestForPower(requestID, inviterID, groupID, (ulong)GroupPowers.Invite))
             {
-                _log.WarnFormat("[GROUPS]: {0} No permission to invite {1} to group {2}", inviterID, agentID, groupID);
+                m_log.WarnFormat("[GROUPS]: {0} No permission to invite {1} to group {2}", inviterID, agentID, groupID);
                 reason = "You do not have permission to invite others into that group.";
                 return (int)Constants.GenericReturnCodes.PERMISSION;
             }
@@ -782,7 +846,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             {
                 if (!CanAddAgentToRole(requestID, inviterID, agentID, groupID, roleID, false))
                 {
-                    _log.WarnFormat("[GROUPS]: {0} No permission to assign new role for user {1} in group {2}.", inviterID, agentID, groupID);
+                    m_log.WarnFormat("[GROUPS]: {0} No permission to assign new role for user {1} in group {2}.", inviterID, agentID, groupID);
                     reason = "You do not have permission to invite others into that group role.";
                     return (int)Constants.GenericReturnCodes.PERMISSION;
                 }
@@ -792,8 +856,14 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             // if (AgentHasBeenInvitedToGroup(agentID, groupID, roleID))
             //    return (int)Constants.GenericReturnCodes.NOCHANGE;  // redundant request
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                {
+                    reason = "MySQL connection failed";
+                    return (int)Constants.GenericReturnCodes.ERROR;
+                }
+
                 if (IsAgentMemberOfGroup(db, agentID, groupID))
                 {
                     // The target user is already a member of the group. See if they are already in that role.
@@ -841,8 +911,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public GroupInviteInfo GetAgentToGroupInvite(GroupRequestID requestID, OpenMetaverse.UUID inviteID)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return null;
+
                 string query =  " SELECT GroupID, RoleID, InviteID, AgentID FROM osgroupinvite" +
                                 " WHERE osgroupinvite.InviteID = ?inviteID";
 
@@ -874,8 +947,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public void RemoveAgentToGroupInvite(GroupRequestID requestID, OpenMetaverse.UUID inviteID)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return;
+
                 string query =  " DELETE FROM osgroupinvite " +
                                 " WHERE osgroupinvite.InviteID = ?inviteID";
 
@@ -903,7 +979,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             if (agentInRoleResults.Count == 0)
             {
                 //this shouldnt happen
-                _log.Error("[GROUPS]: IsAgentInRole: Expected at least one record");
+                m_log.Error("[GROUPS]: IsAgentInRole: Expected at least one record");
                 return false;
             }
             else if (agentInRoleResults[0]["isMember"] == "0")
@@ -936,12 +1012,13 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                 success = true;
             }
             else
-                if (TestForPower(requestID, inviterID, GroupID, (ulong)GroupPowers.AssignMemberLimited))
+            if (TestForPower(requestID, inviterID, GroupID, (ulong)GroupPowers.AssignMemberLimited))
+            {
+                using (ISimpleDB db = GetConnection())
                 {
-                using (ISimpleDB db = _connectionFactory.GetConnection())
-                {
-                    if (IsAgentInRole(db, inviterID, GroupID, RoleID))
-                        success = true;
+                    if (db != null)
+                        if (IsAgentInRole(db, inviterID, GroupID, RoleID))
+                            success = true;
                 }
             }
 
@@ -953,12 +1030,15 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
         {
             if (!CanAddAgentToRole(requestID, inviterID, AgentID, GroupID, RoleID, bypassChecks))
             {
-                _log.WarnFormat("[GROUPS]: {0} No permission to assign new role for user {1} in group {2}.", inviterID, AgentID, GroupID);
+                m_log.WarnFormat("[GROUPS]: {0} No permission to assign new role for user {1} in group {2}.", inviterID, AgentID, GroupID);
                 return;
             }
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return;
+
                 if (! IsAgentInRole(db, AgentID, GroupID, RoleID))
                 {
                     string query 
@@ -979,12 +1059,15 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
         {
             if (!this.TestForPower(requestID, requestID.AgentID, GroupID, (ulong)GroupPowers.RemoveMember))
             {
-                _log.WarnFormat("[GROUPS]: {0} No permission to remove role from user {1} in group {2}", requestID.AgentID, AgentID, GroupID);
+                m_log.WarnFormat("[GROUPS]: {0} No permission to remove role from user {1} in group {2}", requestID.AgentID, AgentID, GroupID);
                 return;
             }
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return;
+
                 // Extra check needed for group owner removals - cannot remove the Owner role unless you are the user
                 GroupRecord groupRec = GetGroupRecord(requestID, GroupID, null);
                 if (groupRec == null) return;
@@ -994,14 +1077,14 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                     List<UUID> groupOwners = GetGroupMembersWithRole(requestID, GroupID, RoleID);
                     if (groupOwners.Count < 2)
                     {
-                        _log.WarnFormat("[GROUPS]: {0} Cannot remove the only owner {1} in group {2}", requestID.AgentID, AgentID, GroupID);
+                        m_log.WarnFormat("[GROUPS]: {0} Cannot remove the only owner {1} in group {2}", requestID.AgentID, AgentID, GroupID);
                         return;
                     }
 
                     // Is the requesting agent the one being removed? Allow them to remove their own Ownership (if not the last owner).
                     if (requestID.AgentID != AgentID)
                     {
-                        _log.WarnFormat("[GROUPS]: {0} No permission to modify group owner roles for {1} in {2}", requestID.AgentID, AgentID, GroupID);
+                        m_log.WarnFormat("[GROUPS]: {0} No permission to modify group owner roles for {1} in {2}", requestID.AgentID, AgentID, GroupID);
                         return;
                     }
                 }
@@ -1027,8 +1110,13 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public List<OpenSim.Framework.GroupRolesData> GetAgentGroupRoles(GroupRequestID requestID, OpenMetaverse.UUID AgentID, OpenMetaverse.UUID GroupID)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            List<OpenSim.Framework.GroupRolesData> foundGroupRoles = new List<OpenSim.Framework.GroupRolesData>();
+
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return foundGroupRoles;
+
                 string query
                     =   " SELECT osrole.RoleID, osrole.GroupID, osrole.Title, osrole.Name, osrole.Description, osrole.Powers" +
                             " , CASE WHEN osgroupmembership.SelectedRoleID = osrole.RoleID THEN 1 ELSE 0 END AS Selected" +
@@ -1048,14 +1136,14 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                 }
 
                 List<Dictionary<string, string>> results = db.QueryWithResults(query, parms);
-                List<OpenSim.Framework.GroupRolesData> foundGroupRoles = new List<OpenSim.Framework.GroupRolesData>();
                 foreach (Dictionary<string, string> result in results)
                 {
                     foundGroupRoles.Add(this.MapGroupRolesDataFromResult(result));
                 }
 
-                return foundGroupRoles;
             }
+
+            return foundGroupRoles;
         }
 
         private bool AgentHasActiveGroup(ISimpleDB db, OpenMetaverse.UUID agentID)
@@ -1084,12 +1172,15 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             //only the agent making the call can change their own group
             if (requestID.AgentID != AgentID)
             {
-                _log.WarnFormat("[GROUPS]: User {0} No permission to change the active group for {1}", requestID.AgentID, AgentID);
+                m_log.WarnFormat("[GROUPS]: User {0} No permission to change the active group for {1}", requestID.AgentID, AgentID);
                 return;
             }
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return;
+
                 //test to see if the user even exists in osagent
                 if (AgentHasActiveGroup(db, AgentID))
                 {
@@ -1121,8 +1212,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public OpenSim.Framework.GroupMembershipData GetAgentActiveMembership(GroupRequestID requestID, OpenMetaverse.UUID AgentID)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return null;
+
                 string query
                     = " SELECT osgroup.GroupID, osgroup.Name as GroupName, osgroup.Charter, osgroup.InsigniaID, " +
                             "osgroup.FounderID, osgroup.MembershipFee, osgroup.OpenEnrollment, osgroup.ShowInList, " +
@@ -1217,9 +1311,10 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             parms.Add("?groupID", GroupID);
             parms.Add("?agentID", AgentID);
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
-                db.QueryNoResults(query, parms);
+                if (db != null)
+                    db.QueryNoResults(query, parms);
             }
         }
 
@@ -1228,7 +1323,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             //the agent making the reuqest must be the target agent
             if (requestID.AgentID != AgentID)
             {
-                _log.WarnFormat("[GROUPS]: {0} No permission to change group info for {1}", requestID.AgentID, AgentID);
+                m_log.WarnFormat("[GROUPS]: {0} No permission to change group info for {1}", requestID.AgentID, AgentID);
                 return;
             }
 
@@ -1245,17 +1340,21 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             parms.Add("?groupID", GroupID);
             parms.Add("?agentID", AgentID);
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
-                db.QueryNoResults(query, parms);
+                if (db != null)
+                    db.QueryNoResults(query, parms);
             }
         }
 
         public OpenSim.Framework.GroupMembershipData GetAgentGroupMembership(GroupRequestID requestID, OpenMetaverse.UUID AgentID, OpenMetaverse.UUID GroupID)
         {
             //TODO?  Refactor?  This is very similar to another method, just different params and queries
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return null;
+
                 string query
                     =   " SELECT osgroup.GroupID, osgroup.Name as GroupName, osgroup.Charter, osgroup.InsigniaID, " +
                             "osgroup.FounderID, osgroup.MembershipFee, osgroup.OpenEnrollment, osgroup.ShowInList, " +
@@ -1300,7 +1399,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
             if (powersResults.Count == 0)
             {
-                _log.Error("[GROUPS]: Could not find any matching powers for agent");
+                m_log.Error("[GROUPS]: Could not find any matching powers for agent");
                 return null;
             }
 
@@ -1309,8 +1408,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public uint GetAgentGroupCount(OpenMetaverse.UUID AgentID)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return 0;
+
                 string query = "SELECT COUNT(osgroup.GroupID) AS GroupCount FROM osgroup" +
                                 " JOIN osgroupmembership ON (osgroup.GroupID = osgroupmembership.GroupID) " +
                                 " WHERE osgroupmembership.AgentID = ?agentID";
@@ -1329,8 +1431,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public List<OpenSim.Framework.GroupMembershipData> GetAgentGroupMemberships(GroupRequestID requestID, OpenMetaverse.UUID AgentID)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return new List<OpenSim.Framework.GroupMembershipData>();
+
 
                 string query =  " SELECT osgroup.GroupID, osgroup.Name as GroupName, osgroup.Charter, osgroup.InsigniaID, osgroup.FounderID, osgroup.MembershipFee, osgroup.OpenEnrollment, osgroup.ShowInList, osgroup.AllowPublish, osgroup.MaturePublish" +
                                 " , osgroupmembership.Contribution, osgroupmembership.ListInProfile, osgroupmembership.AcceptNotices" +
@@ -1379,12 +1484,15 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
         {
             if (!this.TestForPower(requestID, requestID.AgentID, groupID, (ulong)GroupPowers.SendNotices))
             {
-                _log.WarnFormat("[GROUPS]: {0} No permission to send notices for group {1}", requestID.AgentID, groupID);
+                m_log.WarnFormat("[GROUPS]: {0} No permission to send notices for group {1}", requestID.AgentID, groupID);
                 return false;
             }
 
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return false;
+
                 string binBucketString = OpenMetaverse.Utils.BytesToHexString(binaryBucket, "");
 
                 string query = " INSERT INTO osgroupnotice" +
@@ -1411,8 +1519,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
         // See FlexiGroups.cs method InitializeNoticeFromBucket() for an example.
         public GroupNoticeInfo GetGroupNotice(GroupRequestID requestID, OpenMetaverse.UUID noticeID)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return null;
+
                 string query 
                     =   " SELECT GroupID, NoticeID, Timestamp, FromName, Subject, Message, BinaryBucket" +
                         " FROM osgroupnotice" +
@@ -1436,8 +1547,13 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
         // This fetches a summary list of all notices in the group.
         public List<OpenSim.Framework.GroupNoticeData> GetGroupNotices(GroupRequestID requestID, OpenMetaverse.UUID GroupID)
         {
-            using (ISimpleDB db = _connectionFactory.GetConnection())
+            List<OpenSim.Framework.GroupNoticeData> foundNotices = new List<OpenSim.Framework.GroupNoticeData>();
+
+            using (ISimpleDB db = GetConnection())
             {
+                if (db == null)
+                    return foundNotices;
+
                 string query
                     = " SELECT GroupID, NoticeID, Timestamp, FromName, Subject, Message, BinaryBucket" +
                         " FROM osgroupnotice" +
@@ -1447,14 +1563,13 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                 parms.Add("?groupID", GroupID);
 
                 List<Dictionary<string, string>> results = db.QueryWithResults(query, parms);
-                List<OpenSim.Framework.GroupNoticeData> foundNotices = new List<OpenSim.Framework.GroupNoticeData>();
                 foreach (Dictionary<string, string> result in results)
                 {
                     foundNotices.Add(this.MapGroupNoticeDataFromResult(result));
                 }
-
-                return foundNotices;
             }
+
+            return foundNotices;
         }
 
         // This fetches a summary of a single notice for the notice list (no message body).

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/NativeGroupDataProvider.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/NativeGroupDataProvider.cs
@@ -1480,6 +1480,31 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             }
         }
 
+        // Returns null on error, empty list if not in any groups.
+        public List<UUID> GetAgentGroupList(GroupRequestID requestID, UUID AgentID)
+        {
+            List<UUID> groups = new List<UUID>();
+
+            using (ISimpleDB db = GetConnection())
+            {
+                if (db == null)
+                    return null;    // signal error
+
+                string query = " SELECT osgroupmembership.GroupID FROM osgroupmembership WHERE osgroupmembership.AgentID = ?agentID";
+
+                Dictionary<string, object> parms = new Dictionary<string, object>();
+                parms.Add("?agentID", AgentID);
+
+                List<Dictionary<string, string>> results = db.QueryWithResults(query, parms);
+                foreach (Dictionary<string, string> result in results)
+                {
+                    groups.Add(new UUID(result["GroupID"]));
+                }
+            }
+
+            return groups;
+        }
+
         public bool AddGroupNotice(GroupRequestID requestID, OpenMetaverse.UUID groupID, OpenMetaverse.UUID noticeID, string fromName, string subject, string message, byte[] binaryBucket)
         {
             if (!this.TestForPower(requestID, requestID.AgentID, groupID, (ulong)GroupPowers.SendNotices))

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/XmlRpcGroupData.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/XmlRpcGroupData.cs
@@ -469,6 +469,29 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             return memberships;
         }
 
+        // Returns null on error, empty list if not in any groups.
+        public List<UUID> GetAgentGroupList(GroupRequestID requestID, UUID AgentID)
+        {
+            Hashtable param = new Hashtable();
+            param["AgentID"] = AgentID.ToString();
+
+            Hashtable respData = XmlRpcCall(requestID, "groups.getAgentGroupMemberships", param);
+
+            if (respData.Contains("error"))
+                return null;
+
+            List<UUID> groups = new List<UUID>();
+            foreach (object membership in respData.Values)
+            {
+                Hashtable data = (Hashtable)membership;
+                UUID groupID = new UUID((string)data["GroupID"]);
+
+                groups.Add(groupID);
+            }
+
+            return groups;
+        }
+
         public bool IsAgentInGroup(UUID groupID, UUID agentID)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Several significant performance penalties have been eliminated, especially on crossings. These are in the areas of parcel crossing checks for users and objects (checking if the user or prim owner are denied entry), user profile fetching inside a lock, and unconditional database fetches each time the environment settings were needed (including on crossings).