### PR TITLE
Gendarme-guided low-hanging fruit cleanup

### DIFF
--- a/InWorldz/Halcyon/Application.cs
+++ b/InWorldz/Halcyon/Application.cs
@@ -77,7 +77,7 @@ namespace OpenSim
             // Configure Log4Net
             configSource.AddSwitch("Startup", "logconfig");
             string logConfigFile = configSource.Configs["Startup"].GetString("logconfig", String.Empty);
-            if (logConfigFile != String.Empty)
+            if (!String.IsNullOrEmpty(logConfigFile))
             {
                 XmlConfigurator.Configure(new System.IO.FileInfo(logConfigFile));
                 m_log.InfoFormat("[HALCYON MAIN]: configured log4net using \"{0}\" as configuration file", 

--- a/InWorldz/Halcyon/Application.cs
+++ b/InWorldz/Halcyon/Application.cs
@@ -40,7 +40,7 @@ namespace OpenSim
     /// <summary>
     /// Starting class for the OpenSimulator Region
     /// </summary>
-    public class Application
+    public static class Application
     {
         /// <summary>
         /// Text Console Logger
@@ -60,7 +60,7 @@ namespace OpenSim
         /// <summary>
         /// Instance of the OpenSim class.  This could be OpenSim or OpenSimBackground depending on the configuration
         /// </summary>
-        protected static OpenSimBase m_sim = null;
+        private static OpenSimBase m_sim = null;
 
         //could move our main function into OpenSimMain and kill this class
         public static void Main(string[] args)

--- a/InWorldz/InWorldz.ApplicationPlugins/AvatarRemoteCommandModule/AvatarRemoteCommandModule.cs
+++ b/InWorldz/InWorldz.ApplicationPlugins/AvatarRemoteCommandModule/AvatarRemoteCommandModule.cs
@@ -321,7 +321,7 @@ namespace InWorldz.ApplicationPlugins.AvatarRemoteCommandModule
             {
                 Channel = channel,
                 DestinationUUID = UUID.Zero,
-                From = string.Empty,
+                From = String.Empty,
                 Message = message,
                 Position = presence.AbsolutePosition,
                 Scene = presence.Scene,

--- a/InWorldz/InWorldz.ApplicationPlugins/ChatFilter/ChatFilterModule.cs
+++ b/InWorldz/InWorldz.ApplicationPlugins/ChatFilter/ChatFilterModule.cs
@@ -132,7 +132,7 @@ namespace InWorldz.ApplicationPlugins.ChatFilterModule
         void EventManager_OnChatFromClient(object sender, OSChatMessage chat)
         {
             if (!m_enabled) return;
-            if (chat.Message == "" || chat.SenderUUID == chat.DestinationUUID) return;
+            if (String.IsNullOrEmpty(chat.Message) || chat.SenderUUID == chat.DestinationUUID) return;
 
             if (chat.Message.Length < m_minWordLength) return; //too small, nothing to filter, dont waste time
 
@@ -195,7 +195,7 @@ namespace InWorldz.ApplicationPlugins.ChatFilterModule
         bool EventManager_OnBeforeSendInstantMessage(GridInstantMessage message)
         {
             if (!m_enabled) return true;
-            if (message.message == "" || message.fromAgentID == message.toAgentID) return true;
+            if (String.IsNullOrEmpty(message.message) || message.fromAgentID == message.toAgentID) return true;
             if (message.message.Length < m_minWordLength) return true; //too small, nothing to filter, dont waste time
 
             StringBuilder result = new StringBuilder(message.message);

--- a/InWorldz/InWorldz.ApplicationPlugins/ChatLog/ChatLogMessageCassandra12Backend.cs
+++ b/InWorldz/InWorldz.ApplicationPlugins/ChatLog/ChatLogMessageCassandra12Backend.cs
@@ -85,7 +85,7 @@ namespace InWorldz.ApplicationPlugins.ChatLog
             IConfig config = openSim.ConfigSource.Source.Configs["ChatLogModule"];
             if (config == null) return;
 
-            m_enabled = config.GetBoolean("Enabled", false) && config.GetString("Backend", "") == "Cassandra12Backend";
+            m_enabled = config.GetBoolean("Enabled", false) && config.GetString("Backend", String.Empty) == "Cassandra12Backend";
             m_debug = config.GetBoolean("Debug", m_debug);
             m_ttl = config.GetInt("TTL", m_ttl);
 

--- a/InWorldz/InWorldz.ApplicationPlugins/ChatLog/ChatLogMessageFileBackend.cs
+++ b/InWorldz/InWorldz.ApplicationPlugins/ChatLog/ChatLogMessageFileBackend.cs
@@ -70,7 +70,7 @@ namespace InWorldz.ApplicationPlugins.ChatLog
             IConfig config = openSim.ConfigSource.Source.Configs["ChatLogModule"];
             if (config == null) return;
 
-            m_enabled = config.GetString("Backend", "") == "FileBackend";
+            m_enabled = config.GetString("Backend", String.Empty) == "FileBackend";
             m_fileName = config.GetString("File", m_fileName);
 
             if (m_enabled)

--- a/InWorldz/InWorldz.ApplicationPlugins/ChatLog/ChatLogModule.cs
+++ b/InWorldz/InWorldz.ApplicationPlugins/ChatLog/ChatLogModule.cs
@@ -110,7 +110,7 @@ namespace InWorldz.ApplicationPlugins.ChatLog
         void EventManager_OnChatToClient(string message, UUID fromID, UUID toID, UUID regionID, 
             uint timestamp, ChatToClientType type)
         {
-            if (message == "" || toID == fromID) return;
+            if (String.IsNullOrEmpty(message) || toID == fromID) return;
 
             //Create the log, then pass it to the backend
             ChatMessageLog log = new ChatMessageLog()

--- a/InWorldz/InWorldz.ApplicationPlugins/Guest/GuestModule.cs
+++ b/InWorldz/InWorldz.ApplicationPlugins/Guest/GuestModule.cs
@@ -122,7 +122,7 @@ namespace InWorldz.ApplicationPlugins.GuestModule
         void EventManager_OnChatFromClient(object sender, OSChatMessage chat)
         {
             if (!m_enabled) return;
-            if (chat.Message == "" || chat.SenderUUID == chat.DestinationUUID) return;
+            if (String.IsNullOrEmpty(chat.Message) || chat.SenderUUID == chat.DestinationUUID) return;
 
             string lastName = m_scene.CommsManager.UserService.GetLastName(chat.SenderUUID, false);
             if (lastName == "Guest")
@@ -134,8 +134,8 @@ namespace InWorldz.ApplicationPlugins.GuestModule
                 string noProto = "(\\bwww\\.\\S+\\.\\S+|(?<!@)\\b[^[:space:]:@/>]+\\.(?:com|net|edu|org)([/:][^[:space:]<]*)?\\b)";
                 string withProto = "https?://([-\\w\\.]+)+(:\\d+)?(:\\w+)?(@\\d+)?(@\\w+)?/?\\S*";
 
-                string replaced = Regex.Replace(chat.Message, withProto, "", RegexOptions.IgnoreCase);
-                replaced = Regex.Replace(replaced, noProto, "", RegexOptions.IgnoreCase);
+                string replaced = Regex.Replace(chat.Message, withProto, String.Empty, RegexOptions.IgnoreCase);
+                replaced = Regex.Replace(replaced, noProto, String.Empty, RegexOptions.IgnoreCase);
 
                 chat.Message = replaced;
             }

--- a/InWorldz/InWorldz.Data.Assets.Stratus/CloudFilesAssetWorker.cs
+++ b/InWorldz/InWorldz.Data.Assets.Stratus/CloudFilesAssetWorker.cs
@@ -120,7 +120,7 @@ namespace InWorldz.Data.Assets.Stratus
         /// <returns></returns>
         private static string GenerateAssetObjectName(string assetId)
         {
-            return assetId.Replace("-", "").ToLower() + ".asset";
+            return assetId.Replace("-", String.Empty).ToLower() + ".asset";
         }
 
         private void WarnIfLongOperation(string opName, Action operation)

--- a/InWorldz/InWorldz.Data.Inventory.Cassandra/LegacyMysqlStorageImpl.cs
+++ b/InWorldz/InWorldz.Data.Inventory.Cassandra/LegacyMysqlStorageImpl.cs
@@ -111,7 +111,7 @@ namespace InWorldz.Data.Inventory.Cassandra
 
             foreach (InventoryFolderBase folder in folders)
             {
-                if (inList != String.Empty) inList += ",";
+                if (!String.IsNullOrEmpty(inList)) inList += ",";
                 inList += "'" + folder.ID.ToString() + "'";
             }
 

--- a/InWorldz/InWorldz.Data.Inventory.Cassandra/LegacyMysqlStorageImpl.cs
+++ b/InWorldz/InWorldz.Data.Inventory.Cassandra/LegacyMysqlStorageImpl.cs
@@ -107,15 +107,15 @@ namespace InWorldz.Data.Inventory.Cassandra
         /// <returns></returns>
         public List<InventoryItemBase> getItemsInFolders(IEnumerable<InventoryFolderBase> folders)
         {
-            string inList = "";
+            string inList = String.Empty;
 
             foreach (InventoryFolderBase folder in folders)
             {
-                if (inList != "") inList += ",";
+                if (inList != String.Empty) inList += ",";
                 inList += "'" + folder.ID.ToString() + "'";
             }
 
-            if (inList == "") return new List<InventoryItemBase>();
+            if (String.IsNullOrEmpty(inList)) return new List<InventoryItemBase>();
 
             string query = "SELECT * FROM inventoryitems WHERE parentFolderID IN (" + inList + ");";
 

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -186,7 +186,7 @@ namespace InWorldz.Phlox.Engine
                         Vector3 pos = m_host.AbsolutePosition;
                         string thePos = string.Format("at {0}/{1}/{2}", (int)pos.X, (int)pos.Y, (int)pos.Z);
                         string theObject = " in '" + m_host.ParentGroup.Name + "'";
-                        string theLink = (m_host.LinkNum < 2) ? "" : " link #" + m_host.LinkNum.ToString();
+                        string theLink = (m_host.LinkNum < 2) ? String.Empty : " link #" + m_host.LinkNum.ToString();
                         string context = string.Format("{0}{1} {2}", theObject, theLink, thePos);
                         m_log.WarnFormat("[Phlox]: Script '{0}' calling llResetScript too frequently: {1}",
                             llGetScriptName(), context);
@@ -1143,7 +1143,7 @@ namespace InWorldz.Phlox.Engine
         {
             // try avatar username surname
             string name = World.CommsManager.UserService.Key2Name(objecUUID, false);
-            if (name != String.Empty)
+            if (!String.IsNullOrEmpty(name))
             {
                 return name;
             }
@@ -2284,7 +2284,7 @@ namespace InWorldz.Phlox.Engine
 
             // We need to provide the name if present in the prim.
             string result = InventoryName(assetID);
-            if (result != "")
+            if (result != String.Empty)
                 return result;
 
             // Not present in the prim, if full-perm object, return the UUID.
@@ -2662,7 +2662,7 @@ namespace InWorldz.Phlox.Engine
                 date = DateTime.SpecifyKind(date, DateTimeKind.Local);
             }
 
-            if (format == "")
+            if (String.IsNullOrEmpty(format))
                 format = "yyyy'-'MM'-'dd' 'HH':'mm':'ss";
             return date.ToString(format);
         }
@@ -3111,7 +3111,7 @@ namespace InWorldz.Phlox.Engine
                     // If either of these are null, then there was an unknown error.
                     if (new_group == null)
                     {
-                        string errtext = "";
+                        string errtext = String.Empty;
                         switch (reason)
                         {
                             case "permission":
@@ -4020,7 +4020,7 @@ namespace InWorldz.Phlox.Engine
                         result = presence.AddAnimation(anim, m_host.UUID);
                     else
                         result = presence.AddAnimation(animID, m_host.UUID);
-                    if (result != String.Empty)
+                    if (!String.IsNullOrEmpty(result))
                         ScriptShoutError(result);
                 }
                 else
@@ -4090,7 +4090,7 @@ namespace InWorldz.Phlox.Engine
                         result = presence.AddAnimation(anim, m_host.UUID);
                     else
                         result = presence.AddAnimation(animID, m_host.UUID);
-                    if (result != String.Empty)
+                    if (!String.IsNullOrEmpty(result))
                         ScriptShoutError(result);
                 }
                 else
@@ -4481,7 +4481,7 @@ namespace InWorldz.Phlox.Engine
 
             // Okay, now we need to ask the user for permission.
             string ownerName = resolveName(m_host.ParentGroup.RootPart.OwnerID);
-            if (ownerName == String.Empty)
+            if (String.IsNullOrEmpty(ownerName))
                 ownerName = "(hippos)";
 
             lock (m_host.TaskInventory)
@@ -5024,7 +5024,7 @@ namespace InWorldz.Phlox.Engine
         }
         public string iwGetLinkInventoryName(int linknumber, int type, int number)
         {
-            string name = "";
+            string name = String.Empty;
             SceneObjectPart[] parts = GetLinkParts(linknumber);
     
             if (parts.Length == 1)
@@ -5048,7 +5048,7 @@ namespace InWorldz.Phlox.Engine
                 {
                     if(inv.Value.Type == type || type == -1)
                     {
-                        if (pattern == "" || iwMatchString(inv.Value.Name, pattern, matchType) == 1)
+                        if (String.IsNullOrEmpty(pattern) || iwMatchString(inv.Value.Name, pattern, matchType) == 1)
                             keys.Add(inv.Value.Name);
                     }
                 }
@@ -5213,7 +5213,7 @@ namespace InWorldz.Phlox.Engine
             int x = (int)Math.Floor(posx);
             int y = (int)Math.Floor(posy);
             int z = (int)Math.Floor(posz);
-            string prefix = includePrefix ? "http://places.inworldz.com/" : "";
+            string prefix = includePrefix ? "http://places.inworldz.com/" : String.Empty;
 
             return prefix + Util.EscapeUriDataStringRfc3986(region) + "/" + x.ToString() + "/" + y.ToString() + "/" + z.ToString();
         }
@@ -5429,7 +5429,7 @@ namespace InWorldz.Phlox.Engine
                     break;
 
                 case ScriptBaseClass.DATA_NAME: // "First Last"
-                    reply = (userProfile == null) ? "" : userProfile.FirstName + " " + userProfile.SurName;
+                    reply = (userProfile == null) ? String.Empty : userProfile.FirstName + " " + userProfile.SurName;
                     break;
 
                 case ScriptBaseClass.DATA_BORN: // "YYYY-MM-DD"
@@ -5686,7 +5686,7 @@ namespace InWorldz.Phlox.Engine
             UUID avatar = (UUID)id;
             ScenePresence presence = World.GetScenePresence(avatar);
             if (presence == null)
-                return "";
+                return String.Empty;
 
             if (m_host.RegionHandle == presence.RegionHandle)
             {
@@ -6194,14 +6194,14 @@ namespace InWorldz.Phlox.Engine
                     }
                 }
             }
-            return "";
+            return String.Empty;
         }
         public string iwGetLinkInventoryDesc(int linknumber, string name)
         {
             SceneObjectPart[] parts = GetLinkParts(linknumber);
 
             if (parts.Length != 1)
-                return "";
+                return String.Empty;
 
             return GetInventoryDesc(parts[0], name);
         }
@@ -7372,9 +7372,9 @@ namespace InWorldz.Phlox.Engine
 
         private Object AutoCastString(string str)
         {
-            if(str == "") return str;
+            if(String.IsNullOrEmpty(str)) return str;
 
-            int c = str.Length - str.Replace(".", "").Length;
+            int c = str.Length - str.Replace(".", String.Empty).Length;
 
             if (c == 1)
             {
@@ -7414,7 +7414,7 @@ namespace InWorldz.Phlox.Engine
 
         private string iwParseString2ListSub(string str, int trimString, int doCapitalize)
         {
-            if (str == "") return "";
+            if (String.IsNullOrEmpty(str)) return str;
             if (trimString != 0)
             {
                 str = llStringTrim(str, trimString);
@@ -7532,12 +7532,12 @@ namespace InWorldz.Phlox.Engine
             {
                 dfound = false;
                 int cindex = -1;
-                string cdeli = "";
+                string cdeli = String.Empty;
                 foreach (var delimiter in delimiters)
                 {
                     int index = str.IndexOf(delimiter.ToString());
                     bool found = index != -1;
-                    if (found && String.Empty != delimiter.ToString())
+                    if (found && !String.IsNullOrEmpty(delimiter.ToString()))
                     {
                         if ((cindex > index) || (cindex == -1))
                         {
@@ -7551,7 +7551,6 @@ namespace InWorldz.Phlox.Engine
                 {
                     if (cindex > 0)
                     {
-                        //string temp = (string)(str.Substring(0, cindex));
                         string temp = iwParseString2ListSub((string)(str.Substring(0, cindex)), trimString, doCapitalize);
                         if (temp.Length > 0 || keepNulls == true)
                         {
@@ -7563,7 +7562,7 @@ namespace InWorldz.Phlox.Engine
                     else if (cindex == 0 || keepNulls == true)
                     {
                         totalSplits++;
-                        ret.Add("");
+                        ret.Add(String.Empty);
                     }
                     if (maxSplits > 0 && totalSplits >= maxSplits)
                     {
@@ -7614,7 +7613,7 @@ namespace InWorldz.Phlox.Engine
 
             str = iwParseString2ListSub(str, trimString, doCapitalize);
 
-            if (str != "" || keepNulls == true)
+            if (str != String.Empty || keepNulls == true)
             {
                 if (autoCast > 1) ret.Add(AutoCastString((string)str));
                 else ret.Add((string)(str));
@@ -7667,12 +7666,12 @@ namespace InWorldz.Phlox.Engine
             {
                 dfound = false;
                 int cindex = -1;
-                string cdeli = "";
+                string cdeli = String.Empty;
                 foreach (var delimiter in delimiters)
                 {
                     int index = str.IndexOf(delimiter.ToString());
                     bool found = index != -1;
-                    if (found && String.Empty != delimiter.ToString())
+                    if (found && !String.IsNullOrEmpty(delimiter.ToString()))
                     {
                         if ((cindex > index) || (cindex == -1))
                         {
@@ -7700,7 +7699,7 @@ namespace InWorldz.Phlox.Engine
                     str = str.Substring(cindex + cdeli.Length);
                 }
             } while (dfound);
-            if (str != "")
+            if (str != String.Empty)
             {
                 ret.Add((string)(str));
             }
@@ -8655,7 +8654,7 @@ namespace InWorldz.Phlox.Engine
 
                 for (int i = 0; i < buttons.Length; i++)
                 {
-                    if (buttons.Data[i].ToString() == String.Empty)
+                    if (String.IsNullOrEmpty(buttons.Data[i].ToString()))
                     {
                         LSLError("button label cannot be blank");
                         return;
@@ -8795,7 +8794,7 @@ namespace InWorldz.Phlox.Engine
                 IXmlRpcRouter xmlRpcRouter = m_ScriptEngine.World.RequestModuleInterface<IXmlRpcRouter>();
                 if (xmlRpcRouter != null)
                     xmlRpcRouter.RegisterNewReceiver(m_ScriptEngine.ScriptModule, channelID, m_host.UUID, m_itemID, "http://" + System.Environment.MachineName + ":" + xmlrpcMod.Port.ToString() + "/");
-                object[] resobj = new object[] { (int)(1), (string)(channelID.ToString()), (string)(UUID.Zero.ToString()), (string)(String.Empty), (int)(0), (string)(String.Empty) };
+                object[] resobj = new object[] { (int)(1), channelID.ToString(), UUID.Zero.ToString(), String.Empty, (int)(0), String.Empty };
                 m_ScriptEngine.PostScriptEvent(m_itemID, new EventParams(
                         "remote_data", resobj,
                         new DetectParams[0]));
@@ -9761,7 +9760,7 @@ namespace InWorldz.Phlox.Engine
             catch (Exception e)
             {
                 LSLError("Error in base64Encode" + e.Message);
-                return "";
+                return String.Empty;
             }
         }
 
@@ -11273,7 +11272,7 @@ namespace InWorldz.Phlox.Engine
             if (beginning == srclen)
             {
                 if (srclen != 0)
-                    tokens.Add((string)(""));
+                    tokens.Add((string)(String.Empty));
             }
 
             return new LSL_List(tokens);
@@ -12406,7 +12405,7 @@ namespace InWorldz.Phlox.Engine
 
         public string llXorBase64StringsCorrect(string str1, string str2)
         {
-            if ((str1 == String.Empty) || (str2 == String.Empty))
+            if (String.IsNullOrEmpty(str1) || String.IsNullOrEmpty(str2))
                 return str1;
             string ret = String.Empty;
             string src1 = llBase64ToString(str1);
@@ -12805,7 +12804,7 @@ namespace InWorldz.Phlox.Engine
                         ret.Add(av.Firstname + " " + av.Lastname);
                         break;
                     case ScriptBaseClass.OBJECT_DESC:
-                        ret.Add("");
+                        ret.Add(String.Empty);
                         break;
                     case ScriptBaseClass.OBJECT_POS:
                         Vector3 pos = av.AbsolutePosition;
@@ -13801,7 +13800,7 @@ namespace InWorldz.Phlox.Engine
         public string UserNameToReport(UUID agentId, bool onlyIfCached)
         {
             string name = World.CommsManager.UserService.Key2Name(agentId, onlyIfCached);
-            if (name != String.Empty)
+            if (!String.IsNullOrEmpty(name))
                 return name;
 
             return agentId.ToString();
@@ -13932,7 +13931,7 @@ namespace InWorldz.Phlox.Engine
                 OSD specVal = JsonGetSpecific(o, specifiers, 0);
                 if (specVal == null) return ScriptBaseClass.JSON_INVALID;
                 string ret = OSDToJsonStringValue(specVal);
-                if (ret == "") return ScriptBaseClass.JSON_NULL;
+                if (String.IsNullOrEmpty(ret)) return ScriptBaseClass.JSON_NULL;
                 return ret;
             }
             catch (Exception)
@@ -13947,7 +13946,7 @@ namespace InWorldz.Phlox.Engine
             try
             {
                 // Special case an empty string as meaning empty list
-                if (text == "")
+                if (String.IsNullOrEmpty(text))
                     return new LSL_List();
                 LitJson.JsonData json = DetectJson(text);
                 if (json == null)
@@ -14039,11 +14038,11 @@ namespace InWorldz.Phlox.Engine
             }
             else if (node.Type == OSDType.Array)
             {
-                string resp = "";
+                string resp = String.Empty;
                 OSDArray ar = node as OSDArray;
                 foreach (OSD o in ar)
                 {
-                    if (resp != "") resp += ",";
+                    if (resp != String.Empty) resp += ",";
                     resp += JsonNode2ListElement(o, true);
                 }
 
@@ -14051,11 +14050,11 @@ namespace InWorldz.Phlox.Engine
             }
             else if (node.Type == OSDType.Map)
             {
-                string resp = "";
+                string resp = String.Empty;
                 OSDMap ar = node as OSDMap;
                 foreach (KeyValuePair<string, OSD> o in ar)
                 {
-                    if (resp != "") resp += ",";
+                    if (resp != String.Empty) resp += ",";
                     resp += "\""+o.Key.ToString() + "\":" + JsonNode2ListElement(o.Value, true).ToString();
                 }
                 return "{" + resp + "}";
@@ -14554,8 +14553,8 @@ namespace InWorldz.Phlox.Engine
 
         public string iwReplaceString(string str, string pattern, string replacement)
         {
-            if (str == string.Empty || pattern == string.Empty) return str;
-            if (replacement == "") return str.Replace(pattern, null);
+            if (String.IsNullOrEmpty(str) || String.IsNullOrEmpty(pattern)) return str;
+            if (String.IsNullOrEmpty(replacement)) return str.Replace(pattern, null);
             if (replacement.Length > 1024 || pattern.Length > 1024) return str;
             return str.Replace(pattern, replacement);
         }
@@ -14588,7 +14587,7 @@ namespace InWorldz.Phlox.Engine
                 if (str.Length > 32768)
                 {
                     LSLError("Return value from iwFormatString is greater than 64kb");
-                    return "";
+                    return String.Empty;
                 }
 
                 float time2 = Util.GetLongTickCount();
@@ -14783,7 +14782,7 @@ namespace InWorldz.Phlox.Engine
                     case "base16":
                         return DecodeBase16(str);
                     case "uuid":
-                        return DecodeBase16(str.Replace("-",""));
+                        return DecodeBase16(str.Replace("-", String.Empty));
                     case "base64":
                         try
                         {
@@ -14985,9 +14984,9 @@ namespace InWorldz.Phlox.Engine
                 if (str.EndsWith("==")) extra = 2;
                 else if (str.EndsWith("=")) extra = 1;
 
-                str = Uri.EscapeDataString(str.Replace("=",""));
-                //byte[] bytes = Encoding.Unicode.GetBytes(str.Replace("%", "").ToLower());
-                byte[] inBytes = DecodeBase16(str.Replace("%", ""));
+                str = Uri.EscapeDataString(str.Replace("=", String.Empty));
+                //byte[] bytes = Encoding.Unicode.GetBytes(str.Replace("%", String.Empty).ToLower());
+                byte[] inBytes = DecodeBase16(str.Replace("%", String.Empty));
                 StringBuilder ret = new StringBuilder();
 
 
@@ -15199,7 +15198,7 @@ namespace InWorldz.Phlox.Engine
             // http://wiki.secondlife.com/wiki/User:Becky_Pippen/Text_Storage
             public static string AsciiCompress(string str)
             {
-                if (str == "") return str;
+                if (String.IsNullOrEmpty(str)) return str;
                 str = StringToAscii(str);
                 int len = str.Length;
                 bool emptyEnd = false;
@@ -15228,7 +15227,7 @@ namespace InWorldz.Phlox.Engine
             // http://wiki.secondlife.com/wiki/User:Becky_Pippen/Text_Storage
             public static string AsciiDecompress(string str)
             {
-                if (str == "") return str;
+                if (String.IsNullOrEmpty(str)) return str;
                 int len = str.Length;
                 StringBuilder result = new StringBuilder(len * 2);
                 for (int i = 0; i < len; i++)
@@ -15285,7 +15284,7 @@ namespace InWorldz.Phlox.Engine
                             bytes = sha512util.ComputeHash(inBytes);
                         break;
                     default:
-                        return "";
+                        return String.Empty;
                 }
                 return Encode(bytes, outCodec);
             }
@@ -15317,7 +15316,7 @@ namespace InWorldz.Phlox.Engine
                     if (CodecUtil.HasCodec(v) == false)
                     {
                         LSLError("Invalid input codec: " + v);
-                        return "";
+                        return String.Empty;
                     }
                     cBytes = CodecUtil.Decode(str, v.ToLower());
                     useBytes = true;
@@ -15364,7 +15363,7 @@ namespace InWorldz.Phlox.Engine
                     if (!CodecUtil.HasCodec(outputCodec))
                     {
                         LSLError("Bad codec for gzip compression: " + outputCodec);
-                        return "";
+                        return String.Empty;
                     }
                     if (operation == OP_ENCODE) return CodecUtil.gzipCompress(str, outputCodec);
                     else if (operation == OP_DECODE) return CodecUtil.gzipDecompress(str, outputCodec);
@@ -15382,7 +15381,7 @@ namespace InWorldz.Phlox.Engine
                 case "sha384":
                 case "sha512":
                     string outCodec = "base16";
-                    string nonce = "";
+                    string nonce = String.Empty;
                     if (extraParams.Length >= 0 && extraParams.Length % 2 == 0)
                     {
                         int len = extraParams.Length;
@@ -15412,7 +15411,7 @@ namespace InWorldz.Phlox.Engine
                     if (str == string.Empty)
                     {
                         LSLError(string.Format("Error: using a blank password to generate an AES encryption key is not allowed."));
-                        return "";
+                        return String.Empty;
                     }
                     byte[] _aesKeySalt = null;
                     string _aesKeyCodec = "base16";
@@ -15429,7 +15428,7 @@ namespace InWorldz.Phlox.Engine
                                 case "salt":
                                     if(val.Length == 0) {
                                         LSLError("Salt for AES encryption key cannot be blank.");
-                                        return "";
+                                        return String.Empty;
                                     }
                                     _aesKeySalt = Encoding.UTF8.GetBytes(val);
                                     break;
@@ -15437,7 +15436,7 @@ namespace InWorldz.Phlox.Engine
                                     if (CodecUtil.HasCodec(val) == false)
                                     {
                                         LSLError("Error: invalid codec for AES encryption key: " + val);
-                                        return "";
+                                        return String.Empty;
                                     }
                                     _aesKeyCodec = val;
                                     break;
@@ -15445,7 +15444,7 @@ namespace InWorldz.Phlox.Engine
                                     int iterTest = Convert.ToInt32(val);
                                     if (iterTest < 1 || iterTest > 1024) {
                                         LSLError("Rounds for AES encryption key cannot be more than 1024 or less than 1");
-                                        return "";
+                                        return String.Empty;
                                     }
                                     _aesKeyIter = iterTest;
                                     break;
@@ -15465,8 +15464,8 @@ namespace InWorldz.Phlox.Engine
                     if (str == string.Empty) return str;
                     string aesCodec = "base4096";
                     string aesKeyCodec = "base16";
-                    string aesKey = "";
-                    string aesVector = "";
+                    string aesKey = String.Empty;
+                    string aesVector = String.Empty;
                     
                     if (extraParams.Length >= 0)
                     {
@@ -15481,7 +15480,7 @@ namespace InWorldz.Phlox.Engine
                                     aesKey = val;
                                     break;
                                 case "vector":
-                                    if (val != "") aesVector = val.Replace("-",null);
+                                    if (val != String.Empty) aesVector = val.Replace("-",null);
                                     break;
                                 case "key codec":
                                     aesKeyCodec = val;
@@ -15494,24 +15493,24 @@ namespace InWorldz.Phlox.Engine
                             }
                         }
                     }
-                    if (aesKey == "" || aesVector == "" || aesCodec == "")
+                    if (String.IsNullOrEmpty(aesKey) || String.IsNullOrEmpty(aesVector) || String.IsNullOrEmpty(aesCodec))
                     {
                         LSLError("Error: some parameters for AES encryption are blank or missing!");
-                        return "";
+                        return String.Empty;
                     }
                     if (aesVector.Length != 32)
                     {
                         LSLError("AES vectors require a 32-character hexadecimal string.");
-                        return "";
+                        return String.Empty;
                     }
                     if (CodecUtil.HasCodec(aesCodec) == false)
                     {
                         LSLError("Error: invalid codec for AES encryption: " + aesCodec);
-                        return "";
+                        return String.Empty;
                     }
                     if(CodecUtil.HasCodec(aesKeyCodec) == false) {
                         LSLError("Error: invalid input codec for AES encryption key: " + aesKeyCodec);
-                        return "";
+                        return String.Empty;
                     }
                     byte[] aesKeyBytes = CodecUtil.Decode(aesKey, aesKeyCodec);
 
@@ -15571,11 +15570,11 @@ namespace InWorldz.Phlox.Engine
                     if (ret == null)
                     {
                         LSLError("Error: \"X\" is not a valid codec for iwStringCodec!".Replace("X", codec));
-                        return "";
+                        return String.Empty;
                     }
                     return ret;
             }
-            return "";
+            return String.Empty;
         }
 
         public LSL_List llCastRay(Vector3 start, Vector3 end, LSL_List options)
@@ -16129,7 +16128,7 @@ namespace InWorldz.Phlox.Engine
                         int count=0;
                         foreach(string outfit in itms)
                         {
-                            if(pattern == "" || iwMatchString(outfit, pattern, matchType) == 1)
+                            if(String.IsNullOrEmpty(pattern) || iwMatchString(outfit, pattern, matchType) == 1)
                             {
                                 if (count >= start && (end == -1 || count <= end))
                                 {
@@ -16530,7 +16529,7 @@ namespace InWorldz.Phlox.Engine
 
             IBotManager manager = World.RequestModuleInterface<IBotManager>();
             if (manager != null)
-                manager.BotChat(botUUID, 0, "", ChatTypeEnum.StartTyping, m_host.OwnerID);
+                manager.BotChat(botUUID, 0, String.Empty, ChatTypeEnum.StartTyping, m_host.OwnerID);
             ScriptSleep(15);
         }
 
@@ -16542,7 +16541,7 @@ namespace InWorldz.Phlox.Engine
 
             IBotManager manager = World.RequestModuleInterface<IBotManager>();
             if (manager != null)
-                manager.BotChat(botUUID, 0, "", ChatTypeEnum.StopTyping, m_host.OwnerID);
+                manager.BotChat(botUUID, 0, String.Empty, ChatTypeEnum.StopTyping, m_host.OwnerID);
             ScriptSleep(15);
         }
 
@@ -16896,7 +16895,7 @@ namespace InWorldz.Phlox.Engine
 
             foreach(SceneObjectPart part in m_host.ParentGroup.Children.Values)
             {
-                if (pattern == "" || iwMatchString(part.Name, pattern, matchType) == 1)
+                if (String.IsNullOrEmpty(pattern) || iwMatchString(part.Name, pattern, matchType) == 1)
                     parts.Add(part);
             }
 
@@ -16928,7 +16927,7 @@ namespace InWorldz.Phlox.Engine
 
             foreach (SceneObjectPart part in m_host.ParentGroup.Children.Values)
             {
-                if (pattern == "" || iwMatchString(part.Description, pattern, matchType) == 1)
+                if (String.IsNullOrEmpty(pattern) || iwMatchString(part.Description, pattern, matchType) == 1)
                     parts.Add(part);
             }
 
@@ -17041,7 +17040,7 @@ namespace InWorldz.Phlox.Engine
                                 }
 
                                 string ln = Util.ArraySegmentToString(input[idx], Encoding.UTF8);
-                                if (ln.Contains("\r")) ln = ln.Replace("\r", "");
+                                if (ln.Contains("\r")) ln = ln.Replace("\r", String.Empty);
 
                                 output.Add(ln);
                                 count += input[idx].Count + 1;
@@ -17095,26 +17094,26 @@ namespace InWorldz.Phlox.Engine
         public static string GetLine(UUID assetID, int line, int startOffset, int maxLength)
         {
             if ((line < 0) || (maxLength < 0))
-                return "";
+                return String.Empty;
 
             string data;
 
             lock (m_Notecards)
             {
                 if (!IsCachedNoLock(assetID))
-                    return "";
+                    return String.Empty;
 
                 m_Notecards[assetID].lastRef = DateTime.Now;
 
                 if (maxLength == 0)  // 0 is valid so update lastRef before this check.
-                    return "";
+                    return String.Empty;
 
                 if (line >= m_Notecards[assetID].text.Length)
                     return "\n\n\n";
 
                 data = m_Notecards[assetID].text[line];
                 if (startOffset >= data.Length)
-                    return "";  // no more data
+                    return String.Empty;  // no more data
                 if (startOffset + maxLength > data.Length)
                     maxLength = data.Length - startOffset;  // last bit of data on the line
 

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -2284,7 +2284,7 @@ namespace InWorldz.Phlox.Engine
 
             // We need to provide the name if present in the prim.
             string result = InventoryName(assetID);
-            if (result != String.Empty)
+            if (!String.IsNullOrEmpty(result))
                 return result;
 
             // Not present in the prim, if full-perm object, return the UUID.
@@ -7613,7 +7613,7 @@ namespace InWorldz.Phlox.Engine
 
             str = iwParseString2ListSub(str, trimString, doCapitalize);
 
-            if (str != String.Empty || keepNulls == true)
+            if (!String.IsNullOrEmpty(str) || keepNulls == true)
             {
                 if (autoCast > 1) ret.Add(AutoCastString((string)str));
                 else ret.Add((string)(str));
@@ -7699,7 +7699,7 @@ namespace InWorldz.Phlox.Engine
                     str = str.Substring(cindex + cdeli.Length);
                 }
             } while (dfound);
-            if (str != String.Empty)
+            if (!String.IsNullOrEmpty(str))
             {
                 ret.Add((string)(str));
             }
@@ -14042,7 +14042,7 @@ namespace InWorldz.Phlox.Engine
                 OSDArray ar = node as OSDArray;
                 foreach (OSD o in ar)
                 {
-                    if (resp != String.Empty) resp += ",";
+                    if (!String.IsNullOrEmpty(resp)) resp += ",";
                     resp += JsonNode2ListElement(o, true);
                 }
 
@@ -14054,7 +14054,7 @@ namespace InWorldz.Phlox.Engine
                 OSDMap ar = node as OSDMap;
                 foreach (KeyValuePair<string, OSD> o in ar)
                 {
-                    if (resp != String.Empty) resp += ",";
+                    if (!String.IsNullOrEmpty(resp)) resp += ",";
                     resp += "\""+o.Key.ToString() + "\":" + JsonNode2ListElement(o.Value, true).ToString();
                 }
                 return "{" + resp + "}";
@@ -15480,7 +15480,7 @@ namespace InWorldz.Phlox.Engine
                                     aesKey = val;
                                     break;
                                 case "vector":
-                                    if (val != String.Empty) aesVector = val.Replace("-",null);
+                                    if (!String.IsNullOrEmpty(val)) aesVector = val.Replace("-",null);
                                     break;
                                 case "key codec":
                                     aesKeyCodec = val;

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -7437,7 +7437,7 @@ namespace InWorldz.Phlox.Engine
         }
 
         public LSL_List iwParseString2List(string str, LSL_List separators, LSL_List in_spacers, LSL_List args) {
-            if(str == string.Empty) return new LSL_List();
+            if(str == String.Empty) return new LSL_List();
             List<object> ret = new List<object>();
             List<object> spacers = new List<object>();
 
@@ -8772,7 +8772,7 @@ namespace InWorldz.Phlox.Engine
 
             // the rest of the permission checks are done in RezScript, so check the pin there as well
             string result = World.RezScript(srcId, m_host, destId, pin, running, start_param);
-            if (result != string.Empty)
+            if (result != String.Empty)
             {
                 // validation error updating script
                 if (result == "PIN")    // special case for public error (let's not match the silly SL "illegal" text)
@@ -9773,7 +9773,7 @@ namespace InWorldz.Phlox.Engine
             }
             catch
             {
-                return string.Empty;
+                return String.Empty;
             }
         }
 
@@ -11058,7 +11058,7 @@ namespace InWorldz.Phlox.Engine
 
             if (!UUID.TryParse(request_id, out requestIdAsUuid))
             {
-                return string.Empty;
+                return String.Empty;
             }
 
             if (m_UrlModule != null)
@@ -11131,7 +11131,7 @@ namespace InWorldz.Phlox.Engine
             foreach (object obj in separray)
             {
                 string str = (string)obj;
-                if (str != string.Empty)
+                if (str != String.Empty)
                 {
                     newSepArray.Add(obj);
                 }
@@ -11144,7 +11144,7 @@ namespace InWorldz.Phlox.Engine
             foreach (object obj in spcarray)
             {
                 string str = (string)obj;
-                if (str != string.Empty)
+                if (str != String.Empty)
                 {
                     newSpcArray.Add(obj);
                 }
@@ -13638,7 +13638,7 @@ namespace InWorldz.Phlox.Engine
                     if (!IsTeleportAuthorized(targetSP))
                         return;
 
-                    if (region == string.Empty)
+                    if (region == String.Empty)
                         region = targetSP.Scene.RegionInfo.RegionName;
                     else
                     if (region != targetSP.Scene.RegionInfo.RegionName) // diff region?
@@ -14547,7 +14547,7 @@ namespace InWorldz.Phlox.Engine
 
         public string iwInt2Char(int num)
         {
-            if (num < 0 || num > 0xffff) return string.Empty;
+            if (num < 0 || num > 0xffff) return String.Empty;
             return Convert.ToChar(num).ToString();
         }
 
@@ -14561,7 +14561,7 @@ namespace InWorldz.Phlox.Engine
 
         public string iwFormatString(string str, LSL_List values)
         {
-            if (str == string.Empty) return str;
+            if (str == String.Empty) return str;
 
             int len = values.Length;
 
@@ -14574,7 +14574,7 @@ namespace InWorldz.Phlox.Engine
             {
                 string pattern = "{" + Convert.ToString(i) + "}";
                 string val = values.GetLSLStringItem(i);
-                if (val == string.Empty) val = null;
+                if (val == String.Empty) val = null;
                 else if (val.Length > 1024) val = val.Substring(0, 1023);
                 if (str.Contains(pattern))
                 {
@@ -15326,7 +15326,7 @@ namespace InWorldz.Phlox.Engine
             switch (codec)
             {
                 case "ascii":
-                    if (str == string.Empty) return str;
+                    if (str == String.Empty) return str;
                     if(operation == OP_ENCODE) {
                         return CodecUtil.StringToAscii(str);
                     } else if(operation == OP_DECODE) {
@@ -15346,7 +15346,7 @@ namespace InWorldz.Phlox.Engine
                     }
                     break;
                 case "gzip":
-                    if (str == string.Empty) return str;
+                    if (str == String.Empty) return str;
                     string outputCodec = "base4096";
                     if (extraParams.Length >= 2 && extraParams.Length % 2 == 0)
                     {
@@ -15369,7 +15369,7 @@ namespace InWorldz.Phlox.Engine
                     else if (operation == OP_DECODE) return CodecUtil.gzipDecompress(str, outputCodec);
                     break;
                 case "ascii-zip":
-                    if (str == string.Empty) return str;
+                    if (str == String.Empty) return str;
                     if (operation == OP_ENCODE) return CodecUtil.AsciiCompress(str);
                     else if (operation == OP_DECODE) return CodecUtil.AsciiDecompress(str);
                     break;
@@ -15408,7 +15408,7 @@ namespace InWorldz.Phlox.Engine
                     }
                     return CodecUtil.Hash(str, nonce, codec, outCodec);
                 case "aes-key":
-                    if (str == string.Empty)
+                    if (str == String.Empty)
                     {
                         LSLError(string.Format("Error: using a blank password to generate an AES encryption key is not allowed."));
                         return String.Empty;
@@ -15461,7 +15461,7 @@ namespace InWorldz.Phlox.Engine
                         return aesKeyNew;
                     }
                 case "aes":
-                    if (str == string.Empty) return str;
+                    if (str == String.Empty) return str;
                     string aesCodec = "base4096";
                     string aesKeyCodec = "base16";
                     string aesKey = String.Empty;
@@ -15552,7 +15552,7 @@ namespace InWorldz.Phlox.Engine
                     LSLError("Error: No codec specified for iwStringCodec!");
                     break;
                 default:
-                    if (str == string.Empty) return str;
+                    if (str == String.Empty) return str;
                     string ret = null;
                     if (operation == OP_ENCODE)
                     {
@@ -15796,7 +15796,7 @@ namespace InWorldz.Phlox.Engine
             UUID userID = UUID.Zero;
             if ((!UUID.TryParse(user, out userID)) || (userID == UUID.Zero))
                 return (int)Constants.GenericReturnCodes.PARAMETER;
-            if (roleName == string.Empty)
+            if (roleName == String.Empty)
                 roleName = "Everyone";
 
             if (!ScriptOwnerIsCreator())
@@ -15887,12 +15887,12 @@ namespace InWorldz.Phlox.Engine
         {
             UUID botUUID = UUID.Zero;
             if (!UUID.TryParse(botID, out botUUID) || (botUUID == UUID.Zero))
-                return string.Empty;
+                return String.Empty;
 
             IBotManager manager = World.RequestModuleInterface<IBotManager>();
             if (manager != null)
                 return manager.GetBotOwner(botUUID).ToString();
-            return string.Empty;
+            return String.Empty;
         }
 
         public int botIsBot(string userID)
@@ -15911,12 +15911,12 @@ namespace InWorldz.Phlox.Engine
         {
             UUID botUUID = UUID.Zero;
             if (!UUID.TryParse(botID, out botUUID) || (botUUID == UUID.Zero))
-                return string.Empty;
+                return String.Empty;
 
             IBotManager manager = World.RequestModuleInterface<IBotManager>();
             if (manager != null)
                 return manager.GetBotName(botUUID);
-            return string.Empty;
+            return String.Empty;
         }
 
         public void botChangeOwner(string botID, string newOwnerID)

--- a/InWorldz/InWorldz.RemoteAdmin/RemoteAdmin.cs
+++ b/InWorldz/InWorldz.RemoteAdmin/RemoteAdmin.cs
@@ -132,7 +132,7 @@ namespace InWorldz.RemoteAdmin
             try
             {
                 responseData["Status"] = "Success";
-                responseData["Value"] = "";
+                responseData["Value"] = String.Empty;
 
                 XmlMethodHandler handler = LookupCommand(request.MethodNameObject, request.MethodNameMethod);
 
@@ -236,7 +236,7 @@ namespace InWorldz.RemoteAdmin
 
             string command = (string)args[1];
             MainConsole.Instance.RunCommand(command);
-            return "";
+            return String.Empty;
         }
 
         public void Dispose()

--- a/InWorldz/InWorldz.RemoteAdmin/RemoteAdminPlugin.cs
+++ b/InWorldz/InWorldz.RemoteAdmin/RemoteAdminPlugin.cs
@@ -191,7 +191,7 @@ namespace InWorldz.RemoteAdmin
             {
                 m_log.ErrorFormat("[RADMIN] Shutdown: failed: {0}", e.Message);
                 m_log.DebugFormat("[RADMIN] Shutdown: failed: {0}", e.ToString());
-                throw e;
+                throw;
             }
 
             m_log.Info("[RADMIN]: Shutdown Administrator Request complete");

--- a/InWorldz/InWorldz.Testing/MockClientAPI.cs
+++ b/InWorldz/InWorldz.Testing/MockClientAPI.cs
@@ -67,7 +67,7 @@ namespace InWorldz.Testing
 
         public string ActiveGroupName
         {
-            get { return ""; }
+            get { return String.Empty; }
         }
 
         public ulong ActiveGroupPowers
@@ -1134,7 +1134,7 @@ namespace InWorldz.Testing
 
         public string GetClientOption(string option)
         {
-            return "";
+            return String.Empty;
         }
 
         public void SendSetFollowCamProperties(OpenMetaverse.UUID objectID, Dictionary<int, float> parameters)

--- a/InWorldz/InWorldz.VivoxVoice/VivoxVoiceModule.cs
+++ b/InWorldz/InWorldz.VivoxVoice/VivoxVoiceModule.cs
@@ -237,7 +237,7 @@ namespace InWorldz.VivoxVoice
                     
                     string channelId;
 
-                    string sceneUUID  = m_forcedChannelName == String.Empty ? scene.RegionInfo.RegionID.ToString() : m_forcedChannelName;
+                    string sceneUUID  = String.IsNullOrEmpty(m_forcedChannelName) ? scene.RegionInfo.RegionID.ToString() : m_forcedChannelName;
                     string sceneName  = scene.RegionInfo.RegionName;
                     
                     // Make sure that all local channels are deleted.
@@ -744,7 +744,7 @@ namespace InWorldz.VivoxVoice
             string landName;
             string parentId;
 
-            lock (m_parents) parentId = m_forcedChannelName == String.Empty ? m_parents[scene.RegionInfo.RegionID.ToString()] : m_parents[m_forcedChannelName];
+            lock (m_parents) parentId = String.IsNullOrEmpty(m_forcedChannelName) ? m_parents[scene.RegionInfo.RegionID.ToString()] : m_parents[m_forcedChannelName];
 
             // Create parcel voice channel. If no parcel exists, then the voice channel ID is the same
             // as the directory ID. Otherwise, it reflects the parcel's ID.
@@ -759,7 +759,7 @@ namespace InWorldz.VivoxVoice
             else
             {
                 landName = String.Format("{0}:{1}", scene.RegionInfo.RegionName, scene.RegionInfo.RegionName);
-                landUUID = m_forcedChannelName == String.Empty ? scene.RegionInfo.RegionID.ToString() : m_forcedChannelName;
+                landUUID = String.IsNullOrEmpty(m_forcedChannelName) ? scene.RegionInfo.RegionID.ToString() : m_forcedChannelName;
                 //m_log.DebugFormat("[VivoxVoice]: Region:Parcel \"{0}\": parcel id {1}: using channel name {2}", 
                 //                  landName, land.LocalID, landUUID);
             }
@@ -871,11 +871,11 @@ namespace InWorldz.VivoxVoice
         {
             string requrl = String.Format(m_vivoxChannelPath, m_vivoxServer, "create", channelId, m_authToken);
 
-            if (parent != null && parent != String.Empty)
+            if (!String.IsNullOrEmpty(parent))
             {
                 requrl = String.Format("{0}&chan_parent={1}", requrl, parent);
             }
-            if (description != null && description != String.Empty)
+            if (!String.IsNullOrEmpty(description))
             {
                 requrl = String.Format("{0}&chan_desc={1}", requrl, description);
             }
@@ -907,12 +907,12 @@ namespace InWorldz.VivoxVoice
         {
             string requrl = String.Format(m_vivoxChannelPath, m_vivoxServer, "create", dirId, m_authToken);
 
-            // if (parent != null && parent != String.Empty)
+            // if (!String.IsNullOrEmpty(parent))
             // {
             //     requrl = String.Format("{0}&chan_parent={1}", requrl, parent);
             // }
 
-            if (description != null && description != String.Empty)
+            if (!String.IsNullOrEmpty(description))
             {
                 requrl = String.Format("{0}&chan_desc={1}", requrl, description);
             }
@@ -1087,7 +1087,7 @@ namespace InWorldz.VivoxVoice
         private XmlElement VivoxDeleteChannel(string parent, string channelid)
         {
             string requrl = String.Format(m_vivoxChannelDel, m_vivoxServer, "delete", channelid, m_authToken);
-            if (parent != null && parent != String.Empty)
+            if (!String.IsNullOrEmpty(parent))
             {
                 requrl = String.Format("{0}&chan_parent={1}", requrl, parent);
             }
@@ -1257,7 +1257,7 @@ namespace InWorldz.VivoxVoice
         /// </summary>
         private bool XmlFind(XmlElement root, string tag, int nth, out string result)
         {
-            if (root == null || tag == null || tag == String.Empty)
+            if (root == null || String.IsNullOrEmpty(tag))
             { 
                 result = String.Empty;
                 return false;
@@ -1268,7 +1268,7 @@ namespace InWorldz.VivoxVoice
         private bool XmlFind(XmlElement root, string tag, out string result)
         {
             int nth = 0;
-            if (root == null || tag == null || tag == String.Empty)
+            if (root == null || String.IsNullOrEmpty(tag))
             { 
                 result = String.Empty;
                 return false;

--- a/OpenSim/ApplicationPlugins/CreateCommsManager/CreateCommsManagerPlugin.cs
+++ b/OpenSim/ApplicationPlugins/CreateCommsManager/CreateCommsManagerPlugin.cs
@@ -160,7 +160,7 @@ namespace OpenSim.ApplicationPlugins.CreateCommsManager
 
             m_httpServer.AddStreamHandler(new OpenSim.SimStatusHandler());
             m_httpServer.AddStreamHandler(new OpenSim.XSimStatusHandler(m_openSim));
-            if (m_openSim.userStatsURI != String.Empty )
+            if (!String.IsNullOrEmpty(m_openSim.userStatsURI))
                 m_httpServer.AddStreamHandler(new OpenSim.UXSimStatusHandler(m_openSim));
         }
 

--- a/OpenSim/ApplicationPlugins/RegionModulesController/RegionModulesControllerPlugin.cs
+++ b/OpenSim/ApplicationPlugins/RegionModulesController/RegionModulesControllerPlugin.cs
@@ -89,7 +89,7 @@ namespace OpenSim.ApplicationPlugins.RegionModulesController
             foreach (TypeExtensionNode node in
                     AddinManager.GetExtensionNodes("/OpenSim/RegionModules"))
             {
-                if (node.Type.GetInterface(typeof(ISharedRegionModule).ToString()) != null)
+                if (typeof(ISharedRegionModule).IsAssignableFrom(node.Type))
                 {
                     if (CheckModuleEnabled(node, modulesConfig))
                     {
@@ -97,7 +97,7 @@ namespace OpenSim.ApplicationPlugins.RegionModulesController
                         m_sharedModules.Add(node);
                     }
                 }
-                else if (node.Type.GetInterface(typeof(INonSharedRegionModule).ToString()) != null)
+                else if (typeof(INonSharedRegionModule).IsAssignableFrom(node.Type))
                 {
                     if (CheckModuleEnabled(node, modulesConfig))
                     {

--- a/OpenSim/ApplicationPlugins/RegionModulesController/RegionModulesControllerPlugin.cs
+++ b/OpenSim/ApplicationPlugins/RegionModulesController/RegionModulesControllerPlugin.cs
@@ -127,7 +127,7 @@ namespace OpenSim.ApplicationPlugins.RegionModulesController
                         modulesConfig.GetString("Setup_" + node.Id, String.Empty);
 
                 // Get the port number, if there is one
-                if (moduleString != String.Empty)
+                if (!String.IsNullOrEmpty(moduleString))
                 {
                     // Get the port number from the string
                     string[] moduleParts = moduleString.Split(new char[] { '/' },
@@ -230,7 +230,7 @@ namespace OpenSim.ApplicationPlugins.RegionModulesController
                     modulesConfig.GetString("Setup_" + node.Id, String.Empty);
 
             // We have a selector
-            if (moduleString != String.Empty)
+            if (!String.IsNullOrEmpty(moduleString))
             {
                 // Allow disabling modules even if they don't have
                 // support for it
@@ -245,8 +245,8 @@ namespace OpenSim.ApplicationPlugins.RegionModulesController
                     className = moduleParts[1];
 
                 // Match the class name if given
-                if (className != String.Empty &&
-                        node.Type.ToString() != className)
+                if (!(String.IsNullOrEmpty(className) ||
+                    node.Type.ToString() == className))
                     return false;
             }            
             
@@ -324,7 +324,7 @@ namespace OpenSim.ApplicationPlugins.RegionModulesController
                         modulesConfig.GetString("Setup_" + node.Id, String.Empty);
 
                 // Get the port number, if there is one
-                if (moduleString != String.Empty)
+                if (!String.IsNullOrEmpty(moduleString))
                 {
                     // Get the port number from the string
                     string[] moduleParts = moduleString.Split(new char[] {'/'},

--- a/OpenSim/ApplicationPlugins/ScriptEngine/ComponentFactory.cs
+++ b/OpenSim/ApplicationPlugins/ScriptEngine/ComponentFactory.cs
@@ -41,8 +41,6 @@ namespace OpenSim.ApplicationPlugins.ScriptEngine
         public static Dictionary<string, Type> scriptEngines = new Dictionary<string, Type>();
 
         internal static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        private readonly static string nameIScriptEngineComponent = typeof(IScriptEngineComponent).Name; // keep interface name in managed code
-        private readonly static string nameIScriptEngine = typeof(IScriptEngine).Name; // keep interface name in managed code
 
         public static string Name
         {
@@ -81,7 +79,7 @@ namespace OpenSim.ApplicationPlugins.ScriptEngine
                                 && !componentType.IsAbstract)
                             {
                                 //if (componentType.IsSubclassOf(typeof(ComponentBase)))
-                                if (componentType.GetInterface(nameIScriptEngineComponent) != null)
+                                if (typeof(IScriptEngineComponent).IsAssignableFrom(componentType))
                                 {
                                     // We have found an type which is derived from ProdiverBase, add it to provider list
                                     m_log.InfoFormat("[{0}] Adding component: {1}", Name, componentType.Name);
@@ -91,7 +89,7 @@ namespace OpenSim.ApplicationPlugins.ScriptEngine
                                     }
                                 }
                                 //if (componentType.IsSubclassOf(typeof(ScriptEngineBase)))
-                                if (componentType.GetInterface(nameIScriptEngine) != null)
+                                if (typeof(IScriptEngine).IsAssignableFrom(componentType))
                                 {
                                     // We have found an type which is derived from RegionScriptEngineBase, add it to engine list
                                     m_log.InfoFormat("[{0}] Adding script engine: {1}", Name, componentType.Name);
@@ -129,13 +127,12 @@ namespace OpenSim.ApplicationPlugins.ScriptEngine
             }
         }
 
-        private readonly static string nameIScriptEngineRegionComponent = typeof(IScriptEngineRegionComponent).Name; // keep interface name in managed code
         public static IScriptEngineComponent GetComponentInstance(RegionInfoStructure info, string name, params Object[] args)
         {
             IScriptEngineComponent c = GetComponentInstance(name, args);
 
             // If module is IScriptEngineRegionComponent then it will have one instance per region and we will initialize it
-            if (c.GetType().GetInterface(nameIScriptEngineRegionComponent) != null)
+            if (typeof(IScriptEngineRegionComponent).IsAssignableFrom(c.GetType()))
                 ((IScriptEngineRegionComponent)c).Initialize(info);
 
             return c;

--- a/OpenSim/Base/ApplicationBase.cs
+++ b/OpenSim/Base/ApplicationBase.cs
@@ -28,6 +28,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
+
 namespace OpenSim
 {
     public class ApplicationBase
@@ -35,6 +37,6 @@ namespace OpenSim
         /// <summary>
         /// Path to the main ini Configuration file
         /// </summary>
-        public static string iniFilePath = "";
+        public static string iniFilePath = String.Empty;
     }
 }

--- a/OpenSim/Base/ConfigurationLoader.cs
+++ b/OpenSim/Base/ConfigurationLoader.cs
@@ -61,7 +61,7 @@ namespace OpenSim
             string iniFileName = startupConfig.GetString("inifile", "Halcyon.ini");
             ApplicationBase.iniFilePath = Path.Combine(Util.configDir(), iniFileName);
 
-            string masterFileName = startupConfig.GetString("inimaster", "");
+            string masterFileName = startupConfig.GetString("inimaster", String.Empty);
             string masterfilePath = Path.Combine(Util.configDir(), masterFileName);
 
             string iniDirName = startupConfig.GetString("inidirectory", "config");
@@ -238,9 +238,9 @@ namespace OpenSim
                 config.Set("accounts_authenticate", true);
                 config.Set("welcome_message", "Welcome to Halcyon");
                 config.Set("inventory_plugin", "OpenSim.Data.SQLite.dll");
-                config.Set("inventory_source", "");
+                config.Set("inventory_source", String.Empty);
                 config.Set("userDatabase_plugin", "OpenSim.Data.SQLite.dll");
-                config.Set("user_source", "");
+                config.Set("user_source", String.Empty);
                 config.Set("asset_plugin", "OpenSim.Data.SQLite.dll");
                 config.Set("asset_source", "URI=file:Asset.db,version=3");
                 config.Set("LibrariesXMLFile", string.Format(".{0}inventory{0}Libraries.xml", Path.DirectorySeparatorChar));

--- a/OpenSim/Base/OpenSim.cs
+++ b/OpenSim/Base/OpenSim.cs
@@ -89,7 +89,7 @@ namespace OpenSim
                 m_startupCommandsFile = startupConfig.GetString("startup_console_commands_file", "startup_commands.txt");
                 m_shutdownCommandsFile = startupConfig.GetString("shutdown_console_commands_file", "shutdown_commands.txt");
 
-                if (startupConfig.GetString("console", String.Empty) == String.Empty)
+                if (String.IsNullOrEmpty(startupConfig.GetString("console", String.Empty)))
                     m_gui = startupConfig.GetBoolean("gui", false);
                 else
                     m_consoleType= startupConfig.GetString("console", String.Empty);
@@ -105,7 +105,7 @@ namespace OpenSim
                         log4net.Appender.FileAppender appender =
                                 (log4net.Appender.FileAppender)m_logFileAppender;
                         string fileName = startupConfig.GetString("LogFile", String.Empty);
-                        if (fileName != String.Empty)
+                        if (!String.IsNullOrEmpty(fileName))
                             appender.File = fileName;
                         m_log.InfoFormat("[LOGGING] Logging started to file {0}", appender.File);
                     }
@@ -463,7 +463,7 @@ namespace OpenSim
 
         public override void ShutdownSpecific()
         {
-            if (m_shutdownCommandsFile != String.Empty)
+            if (!String.IsNullOrEmpty(m_shutdownCommandsFile))
             {
                 RunCommandScript(m_shutdownCommandsFile);
             }
@@ -513,7 +513,7 @@ namespace OpenSim
                     presence.Scene.IncomingCloseAgent(presence.UUID);
                 }
             }
-            m_console.Notice("");
+            m_console.Notice(String.Empty);
         }
 
         /// <summary>
@@ -530,7 +530,7 @@ namespace OpenSim
                 string currentCommand;
                 while ((currentCommand = readFile.ReadLine()) != null)
                 {
-                    if (currentCommand != String.Empty)
+                    if (!String.IsNullOrEmpty(currentCommand))
                     {
                         m_log.Info("[COMMANDFILE]: Running '" + currentCommand + "'");
                         m_console.RunCommand(currentCommand);
@@ -993,7 +993,7 @@ namespace OpenSim
                     else
                         m_console.Notice(String.Format("Agents connected: {0}", nRoot));
 
-                    m_console.Notice("");
+                    m_console.Notice(String.Empty);
                     break;
 
                 case "remotes":
@@ -1027,7 +1027,7 @@ namespace OpenSim
                     m_sceneManager.ForEachScene(
                     delegate(Scene scene)
                     {
-                        string rating = "";
+                        string rating = String.Empty;
                         if (scene.RegionInfo.RegionSettings.Maturity == 1)
                         {
                             rating = "MATURE";
@@ -1056,7 +1056,7 @@ namespace OpenSim
                     }
                     Dictionary<UUID,SceneOwnerCounts> counts = m_sceneManager.GetCurrentSceneOwnerCounts();
 
-                    m_console.Notice(String.Format("Objects Prims UUID Name {0}",MinCount>1?"(with prim counts above "+MinCount.ToString()+")" : ""));
+                    m_console.Notice(String.Format("Objects Prims UUID Name {0}",MinCount>1?"(with prim counts above "+MinCount.ToString()+")" : String.Empty));
                     foreach (KeyValuePair<UUID, SceneOwnerCounts> kvp in counts)
                     {
                         SceneOwnerCounts count = kvp.Value;
@@ -1110,7 +1110,7 @@ namespace OpenSim
                 }
             }
 
-            m_console.Notice("");
+            m_console.Notice(String.Empty);
         }
 
         public void DisableAllTraces(string mod, string[] cmd)
@@ -1149,7 +1149,7 @@ namespace OpenSim
                     m_console.Output(String.Format("Timer Interval: {0}", runtimeInfo.TimerInterval));
                     m_console.Output(String.Format("Timer Last Scheduled: {0}", runtimeInfo.TimerLastScheduledOn));
                     m_console.Output(String.Format("Current Function: {0}", runtimeInfo.StackFrameFunctionName == null ? "none" : runtimeInfo.StackFrameFunctionName));
-                    m_console.Output("");
+                    m_console.Output(String.Empty);
                 }
             }
         }
@@ -1368,7 +1368,7 @@ namespace OpenSim
             else regY = Convert.ToUInt32(cmdparams[6]);
 
             if (cmdparams.Length < 8)
-                email = MainConsole.Instance.CmdPrompt("Email", "");
+                email = MainConsole.Instance.CmdPrompt("Email", String.Empty);
             else email = cmdparams[7];
 
             if (null == m_commsManager.UserService.GetUserProfile(firstName, lastName))

--- a/OpenSim/Base/OpenSim.cs
+++ b/OpenSim/Base/OpenSim.cs
@@ -1193,7 +1193,7 @@ namespace OpenSim
 
             if (args.Length > 2)
             {
-                string param2 = (args.Length > 3) ? args[3] : string.Empty;
+                string param2 = (args.Length > 3) ? args[3] : String.Empty;
                 SceneManager.BlacklistOp operation = SceneManager.BlacklistOp.Owner;
                 m_sceneManager.BlacklistOperation(operation, args[2], param2);
             }
@@ -1213,7 +1213,7 @@ namespace OpenSim
 
             if (args.Length > 2)
             {
-                string param2 = (args.Length > 3) ? args[3] : string.Empty;
+                string param2 = (args.Length > 3) ? args[3] : String.Empty;
                 SceneManager.BlacklistOp operation = SceneManager.BlacklistOp.Creator;
                 SceneManager.BlacklistOperation(operation, args[2], param2);
             }
@@ -1234,7 +1234,7 @@ namespace OpenSim
             if (args.Length > 2)
             {
                 SceneManager.BlacklistOp operation = SceneManager.BlacklistOp.Name;
-                m_sceneManager.BlacklistOperation(operation, args[2], string.Empty);
+                m_sceneManager.BlacklistOperation(operation, args[2], String.Empty);
             }
             else
             {
@@ -1254,7 +1254,7 @@ namespace OpenSim
 
             if (args.Length > 1)
             {
-                string param2 = (args.Length > 2) ? args[2] : string.Empty;
+                string param2 = (args.Length > 2) ? args[2] : String.Empty;
                 SceneManager.BlacklistOp operation = SceneManager.BlacklistOp.User;
                 m_sceneManager.BlacklistOperation(operation, args[1], param2);
             }
@@ -1275,7 +1275,7 @@ namespace OpenSim
             if (args.Length > 1)
             {
                 SceneManager.BlacklistOp operation = SceneManager.BlacklistOp.Remove;
-                m_sceneManager.BlacklistOperation(operation, args[1], string.Empty);
+                m_sceneManager.BlacklistOperation(operation, args[1], String.Empty);
             }
             else
             {
@@ -1288,7 +1288,7 @@ namespace OpenSim
             base.HandleBlacklistClear(module, cmd);
 
             SceneManager.BlacklistOp operation = SceneManager.BlacklistOp.Clear;
-            m_sceneManager.BlacklistOperation(operation, string.Empty, string.Empty);
+            m_sceneManager.BlacklistOperation(operation, String.Empty, String.Empty);
         }
         // blacklist show
         public override void HandleBlacklistShow(string module, string[] cmd)
@@ -1296,7 +1296,7 @@ namespace OpenSim
             base.HandleBlacklistShow(module, cmd);
 
             SceneManager.BlacklistOp operation = SceneManager.BlacklistOp.Show;
-            m_sceneManager.BlacklistOperation(operation, string.Empty, string.Empty);
+            m_sceneManager.BlacklistOperation(operation, String.Empty, String.Empty);
         }
 
         private string GetQueuesReport()

--- a/OpenSim/Base/OpenSimBackground.cs
+++ b/OpenSim/Base/OpenSimBackground.cs
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
 using System.Reflection;
 using System.Threading;
 using log4net;
@@ -55,7 +56,7 @@ namespace OpenSim
             base.Startup();
 
             m_log.InfoFormat("[HALCYON MAIN]: Startup complete, serving {0} region{1}",
-                             m_clientServers.Count.ToString(), m_clientServers.Count > 1 ? "s" : "");
+                             m_clientServers.Count.ToString(), m_clientServers.Count > 1 ? "s" : String.Empty);
 
             WorldHasComeToAnEnd.WaitOne();
             WorldHasComeToAnEnd.Close();

--- a/OpenSim/Base/OpenSimBase.cs
+++ b/OpenSim/Base/OpenSimBase.cs
@@ -157,7 +157,7 @@ namespace OpenSim
             IConfig networkConfig = m_config.Source.Configs["Network"];
             if (networkConfig != null)
             {
-                proxyUrl = networkConfig.GetString("proxy_url", "");
+                proxyUrl = networkConfig.GetString("proxy_url", String.Empty);
                 proxyOffset = Int32.Parse(networkConfig.GetString("proxy_offset", "0"));
             }
         }
@@ -191,7 +191,7 @@ namespace OpenSim
             if (startupConfig != null)
             {
                 string pidFile = startupConfig.GetString("PIDFile", String.Empty);
-                if (pidFile != String.Empty)
+                if (!String.IsNullOrEmpty(pidFile))
                     CreatePIDFile(pidFile);
                 
                 userStatsURI = startupConfig.GetString("Stats_URI", String.Empty);
@@ -302,7 +302,7 @@ namespace OpenSim
             IAssetServer assetServer = null;
             string mode = m_configSettings.AssetStorage;
 
-            if (mode == null | mode == String.Empty)
+            if (String.IsNullOrEmpty(mode))
             {
                 throw new Exception("No asset server specified");
             }
@@ -331,7 +331,7 @@ namespace OpenSim
         // if not, then the first match is used.
         private IAssetServer loadAssetServer(string id, PluginInitializerBase pi)
         {
-            if (id != null && id != String.Empty)
+            if (!String.IsNullOrEmpty(id))
             {
                 m_log.DebugFormat("[HALCYONBASE] Attempting to load asset server id={0}", id);
 

--- a/OpenSim/Client/Linden/LLProxyLoginModule.cs
+++ b/OpenSim/Client/Linden/LLProxyLoginModule.cs
@@ -232,7 +232,7 @@ namespace OpenSim.Client.Linden
             else
             {
                 bool success = false;
-                string denyMess = "";
+                string denyMess = String.Empty;
         
                 Scene scene;
                 if (TryGetRegion(regionHandle, out scene))

--- a/OpenSim/Client/Linden/LLStandaloneLoginModule.cs
+++ b/OpenSim/Client/Linden/LLStandaloneLoginModule.cs
@@ -88,13 +88,13 @@ namespace OpenSim.Client.Linden
                 if (m_enabled)
                 {
                     bool authenticate = true;
-                    string welcomeMessage = "Welcome to InWorldz", mapServerURI = "";
+                    string welcomeMessage = "Welcome to InWorldz", mapServerURI = String.Empty;
                     IConfig standaloneConfig = source.Configs["StandAlone"];
                     if (standaloneConfig != null)
                     {
                         authenticate = standaloneConfig.GetBoolean("accounts_authenticate", true);
                         welcomeMessage = standaloneConfig.GetString("welcome_message");
-                        mapServerURI = standaloneConfig.GetString("map_server_uri", "");
+                        mapServerURI = standaloneConfig.GetString("map_server_uri", String.Empty);
                     }
 
                     //TODO: fix casting.

--- a/OpenSim/Client/Linden/LLStandaloneLoginService.cs
+++ b/OpenSim/Client/Linden/LLStandaloneLoginService.cs
@@ -84,7 +84,7 @@ namespace OpenSim.Client.Linden
                 //no current user account so make one
                 m_log.Info("[LOGIN]: No user account found so creating a new one.");
 
-                m_userManager.AddUser(firstname, lastname, "test", "", m_defaultHomeX, m_defaultHomeY);
+                m_userManager.AddUser(firstname, lastname, "test", String.Empty, m_defaultHomeX, m_defaultHomeY);
 
                 return m_userManager.GetUserProfile(firstname, lastname);
             }

--- a/OpenSim/Data/MySQL/MySQLAssetData.cs
+++ b/OpenSim/Data/MySQL/MySQLAssetData.cs
@@ -65,7 +65,7 @@ namespace OpenSim.Data.MySQL
 
             // TODO: This will let you pass in the connect string in
             // the config, though someone will need to write that.
-            if (connect == String.Empty)
+            if (String.IsNullOrEmpty(connect))
             {
                 // This is old seperate config file
                 m_log.Warn("no connect string, using old mysql_connection.ini instead");

--- a/OpenSim/Data/MySQL/MySQLEstateData.cs
+++ b/OpenSim/Data/MySQL/MySQLEstateData.cs
@@ -341,7 +341,7 @@ namespace OpenSim.Data.MySQL
 
         public EstateSettings LoadEstateSettings(UUID regionID)
         {
-            return LoadEstateSettings(regionID, string.Empty, UUID.Zero, false);
+            return LoadEstateSettings(regionID, String.Empty, UUID.Zero, false);
         }
 
         private void StoreEstateSettingsOnly(EstateSettings es)

--- a/OpenSim/Data/MySQL/MySQLLogData.cs
+++ b/OpenSim/Data/MySQL/MySQLLogData.cs
@@ -57,7 +57,7 @@ namespace OpenSim.Data.MySQL
         /// <param name="connect">connect string</param>
         public void Initialize(string connect)
         {
-            if (connect != String.Empty)
+            if (!String.IsNullOrEmpty(connect))
             {
                 database = new MySQLManager(connect);
             }

--- a/OpenSim/Data/MySQL/MySQLManager.cs
+++ b/OpenSim/Data/MySQL/MySQLManager.cs
@@ -540,7 +540,7 @@ namespace OpenSim.Data.MySQL
                 retval.ID = id;
                 retval.FirstName = (string)reader["username"];
                 retval.SurName = (string)reader["lastname"];
-                retval.Email = (reader.IsDBNull(reader.GetOrdinal("email"))) ? "" : (string)reader["email"];
+                retval.Email = (reader.IsDBNull(reader.GetOrdinal("email"))) ? String.Empty : (string)reader["email"];
 
                 retval.PasswordHash = (string)reader["passwordHash"];
                 retval.PasswordSalt = (string)reader["passwordSalt"];
@@ -566,12 +566,12 @@ namespace OpenSim.Data.MySQL
                 retval.UserAssetURI = (string)reader["userAssetURI"];
 
                 if (reader.IsDBNull(reader.GetOrdinal("profileAboutText")))
-                    retval.AboutText = "";
+                    retval.AboutText = String.Empty;
                 else
                     retval.AboutText = (string)reader["profileAboutText"];
 
                 if (reader.IsDBNull(reader.GetOrdinal("profileFirstText")))
-                    retval.FirstLifeAboutText = "";
+                    retval.FirstLifeAboutText = String.Empty;
                 else
                     retval.FirstLifeAboutText = (string)reader["profileFirstText"];
 
@@ -607,7 +607,7 @@ namespace OpenSim.Data.MySQL
                 retval.UserFlags = Convert.ToInt32(reader["userFlags"].ToString());
                 retval.GodLevel = Convert.ToInt32(reader["godLevel"].ToString());
                 if (reader.IsDBNull(reader.GetOrdinal("customType")))
-                    retval.CustomType = "";
+                    retval.CustomType = String.Empty;
                 else
                     retval.CustomType = reader["customType"].ToString();
 
@@ -623,7 +623,7 @@ namespace OpenSim.Data.MySQL
                 }
 
                 if (reader.IsDBNull(reader.GetOrdinal("profileURL")))
-                    retval.ProfileURL = "";
+                    retval.ProfileURL = String.Empty;
                 else
                     retval.ProfileURL = (string)reader["profileURL"];
 
@@ -755,7 +755,7 @@ namespace OpenSim.Data.MySQL
             parameters["?webLoginKey"] = webLoginKey.ToString();
             parameters["?userFlags"] = userFlags;
             parameters["?godLevel"] = godLevel;
-            parameters["?customType"] = customType == null ? "" : customType;
+            parameters["?customType"] = customType == null ? String.Empty : customType;
             parameters["?partner"] = partner.ToString();
             parameters["?profileURL"] = ProfileURL;
             bool returnval = false;
@@ -854,7 +854,7 @@ namespace OpenSim.Data.MySQL
             parameters["?webLoginKey"] = webLoginKey.ToString();
             parameters["?userFlags"] = userFlags;
             parameters["?godLevel"] = godLevel;
-            parameters["?customType"] = customType == null ? "" : customType;
+            parameters["?customType"] = customType == null ? String.Empty : customType;
             parameters["?partner"] = partner.ToString();
 
             bool returnval = false;

--- a/OpenSim/Data/MySQL/MySQLRegionData.cs
+++ b/OpenSim/Data/MySQL/MySQLRegionData.cs
@@ -1415,7 +1415,7 @@ namespace OpenSim.Data.MySQL
         {
             // "INSERT INTO room(person,address) VALUES(?person, ?address)"
 
-            if (varlist == string.Empty)
+            if (varlist == String.Empty)
             {
                 varlist += ",";
                 values += ",";
@@ -1456,8 +1456,8 @@ namespace OpenSim.Data.MySQL
                     }
 
                     // start with two empty strings
-                    string varlist = string.Empty;
-                    string values = string.Empty;
+                    string varlist = String.Empty;
+                    string values = String.Empty;
 
                     // Sky
                     AddQueryParam(cmd, ref varlist, ref values, "region_id", env.regionID);

--- a/OpenSim/Data/MySQL/MySQLUserData.cs
+++ b/OpenSim/Data/MySQL/MySQLUserData.cs
@@ -193,7 +193,7 @@ namespace OpenSim.Data.MySQL
                 retval.ID = id;
                 retval.FirstName = (string)reader["username"];
                 retval.SurName = (string)reader["lastname"];
-                retval.Email = (reader.IsDBNull(reader.GetOrdinal("email"))) ? "" : (string)reader["email"];
+                retval.Email = (reader.IsDBNull(reader.GetOrdinal("email"))) ? String.Empty : (string)reader["email"];
 
                 retval.PasswordHash = (string)reader["passwordHash"];
                 retval.PasswordSalt = (string)reader["passwordSalt"];
@@ -219,12 +219,12 @@ namespace OpenSim.Data.MySQL
                 retval.UserAssetURI = (string)reader["userAssetURI"];
 
                 if (reader.IsDBNull(reader.GetOrdinal("profileAboutText")))
-                    retval.AboutText = "";
+                    retval.AboutText = String.Empty;
                 else
                     retval.AboutText = (string)reader["profileAboutText"];
 
                 if (reader.IsDBNull(reader.GetOrdinal("profileFirstText")))
-                    retval.FirstLifeAboutText = "";
+                    retval.FirstLifeAboutText = String.Empty;
                 else
                     retval.FirstLifeAboutText = (string)reader["profileFirstText"];
 
@@ -260,7 +260,7 @@ namespace OpenSim.Data.MySQL
                 retval.UserFlags = Convert.ToInt32(reader["userFlags"].ToString());
                 retval.GodLevel = Convert.ToInt32(reader["godLevel"].ToString());
                 if (reader.IsDBNull(reader.GetOrdinal("customType")))
-                    retval.CustomType = "";
+                    retval.CustomType = String.Empty;
                 else
                     retval.CustomType = reader["customType"].ToString();
 
@@ -276,7 +276,7 @@ namespace OpenSim.Data.MySQL
                 }
 
                 if (reader.IsDBNull(reader.GetOrdinal("profileURL")))
-                    retval.ProfileURL = "";
+                    retval.ProfileURL = String.Empty;
                 else
                     retval.ProfileURL = (string)reader["profileURL"];
 
@@ -497,7 +497,7 @@ namespace OpenSim.Data.MySQL
 
             string[] querysplit;
             querysplit = query.Split(' ');
-            if (querysplit.Length > 1 && querysplit[1].Trim() != String.Empty)
+            if (querysplit.Length > 1 && !String.IsNullOrWhiteSpace(querysplit[1]))
             {
                 Dictionary<string, object> param = new Dictionary<string, object>();
                 param["?first"] = objAlphaNumericPattern.Replace(querysplit[0], String.Empty) + "%";
@@ -796,7 +796,7 @@ namespace OpenSim.Data.MySQL
             parameters["?webLoginKey"] = webLoginKey.ToString();
             parameters["?userFlags"] = userFlags;
             parameters["?godLevel"] = godLevel;
-            parameters["?customType"] = customType == null ? "" : customType;
+            parameters["?customType"] = customType == null ? String.Empty : customType;
             parameters["?partner"] = partner.ToString();
             parameters["?profileURL"] = ProfileURL;
             bool returnval = false;
@@ -1039,7 +1039,7 @@ namespace OpenSim.Data.MySQL
             parameters["?webLoginKey"] = webLoginKey.ToString();
             parameters["?userFlags"] = userFlags;
             parameters["?godLevel"] = godLevel;
-            parameters["?customType"] = customType == null ? "" : customType;
+            parameters["?customType"] = customType == null ? String.Empty : customType;
 
             bool returnval = false;
             try

--- a/OpenSim/Framework/AssetBase.cs
+++ b/OpenSim/Framework/AssetBase.cs
@@ -35,6 +35,8 @@ namespace OpenSim.Framework
     public class AssetBase
     {
         private byte[] m_data;
+
+        [NonSerialized]
         private AssetMetadata m_metadata;
 
         public AssetBase()

--- a/OpenSim/Framework/AssetConfig.cs
+++ b/OpenSim/Framework/AssetConfig.cs
@@ -53,7 +53,7 @@ namespace OpenSim.Framework
                                                 "DLL for database provider", "OpenSim.Data.MySQL.dll", false);
 
             m_configMember.addConfigurationOption("database_connect", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
-                                                "Database connection string", "", false);
+                                                "Database connection string", String.Empty, false);
 
             m_configMember.addConfigurationOption("http_port", ConfigurationOption.ConfigurationTypes.TYPE_UINT32,
                                                 "Http Listener port", ConfigSettings.DefaultAssetServerHttpPort.ToString(), false);

--- a/OpenSim/Framework/AssetConfig.cs
+++ b/OpenSim/Framework/AssetConfig.cs
@@ -38,7 +38,7 @@ namespace OpenSim.Framework
         public string DatabaseConnect = String.Empty;
         public string DatabaseProvider = String.Empty;
         public uint HttpPort = ConfigSettings.DefaultAssetServerHttpPort;
-        public string AssetSetsLocation = string.Empty;
+        public string AssetSetsLocation = String.Empty;
 
         public AssetConfig(string description, string filename)
         {

--- a/OpenSim/Framework/AssetLoader/Filesystem/AssetLoaderFileSystem.cs
+++ b/OpenSim/Framework/AssetLoader/Filesystem/AssetLoaderFileSystem.cs
@@ -93,7 +93,7 @@ namespace OpenSim.Framework.AssetLoader.Filesystem
             if (File.Exists(assetSetFilename))
             {
                 string assetSetPath = "ERROR";
-                string assetRootPath = "";
+                string assetRootPath = String.Empty;
                 try
                 {
                     XmlConfigSource source = new XmlConfigSource(assetSetFilename);

--- a/OpenSim/Framework/AvatarAppearance.cs
+++ b/OpenSim/Framework/AvatarAppearance.cs
@@ -437,7 +437,7 @@ namespace OpenSim.Framework
             h["physics_asset"] = wearable.AssetID.ToString();
 
             string attachments = GetAttachmentsString();
-            if (attachments != String.Empty)
+            if (!String.IsNullOrEmpty(attachments))
                 h["attachments"] = attachments;
 
             return h;

--- a/OpenSim/Framework/ChildAgentDataUpdate.cs
+++ b/OpenSim/Framework/ChildAgentDataUpdate.cs
@@ -383,7 +383,7 @@ namespace OpenSim.Framework
                 args["wearables"] = wears;
             }
 
-            if ((CallbackURI != null) && (!CallbackURI.Equals("")))
+            if ((CallbackURI != null) && (!CallbackURI.Equals(String.Empty)))
                 args["callback_uri"] = OSD.FromString(CallbackURI);
 
             if (SatOnGroup != UUID.Zero)

--- a/OpenSim/Framework/Communications/Capabilities/LLSD.cs
+++ b/OpenSim/Framework/Communications/Capabilities/LLSD.cs
@@ -256,7 +256,7 @@ namespace OpenSim.Framework.Communications.Capabilities
                         reader.Read();
                         string s = reader.ReadString().Trim();
 
-                        if (s == String.Empty || s == "false" || s == "0")
+                        if (String.IsNullOrEmpty(s) || s == "false" || s == "0")
                             ret = false;
                         else if (s == "true" || s == "1")
                             ret = true;

--- a/OpenSim/Framework/Communications/Clients/AuthClient.cs
+++ b/OpenSim/Framework/Communications/Clients/AuthClient.cs
@@ -55,12 +55,12 @@ namespace OpenSim.Framework.Communications.Clients
             catch (Exception e)
             {
                 System.Console.WriteLine("[HGrid]: Failed to get new key. Reason: " + e.Message);
-                return string.Empty;
+                return String.Empty;
             }
 
             if (!reply.IsFault)
             {
-                string newKey = string.Empty;
+                string newKey = String.Empty;
                 if (reply.Value != null)
                     newKey = (string)reply.Value;
 
@@ -69,7 +69,7 @@ namespace OpenSim.Framework.Communications.Clients
             else
             {
                 System.Console.WriteLine("[HGrid]: XmlRpc request to get auth key failed with message {0}" + reply.FaultString + ", code " + reply.FaultCode);
-                return string.Empty;
+                return String.Empty;
             }
 
         }

--- a/OpenSim/Framework/Communications/Clients/GridClient.cs
+++ b/OpenSim/Framework/Communications/Clients/GridClient.cs
@@ -173,7 +173,7 @@ namespace OpenSim.Framework.Communications.Clients
         {
             // didn't find it so far, we have to go the long way
             regionInfo = null;
-            errorMsg = string.Empty;
+            errorMsg = String.Empty;
             Hashtable requestData = new Hashtable();
             requestData["region_UUID"] = regionUUID.ToString();
             requestData["authkey"] = sendKey;
@@ -211,7 +211,7 @@ namespace OpenSim.Framework.Communications.Clients
         {
             // didn't find it so far, we have to go the long way
             regionInfo = null;
-            errorMsg = string.Empty;
+            errorMsg = String.Empty;
 
             try
             {
@@ -270,7 +270,7 @@ namespace OpenSim.Framework.Communications.Clients
         public bool RequestClosestRegion(string gridServerURL, string sendKey, string receiveKey, string regionName, out RegionInfo regionInfo, out string errorMsg)
         {
             regionInfo = null;
-            errorMsg = string.Empty;
+            errorMsg = String.Empty;
             try
             {
                 Hashtable requestData = new Hashtable();
@@ -314,7 +314,7 @@ namespace OpenSim.Framework.Communications.Clients
         public bool MapBlockQuery(string gridServerURL, int minX, int minY, int maxX, int maxY, out Hashtable respData, out string errorMsg)
         {
             respData = new Hashtable();
-            errorMsg = string.Empty;
+            errorMsg = String.Empty;
 
             Hashtable param = new Hashtable();
             param["xmin"] = minX;
@@ -343,7 +343,7 @@ namespace OpenSim.Framework.Communications.Clients
         public bool SearchRegionByName(string gridServerURL, IList parameters, out Hashtable respData, out string errorMsg)
         {
             respData = null;
-            errorMsg = string.Empty;
+            errorMsg = String.Empty;
             try
             {
                 string methodName = "search_for_region_by_name";

--- a/OpenSim/Framework/Communications/Clients/GridClient.cs
+++ b/OpenSim/Framework/Communications/Clients/GridClient.cs
@@ -125,7 +125,7 @@ namespace OpenSim.Framework.Communications.Clients
 
         public bool DeregisterRegion(string gridServerURL, string sendKey, string receiveKey, RegionInfo regionInfo, out string errorMsg)
         {
-            errorMsg = "";
+            errorMsg = String.Empty;
             Hashtable GridParams = new Hashtable();
 
             GridParams["UUID"] = regionInfo.RegionID.ToString();
@@ -291,7 +291,7 @@ namespace OpenSim.Framework.Communications.Clients
                     return false;
                 }
 
-                regionInfo = BuildRegionInfo(responseData, "");
+                regionInfo = BuildRegionInfo(responseData, String.Empty);
 
             }
             catch (Exception e)

--- a/OpenSim/Framework/Communications/Clients/InventoryClient.cs
+++ b/OpenSim/Framework/Communications/Clients/InventoryClient.cs
@@ -65,7 +65,7 @@ namespace OpenSim.Framework.Communications.Clients
             System.Console.WriteLine("[HGrid] GetInventory " + item.ID + " from " + ServerURL);
             try
             {
-                item = SynchronousRestSessionObjectPoster<Guid, InventoryItemBase>.BeginPostObject("POST", ServerURL + "/GetItem/", item.ID.Guid, "", "");
+                item = SynchronousRestSessionObjectPoster<Guid, InventoryItemBase>.BeginPostObject("POST", ServerURL + "/GetItem/", item.ID.Guid, String.Empty, String.Empty);
                 return item;
             }
             catch (Exception e)

--- a/OpenSim/Framework/Communications/Clients/InventoryClient.cs
+++ b/OpenSim/Framework/Communications/Clients/InventoryClient.cs
@@ -52,7 +52,7 @@ namespace OpenSim.Framework.Communications.Clients
                         = new RestSessionObjectPosterResponse<InventoryItemBase, InventoryItemBase>();
                 requester.ResponseCallback = callBack;
 
-                requester.BeginPostObject(ServerURL + "/GetItem/", item, string.Empty, string.Empty);
+                requester.BeginPostObject(ServerURL + "/GetItem/", item, String.Empty, String.Empty);
             }
             catch (Exception e)
             {

--- a/OpenSim/Framework/Communications/Clients/RegionClient.cs
+++ b/OpenSim/Framework/Communications/Clients/RegionClient.cs
@@ -482,7 +482,7 @@ namespace OpenSim.Framework.Communications.Clients
             request.Headers["authorization"] = GenerateAuthorization();
 
             HttpWebResponse webResponse = null;
-            string reply = string.Empty;
+            string reply = String.Empty;
             try
             {
                 webResponse = (HttpWebResponse)request.GetResponse();

--- a/OpenSim/Framework/Communications/Clients/RegionClient.cs
+++ b/OpenSim/Framework/Communications/Clients/RegionClient.cs
@@ -90,7 +90,7 @@ namespace OpenSim.Framework.Communications.Clients
             ulong regionHandle = GetRegionHandle(region.RegionHandle);
             args["destination_handle"] = OSD.FromString(regionHandle.ToString());
 
-            string strBuffer = "";
+            string strBuffer = String.Empty;
             byte[] buffer = new byte[1];
             try
             {
@@ -197,7 +197,7 @@ namespace OpenSim.Framework.Communications.Clients
             ulong regionHandle = GetRegionHandle(regionInfo.RegionHandle);
             args["destination_handle"] = OSD.FromString(regionHandle.ToString());
 
-            string strBuffer = "";
+            string strBuffer = String.Empty;
             byte[] buffer = new byte[1];
             try
             {
@@ -267,7 +267,7 @@ namespace OpenSim.Framework.Communications.Clients
 
                     // check for old style response
                     if (response.ToLower().StartsWith("true"))
-                        return Tuple.Create(true, "");
+                        return Tuple.Create(true, String.Empty);
 
                     return Tuple.Create(false, "exception on reply of DoCreateChildAgentCall");
                 }
@@ -313,7 +313,7 @@ namespace OpenSim.Framework.Communications.Clients
             ulong regionHandle = GetRegionHandle(region.RegionHandle);
             args["destination_handle"] = OSD.FromString(regionHandle.ToString());
 
-            string strBuffer = "";
+            string strBuffer = String.Empty;
             byte[] buffer = new byte[1];
             try
             {
@@ -478,7 +478,7 @@ namespace OpenSim.Framework.Communications.Clients
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
             request.Method = "GET";
             request.Timeout = 10000;
-            //request.Headers.Add("authorization", ""); // coming soon
+            //request.Headers.Add("authorization", String.Empty); // coming soon
             request.Headers["authorization"] = GenerateAuthorization();
 
             HttpWebResponse webResponse = null;
@@ -802,7 +802,7 @@ namespace OpenSim.Framework.Communications.Clients
 
             // Fill it in
             OSDMap args = new OSDMap();
-            string strBuffer = "";
+            string strBuffer = String.Empty;
             byte[] buffer = new byte[1];
             try
             {

--- a/OpenSim/Framework/Communications/Services/LoginService.cs
+++ b/OpenSim/Framework/Communications/Services/LoginService.cs
@@ -89,7 +89,7 @@ namespace OpenSim.Framework.Communications.Services
                     while ((line = file.ReadLine()) != null)
                     {
                         line = line.Trim();
-                        if ((line != String.Empty) && !line.StartsWith(";") && !line.StartsWith("//"))
+                        if (!String.IsNullOrEmpty(line) && !line.StartsWith(";") && !line.StartsWith("//"))
                         {
                             theList.Add(line);
                             m_log.InfoFormat("[LOGINSERVICE] Added {0} {1}", desc, line);

--- a/OpenSim/Framework/Communications/Services/LoginService.cs
+++ b/OpenSim/Framework/Communications/Services/LoginService.cs
@@ -50,7 +50,7 @@ namespace OpenSim.Framework.Communications.Services
         private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         protected string m_welcomeMessage = "Welcome to InWorldz";
-        protected string m_MapServerURI = "";
+        protected string m_MapServerURI = String.Empty;
         protected int m_minLoginLevel = 0;
         protected UserProfileManager m_userManager = null;
 
@@ -89,7 +89,7 @@ namespace OpenSim.Framework.Communications.Services
                     while ((line = file.ReadLine()) != null)
                     {
                         line = line.Trim();
-                        if ((line != "") && !line.StartsWith(";") && !line.StartsWith("//"))
+                        if ((line != String.Empty) && !line.StartsWith(";") && !line.StartsWith("//"))
                         {
                             theList.Add(line);
                             m_log.InfoFormat("[LOGINSERVICE] Added {0} {1}", desc, line);
@@ -112,9 +112,9 @@ namespace OpenSim.Framework.Communications.Services
             m_userManager = userManager;
             m_libraryRootFolder = libraryRootFolder;
 
-            if (welcomeMess != String.Empty)
+            if (!String.IsNullOrEmpty(welcomeMess))
                 m_welcomeMessage = welcomeMess;
-            if (mapServerURI != String.Empty)
+            if (!String.IsNullOrEmpty(mapServerURI))
                 m_MapServerURI = mapServerURI;
 
             // For new users' first-time logins
@@ -998,7 +998,7 @@ namespace OpenSim.Framework.Communications.Services
                 }
 
                 // StartLocation not available, send him to a nearby region instead
-                // regionInfo = m_gridService.RequestClosestRegion("");
+                // regionInfo = m_gridService.RequestClosestRegion(String.Empty);
                 //m_log.InfoFormat("[LOGIN]: StartLocation not available sending to region {0}", regionInfo.regionName);
 
                 // Normal login failed, try to find a default region from the list

--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -1283,7 +1283,7 @@ namespace OpenSim.Framework.Communications
         public string GetNewKey(string url, UUID userID, UUID authToken)
         {
             UserProfileData profile = GetUserProfile(userID);
-            string newKey = string.Empty;
+            string newKey = String.Empty;
             if (!url.EndsWith("/"))
                 url = url + "/";
 

--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -368,8 +368,8 @@ namespace OpenSim.Framework.Communications
                 }
             }
 
-            firstName = "";
-            lastName = "";
+            firstName = String.Empty;
+            lastName = String.Empty;
 
             if (onlyIfCached)
                 return false;
@@ -387,30 +387,30 @@ namespace OpenSim.Framework.Communications
 
         public string Key2Name(UUID uuid, bool onlyIfCached)
         {
-            string firstName = "";
-            string lastName = "";
+            string firstName = String.Empty;
+            string lastName = String.Empty;
             if (!Key2Names(uuid, onlyIfCached, out firstName, out lastName))
-                return "";
+                return String.Empty;
 
             return firstName + " " + lastName;
         }
 
         public string GetLastName(UUID uuid, bool onlyIfCached)
         {
-            string firstName = "";
-            string lastName = "";
+            string firstName = String.Empty;
+            string lastName = String.Empty;
             if (!Key2Names(uuid, onlyIfCached, out firstName, out lastName))
-                return "";
+                return String.Empty;
 
             return lastName;
         }
 
         public string GetFirstName(UUID uuid, bool onlyIfCached)
         {
-            string firstName = "";
-            string lastName = "";
+            string firstName = String.Empty;
+            string lastName = String.Empty;
             if (!Key2Names(uuid, onlyIfCached, out firstName, out lastName))
-                return "";
+                return String.Empty;
 
             return firstName;
         }

--- a/OpenSim/Framework/Configuration/XML/XmlConfiguration.cs
+++ b/OpenSim/Framework/Configuration/XML/XmlConfiguration.cs
@@ -133,7 +133,7 @@ namespace OpenSim.Framework.Configuration.XML
             if (!needsCommit)
                 return;
 
-            if (fileName == null || fileName == String.Empty)
+            if (String.IsNullOrEmpty(fileName))
                 return;
 
             if (!Directory.Exists(Util.configDir()))

--- a/OpenSim/Framework/ConfigurationMember.cs
+++ b/OpenSim/Framework/ConfigurationMember.cs
@@ -108,8 +108,8 @@ namespace OpenSim.Framework
 
         private void checkAndAddConfigOption(ConfigurationOption option)
         {
-            if ((option.configurationKey != String.Empty && option.configurationQuestion != String.Empty) ||
-                (option.configurationKey != String.Empty && option.configurationUseDefaultNoPrompt))
+            if ((!String.IsNullOrEmpty(option.configurationKey) && !String.IsNullOrEmpty(option.configurationQuestion)) ||
+                (!String.IsNullOrEmpty(option.configurationKey) && option.configurationUseDefaultNoPrompt))
             {
                 if (!configurationOptions.Contains(option))
                 {
@@ -195,7 +195,7 @@ namespace OpenSim.Framework
                 return;
             }
 
-            if (configurationFilename.Trim() != String.Empty)
+            if (!String.IsNullOrWhiteSpace(configurationFilename))
             {
                 configurationPlugin.SetFileName(configurationFilename);
                 try
@@ -258,7 +258,7 @@ namespace OpenSim.Framework
                                  configOption.shouldIBeAsked(configOption.configurationKey)) ||
                                 configOption.shouldIBeAsked == null)
                             {
-                                if (configurationDescription.Trim() != String.Empty)
+                                if (!String.IsNullOrWhiteSpace(configurationDescription))
                                 {
                                     console_result =
                                         MainConsole.Instance.CmdPrompt(

--- a/OpenSim/Framework/ConfigurationMember.cs
+++ b/OpenSim/Framework/ConfigurationMember.cs
@@ -503,9 +503,7 @@ namespace OpenSim.Framework
                 {
                     if (!pluginType.IsAbstract)
                     {
-                        Type typeInterface = pluginType.GetInterface("IGenericConfig", true);
-
-                        if (typeInterface != null)
+                        if (typeof(IGenericConfig).IsAssignableFrom(pluginType))
                         {
                             plug =
                                 (IGenericConfig) Activator.CreateInstance(pluginAssembly.GetType(pluginType.ToString()));

--- a/OpenSim/Framework/Console/CommandConsole.cs
+++ b/OpenSim/Framework/Console/CommandConsole.cs
@@ -111,7 +111,7 @@ namespace OpenSim.Framework.Console
             // Remove initial help keyword
             helpParts.RemoveAt(0);
 
-            help.Add(""); // Will become a newline.
+            help.Add(String.Empty); // Will become a newline.
 
             // General help
             if (helpParts.Count == 0)
@@ -129,7 +129,7 @@ namespace OpenSim.Framework.Console
                 help.AddRange(CollectHelp(helpParts));
             }
 
-            help.Add(""); // Will become a newline.
+            help.Add(String.Empty); // Will become a newline.
 
             return help;
         }
@@ -262,7 +262,7 @@ namespace OpenSim.Framework.Console
 //                }
 //                else
 //                {
-//                    if (((CommandInfo)kvp.Value).long_help != String.Empty)
+        //                if (!String.IsNullOrEmpty(((CommandInfo)kvp.Value).long_help))
 //                        result.Add(((CommandInfo)kvp.Value).help_text+" - "+
 //                                ((CommandInfo)kvp.Value).long_help);
 //                }
@@ -405,7 +405,7 @@ namespace OpenSim.Framework.Console
                 bool addcr = false;
                 foreach (string s in current.Keys)
                 {
-                    if (s == String.Empty)
+                    if (String.IsNullOrEmpty(s))
                     {
                         CommandInfo ci = (CommandInfo)current[String.Empty];
                         if (ci.fn.Count != 0)
@@ -497,7 +497,7 @@ namespace OpenSim.Framework.Console
             if (((Dictionary<string, object>)tree["quit"]).Count == 0)
                 tree.Remove("quit");
 
-            XmlElement root = doc.CreateElement("", "HelpTree", "");
+            XmlElement root = doc.CreateElement(String.Empty, "HelpTree", String.Empty);
 
             ProcessTreeLevel(tree, root, doc);
 
@@ -518,7 +518,7 @@ namespace OpenSim.Framework.Console
             {
                 if (kvp.Value is Dictionary<string, Object>)
                 {
-                    XmlElement next = doc.CreateElement("", "Level", "");
+                    XmlElement next = doc.CreateElement(String.Empty, "Level", String.Empty);
                     next.SetAttribute("Name", kvp.Key);
 
                     xml.AppendChild(next);
@@ -529,27 +529,27 @@ namespace OpenSim.Framework.Console
                 {
                     CommandInfo c = (CommandInfo)kvp.Value;
 
-                    XmlElement cmd = doc.CreateElement("", "Command", "");
+                    XmlElement cmd = doc.CreateElement(String.Empty, "Command", String.Empty);
 
                     XmlElement e;
 
-                    e = doc.CreateElement("", "Module", "");
+                    e = doc.CreateElement(String.Empty, "Module", String.Empty);
                     cmd.AppendChild(e);
                     e.AppendChild(doc.CreateTextNode(c.module));
 
-                    e = doc.CreateElement("", "Shared", "");
+                    e = doc.CreateElement(String.Empty, "Shared", String.Empty);
                     cmd.AppendChild(e);
                     e.AppendChild(doc.CreateTextNode(c.shared.ToString()));
 
-                    e = doc.CreateElement("", "HelpText", "");
+                    e = doc.CreateElement(String.Empty, "HelpText", String.Empty);
                     cmd.AppendChild(e);
                     e.AppendChild(doc.CreateTextNode(c.help_text));
 
-                    e = doc.CreateElement("", "LongHelp", "");
+                    e = doc.CreateElement(String.Empty, "LongHelp", String.Empty);
                     cmd.AppendChild(e);
                     e.AppendChild(doc.CreateTextNode(c.long_help));
 
-                    e = doc.CreateElement("", "Description", "");
+                    e = doc.CreateElement(String.Empty, "Description", String.Empty);
                     cmd.AppendChild(e);
                     e.AppendChild(doc.CreateTextNode(c.descriptive_help));
 
@@ -659,7 +659,7 @@ namespace OpenSim.Framework.Console
                     bool option = false;
                     foreach (string w in words)
                     {
-                        if (w != String.Empty)
+                        if (!String.IsNullOrEmpty(w))
                         {
                             if (optionRegex.Match(w) == Match.Empty)
                                 option = false;
@@ -741,7 +741,7 @@ namespace OpenSim.Framework.Console
         {
             string line = ReadLine(DefaultPrompt + "# ", true, true);
 
-            if (line != String.Empty)
+            if (!String.IsNullOrEmpty(line))
                 Output("Invalid command");
         }
 

--- a/OpenSim/Framework/Console/CommandConsole.cs
+++ b/OpenSim/Framework/Console/CommandConsole.cs
@@ -199,8 +199,8 @@ namespace OpenSim.Framework.Console
                 string descriptiveHelp = commandInfo.descriptive_help;
 
                 // If we do have some descriptive help then insert a spacing line before for readability.
-                if (descriptiveHelp != string.Empty)
-                    help.Add(string.Empty);
+                if (descriptiveHelp != String.Empty)
+                    help.Add(String.Empty);
                 
                 help.Add(commandInfo.descriptive_help);
             }
@@ -488,12 +488,12 @@ namespace OpenSim.Framework.Console
         public XmlElement GetXml(XmlDocument doc)
         {
             CommandInfo help = (CommandInfo)((Dictionary<string, object>)tree["help"])[String.Empty];
-            ((Dictionary<string, object>)tree["help"]).Remove(string.Empty);
+            ((Dictionary<string, object>)tree["help"]).Remove(String.Empty);
             if (((Dictionary<string, object>)tree["help"]).Count == 0)
                 tree.Remove("help");
 
             CommandInfo quit = (CommandInfo)((Dictionary<string, object>)tree["quit"])[String.Empty];
-            ((Dictionary<string, object>)tree["quit"]).Remove(string.Empty);
+            ((Dictionary<string, object>)tree["quit"]).Remove(String.Empty);
             if (((Dictionary<string, object>)tree["quit"]).Count == 0)
                 tree.Remove("quit");
 
@@ -561,12 +561,12 @@ namespace OpenSim.Framework.Console
         public void FromXml(XmlElement root, CommandDelegate fn)
         {
             CommandInfo help = (CommandInfo)((Dictionary<string, object>)tree["help"])[String.Empty];
-            ((Dictionary<string, object>)tree["help"]).Remove(string.Empty);
+            ((Dictionary<string, object>)tree["help"]).Remove(String.Empty);
             if (((Dictionary<string, object>)tree["help"]).Count == 0)
                 tree.Remove("help");
 
             CommandInfo quit = (CommandInfo)((Dictionary<string, object>)tree["quit"])[String.Empty];
-            ((Dictionary<string, object>)tree["quit"]).Remove(string.Empty);
+            ((Dictionary<string, object>)tree["quit"]).Remove(String.Empty);
             if (((Dictionary<string, object>)tree["quit"]).Count == 0)
                 tree.Remove("quit");
 

--- a/OpenSim/Framework/Console/ConsoleBase.cs
+++ b/OpenSim/Framework/Console/ConsoleBase.cs
@@ -227,7 +227,7 @@ namespace OpenSim.Framework.Console
         public string CmdPrompt(string p, string def)
         {
             string ret = ReadLine(String.Format("{0} [{1}]: ", p, def), false, true);
-            if (ret == String.Empty)
+            if (String.IsNullOrEmpty(ret))
                 ret = def;
 
             return ret;
@@ -264,7 +264,7 @@ namespace OpenSim.Framework.Console
                 itisdone = true;
                 ret = CmdPrompt(p, def);
                 
-                if (ret == String.Empty)
+                if (String.IsNullOrEmpty(ret))
                 {
                     ret = def;
                 }

--- a/OpenSim/Framework/Console/ConsoleUtil.cs
+++ b/OpenSim/Framework/Console/ConsoleUtil.cs
@@ -224,13 +224,13 @@ namespace OpenSim.Framework.Console
             }
     
             for (int i = components.Count; i < 3; i++)
-                components.Add("");
+                components.Add(String.Empty);
     
             List<string> semiDigestedComponents
                 = components.ConvertAll<string>(
                     c =>
                     {
-                        if (c == "")
+                        if (String.IsNullOrEmpty(c))
                             return blankComponentFunc.Invoke(c);
                         else if (c == MaxRawConsoleVectorValue)
                             return float.MaxValue.ToString();

--- a/OpenSim/Framework/Console/LocalConsole.cs
+++ b/OpenSim/Framework/Console/LocalConsole.cs
@@ -500,7 +500,7 @@ namespace OpenSim.Framework.Console
                         }
 
                         // If we're not echoing to screen (e.g. a password) then we probably don't want it in history
-                        if (m_echo && commandLine != "")
+                        if (m_echo && commandLine != String.Empty)
                             AddToHistory(commandLine);
                         
                         return commandLine;

--- a/OpenSim/Framework/Console/LocalConsole.cs
+++ b/OpenSim/Framework/Console/LocalConsole.cs
@@ -500,7 +500,7 @@ namespace OpenSim.Framework.Console
                         }
 
                         // If we're not echoing to screen (e.g. a password) then we probably don't want it in history
-                        if (m_echo && commandLine != String.Empty)
+                        if (m_echo && !String.IsNullOrEmpty(commandLine))
                             AddToHistory(commandLine);
                         
                         return commandLine;

--- a/OpenSim/Framework/Console/MockConsole.cs
+++ b/OpenSim/Framework/Console/MockConsole.cs
@@ -56,7 +56,7 @@ namespace OpenSim.Framework.Console
 
         public void RunCommand(string cmd) {}
 
-        public string ReadLine(string p, bool isCommand, bool e) { return ""; }
+        public string ReadLine(string p, bool isCommand, bool e) { return String.Empty; }
 
         public object ConsoleScene { 
             get { return null; }
@@ -67,14 +67,14 @@ namespace OpenSim.Framework.Console
         public void Output(string text) {}
         public void OutputFormat(string format, params object[] components) {}
 
-        public string CmdPrompt(string p) { return ""; }
-        public string CmdPrompt(string p, string def) { return ""; }
-        public string CmdPrompt(string p, List<char> excludedCharacters) { return ""; }
-        public string CmdPrompt(string p, string def, List<char> excludedCharacters) { return ""; }
+        public string CmdPrompt(string p) { return String.Empty; }
+        public string CmdPrompt(string p, string def) { return String.Empty; }
+        public string CmdPrompt(string p, List<char> excludedCharacters) { return String.Empty; }
+        public string CmdPrompt(string p, string def, List<char> excludedCharacters) { return String.Empty; }
 
-        public string CmdPrompt(string prompt, string defaultresponse, List<string> options) { return ""; }
+        public string CmdPrompt(string prompt, string defaultresponse, List<string> options) { return String.Empty; }
 
-        public string PasswdPrompt(string p) { return ""; }
+        public string PasswdPrompt(string p) { return String.Empty; }
     }
 
     public class MockCommands : ICommands

--- a/OpenSim/Framework/Console/RemoteConsole.cs
+++ b/OpenSim/Framework/Console/RemoteConsole.cs
@@ -154,7 +154,7 @@ namespace OpenSim.Framework.Console
                 if (m_InputData.Count == 0)
                 {
                     m_DataEvent.Reset();
-                    return "";
+                    return String.Empty;
                 }
 
                 cmdinput = m_InputData[0];
@@ -247,7 +247,7 @@ namespace OpenSim.Framework.Console
             Hashtable post = DecodePostString(request["body"].ToString());
             Hashtable reply = new Hashtable();
 
-            reply["str_response_string"] = "";
+            reply["str_response_string"] = String.Empty;
             reply["int_response_code"] = 401;
             reply["content_type"] = "text/plain";
 
@@ -274,19 +274,19 @@ namespace OpenSim.Framework.Console
             m_Server.AddStreamHandler(handler);
 
             XmlDocument xmldoc = new XmlDocument();
-            XmlNode xmlnode = xmldoc.CreateNode(XmlNodeType.XmlDeclaration, "", "");
+            XmlNode xmlnode = xmldoc.CreateNode(XmlNodeType.XmlDeclaration, String.Empty, String.Empty);
 
             xmldoc.AppendChild(xmlnode);
-            XmlElement rootElement = xmldoc.CreateElement("", "ConsoleSession", "");
+            XmlElement rootElement = xmldoc.CreateElement(String.Empty, "ConsoleSession", String.Empty);
 
             xmldoc.AppendChild(rootElement);
 
-            XmlElement id = xmldoc.CreateElement("", "SessionID", "");
+            XmlElement id = xmldoc.CreateElement(String.Empty, "SessionID", String.Empty);
             id.AppendChild(xmldoc.CreateTextNode(sessionID.ToString()));
 
             rootElement.AppendChild(id);
 
-            XmlElement prompt = xmldoc.CreateElement("", "Prompt", "");
+            XmlElement prompt = xmldoc.CreateElement(String.Empty, "Prompt", String.Empty);
             prompt.AppendChild(xmldoc.CreateTextNode(DefaultPrompt));
 
             rootElement.AppendChild(prompt);
@@ -308,7 +308,7 @@ namespace OpenSim.Framework.Console
             Hashtable post = DecodePostString(request["body"].ToString());
             Hashtable reply = new Hashtable();
 
-            reply["str_response_string"] = "";
+            reply["str_response_string"] = String.Empty;
             reply["int_response_code"] = 404;
             reply["content_type"] = "text/plain";
 
@@ -336,14 +336,14 @@ namespace OpenSim.Framework.Console
             }
 
             XmlDocument xmldoc = new XmlDocument();
-            XmlNode xmlnode = xmldoc.CreateNode(XmlNodeType.XmlDeclaration, "", "");
+            XmlNode xmlnode = xmldoc.CreateNode(XmlNodeType.XmlDeclaration, String.Empty, String.Empty);
 
             xmldoc.AppendChild(xmlnode);
-            XmlElement rootElement = xmldoc.CreateElement("", "ConsoleSession", "");
+            XmlElement rootElement = xmldoc.CreateElement(String.Empty, "ConsoleSession", String.Empty);
 
             xmldoc.AppendChild(rootElement);
 
-            XmlElement res = xmldoc.CreateElement("", "Result", "");
+            XmlElement res = xmldoc.CreateElement(String.Empty, "Result", String.Empty);
             res.AppendChild(xmldoc.CreateTextNode("OK"));
 
             rootElement.AppendChild(res);
@@ -363,7 +363,7 @@ namespace OpenSim.Framework.Console
             Hashtable post = DecodePostString(request["body"].ToString());
             Hashtable reply = new Hashtable();
 
-            reply["str_response_string"] = "";
+            reply["str_response_string"] = String.Empty;
             reply["int_response_code"] = 404;
             reply["content_type"] = "text/plain";
 
@@ -390,14 +390,14 @@ namespace OpenSim.Framework.Console
             }
 
             XmlDocument xmldoc = new XmlDocument();
-            XmlNode xmlnode = xmldoc.CreateNode(XmlNodeType.XmlDeclaration, "", "");
+            XmlNode xmlnode = xmldoc.CreateNode(XmlNodeType.XmlDeclaration, String.Empty, String.Empty);
 
             xmldoc.AppendChild(xmlnode);
-            XmlElement rootElement = xmldoc.CreateElement("", "ConsoleSession", "");
+            XmlElement rootElement = xmldoc.CreateElement(String.Empty, "ConsoleSession", String.Empty);
 
             xmldoc.AppendChild(rootElement);
 
-            XmlElement res = xmldoc.CreateElement("", "Result", "");
+            XmlElement res = xmldoc.CreateElement(String.Empty, "Result", String.Empty);
             res.AppendChild(xmldoc.CreateTextNode("OK"));
 
             rootElement.AppendChild(res);
@@ -544,10 +544,10 @@ namespace OpenSim.Framework.Console
             Hashtable result = new Hashtable();
 
             XmlDocument xmldoc = new XmlDocument();
-            XmlNode xmlnode = xmldoc.CreateNode(XmlNodeType.XmlDeclaration, "", "");
+            XmlNode xmlnode = xmldoc.CreateNode(XmlNodeType.XmlDeclaration, String.Empty, String.Empty);
 
             xmldoc.AppendChild(xmlnode);
-            XmlElement rootElement = xmldoc.CreateElement("", "ConsoleSession", "");
+            XmlElement rootElement = xmldoc.CreateElement(String.Empty, "ConsoleSession", String.Empty);
 
             if (c.newConnection)
             {
@@ -564,7 +564,7 @@ namespace OpenSim.Framework.Console
 
                 for (long i = sendStart; i < m_LineNumber; i++)
                 {
-                    XmlElement res = xmldoc.CreateElement("", "Line", "");
+                    XmlElement res = xmldoc.CreateElement(String.Empty, "Line", String.Empty);
                     long line = i + 1;
                     res.SetAttribute("Number", line.ToString());
                     res.AppendChild(xmldoc.CreateTextNode(m_Scrollback[(int)(i - startLine)]));
@@ -592,10 +592,10 @@ namespace OpenSim.Framework.Console
             Hashtable result = new Hashtable();
 
             XmlDocument xmldoc = new XmlDocument();
-            XmlNode xmlnode = xmldoc.CreateNode(XmlNodeType.XmlDeclaration,  "", "");
+            XmlNode xmlnode = xmldoc.CreateNode(XmlNodeType.XmlDeclaration,  String.Empty, String.Empty);
 
             xmldoc.AppendChild(xmlnode);
-            XmlElement rootElement = xmldoc.CreateElement("", "ConsoleSession", "");
+            XmlElement rootElement = xmldoc.CreateElement(String.Empty, "ConsoleSession", String.Empty);
 
             xmldoc.AppendChild(rootElement);
 

--- a/OpenSim/Framework/EstateBan.cs
+++ b/OpenSim/Framework/EstateBan.cs
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
 using OpenMetaverse;
 
 namespace OpenSim.Framework

--- a/OpenSim/Framework/EstateBan.cs
+++ b/OpenSim/Framework/EstateBan.cs
@@ -63,7 +63,7 @@ namespace OpenSim.Framework
             }
         }
 
-        private string m_bannedHostAddress = string.Empty;
+        private string m_bannedHostAddress = String.Empty;
         /// <summary>
         /// IP address or domain name of the banned client.
         /// </summary>
@@ -79,7 +79,7 @@ namespace OpenSim.Framework
             }
         }
 
-        private string m_bannedHostIPMask = string.Empty;
+        private string m_bannedHostIPMask = String.Empty;
         /// <summary>
         /// IP address mask for banning group of client hosts.
         /// </summary>
@@ -95,7 +95,7 @@ namespace OpenSim.Framework
             }
         }
 
-        private string m_bannedHostNameMask = string.Empty;
+        private string m_bannedHostNameMask = String.Empty;
         /// <summary>
         /// Domain name mask for banning group of client hosts.
         /// </summary>

--- a/OpenSim/Framework/GridConfig.cs
+++ b/OpenSim/Framework/GridConfig.cs
@@ -81,7 +81,7 @@ namespace OpenSim.Framework
             m_configMember.addConfigurationOption("database_provider", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
                                                 "DLL for database provider", "OpenSim.Data.MySQL.dll", false);
             m_configMember.addConfigurationOption("database_connect", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
-                                                "Database connect string", "", false);
+                                                "Database connect string", String.Empty, false);
 
             m_configMember.addConfigurationOption("http_port", ConfigurationOption.ConfigurationTypes.TYPE_UINT32,
                                                 "Http Listener port", ConfigSettings.DefaultGridServerHttpPort.ToString(), false);

--- a/OpenSim/Framework/HGNetworkServersInfo.cs
+++ b/OpenSim/Framework/HGNetworkServersInfo.cs
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
 using System.Net;
 
 namespace OpenSim.Framework
@@ -56,7 +57,7 @@ namespace OpenSim.Framework
         public bool IsLocalUser(string userserver)
         {
             string userServerURI = ServerURI(userserver);
-            bool ret = (((userServerURI == null) || (userServerURI == "") || (userServerURI == LocalUserServerURI)));
+            bool ret = ((String.IsNullOrEmpty(userServerURI) || (userServerURI == LocalUserServerURI)));
             //m_log.Debug("-------------> HGNetworkServersInfo.IsLocalUser? " + ret + "(userServer=" + userServerURI + "; localuserserver=" + LocalUserServerURI + ")");
             return ret;
         }
@@ -86,7 +87,7 @@ namespace OpenSim.Framework
             catch { }
 
             IPAddress ipaddr1 = null;
-            string port1 = "";
+            string port1 = String.Empty;
             try
             {
                 ipaddr1 = Util.GetHostFromURL(uri);

--- a/OpenSim/Framework/InventoryConfig.cs
+++ b/OpenSim/Framework/InventoryConfig.cs
@@ -63,7 +63,7 @@ namespace OpenSim.Framework
             m_configMember.addConfigurationOption("database_provider", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
                                                 "DLL for database provider", "OpenSim.Data.MySQL.dll", false);
             m_configMember.addConfigurationOption("database_connect", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
-                                                "Database Connect String", "", false);
+                                                "Database Connect String", String.Empty, false);
             m_configMember.addConfigurationOption("http_port", ConfigurationOption.ConfigurationTypes.TYPE_UINT32,
                                                 "Http Listener port", ConfigSettings.DefaultInventoryServerHttpPort.ToString(), false);
             m_configMember.addConfigurationOption("session_lookup", ConfigurationOption.ConfigurationTypes.TYPE_BOOLEAN,

--- a/OpenSim/Framework/InventoryFolderImpl.cs
+++ b/OpenSim/Framework/InventoryFolderImpl.cs
@@ -331,7 +331,7 @@ namespace OpenSim.Framework
         /// <returns>null if the folder is not found</returns>
         public InventoryFolderImpl FindFolderByPath(string path)
         {
-            if (path == string.Empty)
+            if (path == String.Empty)
                 return this;
             
             path = path.Trim();

--- a/OpenSim/Framework/InventoryItemBase.cs
+++ b/OpenSim/Framework/InventoryItemBase.cs
@@ -136,7 +136,7 @@ namespace OpenSim.Framework
         }
         protected UUID m_creatorIdAsUuid = UUID.Zero;
 
-        protected string m_creatorData = string.Empty;
+        protected string m_creatorData = String.Empty;
         public string CreatorData // = <profile url>;<name>
         {
             get { return m_creatorData; }
@@ -152,16 +152,16 @@ namespace OpenSim.Framework
         {
             get
             {
-                if (m_creatorData != null && m_creatorData != string.Empty)
+                if (m_creatorData != null && m_creatorData != String.Empty)
                     return m_creatorId + ';' + m_creatorData;
                 else
                     return m_creatorId;
             }
             set
             {
-                if ((value == null) || (value != null && value == string.Empty))
+                if ((value == null) || (value != null && value == String.Empty))
                 {
-                    m_creatorData = string.Empty;
+                    m_creatorData = String.Empty;
                     return;
                 }
 

--- a/OpenSim/Framework/InventoryNodeBase.cs
+++ b/OpenSim/Framework/InventoryNodeBase.cs
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
 using OpenMetaverse;
 
 namespace OpenSim.Framework

--- a/OpenSim/Framework/InventoryNodeBase.cs
+++ b/OpenSim/Framework/InventoryNodeBase.cs
@@ -58,7 +58,7 @@ namespace OpenSim.Framework
                  
             }
         } 
-        private string m_name = string.Empty;
+        private string m_name = String.Empty;
         
         /// <summary>
         /// A UUID containing the ID for the inventory node itself

--- a/OpenSim/Framework/InventoryStorageException.cs
+++ b/OpenSim/Framework/InventoryStorageException.cs
@@ -41,7 +41,7 @@ namespace OpenSim.Framework
     /// </summary>
     public class InventoryStorageException : Exception
     {
-        private string _details = string.Empty;
+        private string _details = String.Empty;
 
         public string ErrorDetails
         {
@@ -74,7 +74,7 @@ namespace OpenSim.Framework
         {
             get
             {
-                if (_details == string.Empty)
+                if (_details == String.Empty)
                 {
                     return base.Message;
                 }

--- a/OpenSim/Framework/LandData.cs
+++ b/OpenSim/Framework/LandData.cs
@@ -95,7 +95,7 @@ namespace OpenSim.Framework
         private Vector3 _userLookAt = new Vector3();
         private int _otherCleanTime = 0;
         private string _mediaType = "none/none";
-        private string _mediaDescription = "";
+        private string _mediaDescription = String.Empty;
         private int _mediaHeight = 0;
         private int _mediaWidth = 0;
         private bool _mediaLoop = false;

--- a/OpenSim/Framework/MessageServerConfig.cs
+++ b/OpenSim/Framework/MessageServerConfig.cs
@@ -74,7 +74,7 @@ namespace OpenSim.Framework
                                                 "Key to expect from grid server", "null", false);
 
             m_configMember.addConfigurationOption("database_connect", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
-                                                "Connection String for Database", "", false);
+                                                "Connection String for Database", String.Empty, false);
 
             m_configMember.addConfigurationOption("database_provider", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
                                                 "DLL for database provider", "OpenSim.Data.MySQL.dll", false);

--- a/OpenSim/Framework/NetworkServersInfo.cs
+++ b/OpenSim/Framework/NetworkServersInfo.cs
@@ -50,9 +50,9 @@ namespace OpenSim.Framework
         public string UserURL = String.Empty;
         public string HostName = String.Empty;
         public bool HttpUsesSSL = false;
-        public string HttpSSLCN = "";
-        public string HttpSSLCert = "";
-        public string HttpSSLPassword = "";
+        public string HttpSSLCN = String.Empty;
+        public string HttpSSLCert = String.Empty;
+        public string HttpSSLPassword = String.Empty;
         public uint httpSSLPort = 9001;
         public bool useHTTPS = false;
         public SslProtocols sslProtocol = SslProtocols.Default;
@@ -89,8 +89,8 @@ namespace OpenSim.Framework
             httpSSLPort = (uint)config.Configs["Network"].GetInt("http_listener_sslport", ((int)ConfigSettings.DefaultRegionHttpPort+1));
             HttpUsesSSL = config.Configs["Network"].GetBoolean("http_listener_ssl", false);
             HttpSSLCN = config.Configs["Network"].GetString("http_listener_cn", "localhost");
-            HttpSSLCert = config.Configs["Network"].GetString("http_listener_ssl_cert", "");
-            HttpSSLPassword = config.Configs["Network"].GetString("http_listener_ssl_passwd", "");
+            HttpSSLCert = config.Configs["Network"].GetString("http_listener_ssl_cert", String.Empty);
+            HttpSSLPassword = config.Configs["Network"].GetString("http_listener_ssl_passwd", String.Empty);
             useHTTPS = config.Configs["Network"].GetBoolean("use_https", false);
 
             string sslproto = config.Configs["Network"].GetString("https_ssl_protocol", "Default");

--- a/OpenSim/Framework/PluginLoader.cs
+++ b/OpenSim/Framework/PluginLoader.cs
@@ -283,13 +283,13 @@ namespace OpenSim.Framework
     public class PluginExtensionNode : ExtensionNode
     {
         [NodeAttribute]
-        string id = "";
+        string id = String.Empty;
 
         [NodeAttribute]
-        string provider = "";
+        string provider = String.Empty;
 
         [NodeAttribute]
-        string type = "";
+        string type = String.Empty;
 
         Type typeobj;
 

--- a/OpenSim/Framework/PrimitiveBaseShape.cs
+++ b/OpenSim/Framework/PrimitiveBaseShape.cs
@@ -84,7 +84,7 @@ namespace OpenSim.Framework
         [XmlIgnore]
         public static readonly UUID DEFAULT_TEXTURE_ID = new UUID("89556747-24cb-43ed-920b-47caed15465f");
 
-        [XmlIgnore]
+        [XmlIgnore][NonSerialized]
         private Primitive.TextureEntry m_textures;
 
         private byte[] m_textureEntryBytes;  // persisted byte version of m_textures
@@ -115,7 +115,7 @@ namespace OpenSim.Framework
         private PhysicsShapeType _preferredPhysicsShape;
 
         // Materials
-        [XmlIgnore] private RenderMaterials _renderMaterials;
+        [XmlIgnore][NonSerialized] private RenderMaterials _renderMaterials;
 
         // Sculpted
         [XmlIgnore] private UUID _sculptTexture = UUID.Zero;
@@ -1732,6 +1732,7 @@ namespace OpenSim.Framework
 
             // keys are 0-based (face number - 1)
 //            protected Dictionary<int,MediaEntry> m_MediaList = new Dictionary<int,MediaEntry>();
+            [NonSerialized]
             protected MediaEntry[] m_MediaFaces = null;
 
             public PrimMedia() : base() 

--- a/OpenSim/Framework/PrimitiveBaseShape.cs
+++ b/OpenSim/Framework/PrimitiveBaseShape.cs
@@ -1710,7 +1710,7 @@ namespace OpenSim.Framework
 
             prim.Properties = new Primitive.ObjectProperties();
             prim.Properties.Name = "Primitive";
-            prim.Properties.Description = "";
+            prim.Properties.Description = String.Empty;
             prim.Properties.CreatorID = UUID.Zero;
             prim.Properties.GroupID = UUID.Zero;
             prim.Properties.OwnerID = UUID.Zero;

--- a/OpenSim/Framework/RegionInfo.cs
+++ b/OpenSim/Framework/RegionInfo.cs
@@ -276,7 +276,7 @@ namespace OpenSim.Framework
         public string MasterAvatarLastName = String.Empty;
         public string MasterAvatarSandboxPassword = String.Empty;
         public UUID originRegionID = UUID.Zero;
-        public string proxyUrl = "";
+        public string proxyUrl = String.Empty;
         public int ProxyOffset = 0;
         public string RegionName = String.Empty;
         public string regionSecret = UUID.Random().ToString();
@@ -718,8 +718,8 @@ namespace OpenSim.Framework
                 m_externalHostName = Util.GetLocalHost().ToString();
             }
 
-            OutsideIP = source.Configs[sectionName].GetString("outside_ip", "");
-            if (OutsideIP == "") OutsideIP = null;
+            OutsideIP = source.Configs[sectionName].GetString("outside_ip", String.Empty);
+            if (String.IsNullOrEmpty(OutsideIP)) OutsideIP = null;
 
             MasterAvatarFirstName = source.Configs[sectionName].GetString("master_avatar_first", "Test");
             MasterAvatarLastName = source.Configs[sectionName].GetString("master_avatar_last", "User");
@@ -727,9 +727,9 @@ namespace OpenSim.Framework
 
             MasterAvatarSandboxPassword = source.Configs[sectionName].GetString("master_avatar_pass", "test");
 
-            if (errorMessage != String.Empty)
+            if (!String.IsNullOrEmpty(errorMessage))
             {
-                // a error
+                // TODO: a error
             }
         }
 
@@ -877,7 +877,7 @@ namespace OpenSim.Framework
                                                 "Access restrictions, 0=anyone, 1=only Plus users", "0", true);
 
             configMember.addConfigurationOption("outside_ip", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
-                                                "The ip address as seen by the outside world", "", true);
+                                                "The ip address as seen by the outside world", String.Empty, true);
         }
 
         public bool shouldMasterAvatarDetailsBeAsked(string configuration_key)
@@ -991,7 +991,7 @@ namespace OpenSim.Framework
                     break;
                 case "outside_ip":
                     OutsideIP = (string)configuration_result;
-                    if (OutsideIP == "") OutsideIP = null;
+                    if (String.IsNullOrEmpty(OutsideIP)) OutsideIP = null;
                     break;
             }
 
@@ -1013,7 +1013,7 @@ namespace OpenSim.Framework
         {
             OSDMap args = new OSDMap();
             args["region_id"] = OSD.FromUUID(RegionID);
-            if ((RegionName != null) && !RegionName.Equals(""))
+            if ((RegionName != null) && !RegionName.Equals(String.Empty))
                 args["region_name"] = OSD.FromString(RegionName);
             args["external_host_name"] = OSD.FromString(ExternalHostName);
             args["http_port"] = OSD.FromString(HttpPort.ToString());
@@ -1021,11 +1021,11 @@ namespace OpenSim.Framework
             args["region_yloc"] = OSD.FromString(RegionLocY.ToString());
             args["internal_ep_address"] = OSD.FromString(InternalEndPoint.Address.ToString());
             args["internal_ep_port"] = OSD.FromString(InternalEndPoint.Port.ToString());
-            if ((RemotingAddress != null) && !RemotingAddress.Equals(""))
+            if ((RemotingAddress != null) && !RemotingAddress.Equals(String.Empty))
                 args["remoting_address"] = OSD.FromString(RemotingAddress);
             args["remoting_port"] = OSD.FromString(RemotingPort.ToString());
             args["allow_alt_ports"] = OSD.FromBoolean(m_allow_alternate_ports);
-            if ((proxyUrl != null) && !proxyUrl.Equals(""))
+            if ((proxyUrl != null) && !proxyUrl.Equals(String.Empty))
                 args["proxy_url"] = OSD.FromString(proxyUrl);
 
             if (OutsideIP != null) args["outside_ip"] = OSD.FromString(OutsideIP);

--- a/OpenSim/Framework/RegionLoader/Web/RegionLoaderWebServer.cs
+++ b/OpenSim/Framework/RegionLoader/Web/RegionLoaderWebServer.cs
@@ -57,7 +57,7 @@ namespace OpenSim.Framework.RegionLoader.Web
             {
                 IConfig startupConfig = (IConfig) m_configSource.Configs["Startup"];
                 string url = startupConfig.GetString("regionload_webserver_url", String.Empty).Trim();
-                if (url == String.Empty)
+                if (String.IsNullOrEmpty(url))
                 {
                     m_log.Error("[WEBLOADER]: Unable to load webserver URL - URL was empty.");
                     return null;

--- a/OpenSim/Framework/RegionUpData.cs
+++ b/OpenSim/Framework/RegionUpData.cs
@@ -32,7 +32,7 @@ namespace OpenSim.Framework
     [Serializable]
     public class RegionUpData
     {
-        private string m_ipaddr = "";
+        private string m_ipaddr = String.Empty;
         private int m_port = 0;
         private uint m_X = 0;
         private uint m_Y = 0;

--- a/OpenSim/Framework/Serialization/TarArchiveWriter.cs
+++ b/OpenSim/Framework/Serialization/TarArchiveWriter.cs
@@ -121,7 +121,7 @@ namespace OpenSim.Framework.Serialization
 
         public static byte[] ConvertDecimalToPaddedOctalBytes(int d, int padding)
         {
-            string oString = "";
+            string oString = String.Empty;
 
             while (d > 0)
             {

--- a/OpenSim/Framework/Servers/BaseOpenSimServer.cs
+++ b/OpenSim/Framework/Servers/BaseOpenSimServer.cs
@@ -359,7 +359,7 @@ namespace OpenSim.Framework.Servers
         /// <param name="helpArgs"></param>
         protected virtual void ShowHelp(string[] helpArgs)
         {
-            Notice("");
+            Notice(String.Empty);
             
             if (helpArgs.Length == 0)
             {
@@ -372,7 +372,7 @@ namespace OpenSim.Framework.Servers
                 Notice("show threads - list tracked threads");
                 Notice("show uptime - show server startup time and uptime.");
                 Notice("show version - show server version.");
-                Notice("");
+                Notice(String.Empty);
 
                 return;
             }
@@ -491,7 +491,7 @@ namespace OpenSim.Framework.Servers
            
         protected void RemovePIDFile()
         {
-            if (m_pidFile != String.Empty)
+            if (!String.IsNullOrEmpty(m_pidFile))
             {
                 try
                 {

--- a/OpenSim/Framework/Servers/HttpServer/BaseHttpServer.cs
+++ b/OpenSim/Framework/Servers/HttpServer/BaseHttpServer.cs
@@ -369,7 +369,7 @@ namespace OpenSim.Framework.Servers.HttpServer
             try
             {
 
-                if (request.HttpMethod == String.Empty) // Can't handle empty requests, not wasting a thread
+                if (String.IsNullOrEmpty(request.HttpMethod)) // Can't handle empty requests, not wasting a thread
                 {
                     buffer = SendHTML500(response);
                 }
@@ -532,8 +532,8 @@ namespace OpenSim.Framework.Servers.HttpServer
                         request.SeqNo,
                         request.HttpMethod,
                         request.Url.AbsolutePath,
-                        requestHandler != null ? requestHandler.Name : "",
-                        requestHandler != null ? requestHandler.Description : "",
+                        requestHandler != null ? requestHandler.Name : String.Empty,
+                        requestHandler != null ? requestHandler.Description : String.Empty,
                         request.RemoteIPEndPoint,
                         tickdiff);
                 }
@@ -593,8 +593,8 @@ namespace OpenSim.Framework.Servers.HttpServer
                     request.SeqNo,
                     request.HttpMethod,
                     request.Url.AbsolutePath,
-                    requestHandler != null ? requestHandler.Name : "",
-                    requestHandler != null ? requestHandler.Description : "",
+                    requestHandler != null ? requestHandler.Name : String.Empty,
+                    requestHandler != null ? requestHandler.Description : String.Empty,
                     tickdiff);
                 // note that request.RemoteIPEndPoint is often disposed when we reach here (e.g. remote end has crashed)
             }
@@ -621,8 +621,8 @@ namespace OpenSim.Framework.Servers.HttpServer
                     request.SeqNo,
                     request.HttpMethod,
                     request.Url.AbsolutePath,
-                    requestHandler != null ? requestHandler.Name : "",
-                    requestHandler != null ? requestHandler.Description : "");
+                    requestHandler != null ? requestHandler.Name : String.Empty,
+                    requestHandler != null ? requestHandler.Description : String.Empty);
 
                 try
                 {

--- a/OpenSim/Framework/Servers/HttpServer/BaseHttpServer.cs
+++ b/OpenSim/Framework/Servers/HttpServer/BaseHttpServer.cs
@@ -1504,7 +1504,7 @@ namespace OpenSim.Framework.Servers.HttpServer
 
                 // We want this exception to halt the entire server since in current configurations we aren't too
                 // useful without inbound HTTP.
-                throw e;
+                throw;
             }
         }
 

--- a/OpenSim/Framework/Statistics/SimExtraStatsCollector.cs
+++ b/OpenSim/Framework/Statistics/SimExtraStatsCollector.cs
@@ -411,7 +411,7 @@ Average Asset Write Request Latency: {1} ms
             args["Uptime"] = OSD.FromString(uptime);
             args["Version"] = OSD.FromString(version);
             
-            string strBuffer = "";
+            string strBuffer = String.Empty;
             strBuffer = OSDParser.SerializeJsonString(args);
 
             return strBuffer;
@@ -468,7 +468,7 @@ Average Asset Write Request Latency: {1} ms
         
         public string XReport(string uptime, string version)
         {
-            return "";
+            return String.Empty;
         }
     }
 }

--- a/OpenSim/Framework/Telehub.cs
+++ b/OpenSim/Framework/Telehub.cs
@@ -41,7 +41,7 @@ namespace OpenSim.Framework
         /// <summary>
         ///     Name of the teleHUB object
         /// </summary>
-        public string Name = "";
+        public string Name = String.Empty;
 
         /// <summary>
         ///     UUID of the teleHUB object
@@ -70,14 +70,14 @@ namespace OpenSim.Framework
 
         public string BuildFromList(List<Vector3> SpawnPos)
         {
-            return SpawnPos.Aggregate("", (current, Pos) => current + (Pos.ToString() + "\n"));
+            return SpawnPos.Aggregate(String.Empty, (current, Pos) => current + (Pos.ToString() + "\n"));
         }
 
         public static List<Vector3> BuildToList(string SpawnPos)
         {
-            if (SpawnPos == "" || SpawnPos == " ")
+            if (String.IsNullOrWhiteSpace(SpawnPos))
                 return new List<Vector3>();
-            return (from Pos in SpawnPos.Split('\n') where Pos != "" select Vector3.Parse(Pos)).ToList();
+            return (from Pos in SpawnPos.Split('\n') where Pos != String.Empty select Vector3.Parse(Pos)).ToList();
         }
     }
 }

--- a/OpenSim/Framework/Telehub.cs
+++ b/OpenSim/Framework/Telehub.cs
@@ -77,7 +77,7 @@ namespace OpenSim.Framework
         {
             if (String.IsNullOrWhiteSpace(SpawnPos))
                 return new List<Vector3>();
-            return (from Pos in SpawnPos.Split('\n') where Pos != String.Empty select Vector3.Parse(Pos)).ToList();
+            return (from Pos in SpawnPos.Split('\n') where !String.IsNullOrEmpty(Pos) select Vector3.Parse(Pos)).ToList();
         }
     }
 }

--- a/OpenSim/Framework/UserConfig.cs
+++ b/OpenSim/Framework/UserConfig.cs
@@ -46,7 +46,7 @@ namespace OpenSim.Framework
         public uint HttpPort = ConfigSettings.DefaultUserServerHttpPort;
         public bool HttpSSL = ConfigSettings.DefaultUserServerHttpSSL;
         public uint DefaultUserLevel = 0;
-        public string LibraryXmlfile = "";
+        public string LibraryXmlfile = String.Empty;
 
         private Uri m_inventoryUrl;
 
@@ -130,7 +130,7 @@ namespace OpenSim.Framework
             m_configMember.addConfigurationOption("database_provider", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
                                                 "DLL for database provider", "OpenSim.Data.MySQL.dll", false);
             m_configMember.addConfigurationOption("database_connect", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
-                                                "Connection String for Database", "", false);
+                                                "Connection String for Database", String.Empty, false);
 
             m_configMember.addConfigurationOption("http_port", ConfigurationOption.ConfigurationTypes.TYPE_UINT32,
                                                 "Http Listener port", ConfigSettings.DefaultUserServerHttpPort.ToString(), false);
@@ -141,7 +141,7 @@ namespace OpenSim.Framework
             m_configMember.addConfigurationOption("default_Y", ConfigurationOption.ConfigurationTypes.TYPE_UINT32,
                                                 "Known good region Y", "1000", false);
             m_configMember.addConfigurationOption("map_server_uri", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
-                                                "Map server URI?", "", false);
+                                                "Map server URI?", String.Empty, false);
 
             m_configMember.addConfigurationOption("enable_hg_login", ConfigurationOption.ConfigurationTypes.TYPE_BOOLEAN,
                     "Enable Hypergrid login support [Currently used by GridSurfer-proxied clients]? true/false", true.ToString(), false);

--- a/OpenSim/Framework/Util.cs
+++ b/OpenSim/Framework/Util.cs
@@ -1541,8 +1541,8 @@ namespace OpenSim.Framework
 
         public static string ServerURI(string uri)
         {
-            if (uri == string.Empty)
-                return string.Empty;
+            if (uri == String.Empty)
+                return String.Empty;
 
             // Get rid of eventual slashes at the end
             uri = uri.TrimEnd('/');

--- a/OpenSim/Framework/Util.cs
+++ b/OpenSim/Framework/Util.cs
@@ -1568,7 +1568,7 @@ namespace OpenSim.Framework
         public static string XmlRpcRequestPrefix(string methodName)
         {
             string prefix = "/xmlrpc";
-            if ((methodName != null) && (methodName != String.Empty))
+            if (!String.IsNullOrEmpty(methodName))
                 prefix += ("/" + methodName);
             return (prefix);
         }

--- a/OpenSim/Framework/Util.cs
+++ b/OpenSim/Framework/Util.cs
@@ -1033,7 +1033,7 @@ namespace OpenSim.Framework
             }
             catch (Exception)
             {
-                return "";
+                return String.Empty;
             }
         }
 
@@ -1500,7 +1500,7 @@ namespace OpenSim.Framework
             // Glob
 
             path = vol;
-            if (vol != String.Empty)
+            if (!String.IsNullOrEmpty(vol))
                 path += new String(new char[] { Path.VolumeSeparatorChar, Path.DirectorySeparatorChar });
             else
                 path = new String(new char[] { Path.DirectorySeparatorChar });
@@ -1548,7 +1548,7 @@ namespace OpenSim.Framework
             uri = uri.TrimEnd('/');
 
             IPAddress ipaddr1 = null;
-            string port1 = "";
+            string port1 = String.Empty;
             try
             {
                 ipaddr1 = Util.GetHostFromURL(uri);
@@ -1568,7 +1568,7 @@ namespace OpenSim.Framework
         public static string XmlRpcRequestPrefix(string methodName)
         {
             string prefix = "/xmlrpc";
-            if ((methodName != null) && (methodName != ""))
+            if ((methodName != null) && (methodName != String.Empty))
                 prefix += ("/" + methodName);
             return (prefix);
         }
@@ -2142,7 +2142,7 @@ namespace OpenSim.Framework
             int y = (int)pos.Y;
             int z = (int)pos.Z;
             string region;
-            if (regionName == String.Empty)
+            if (String.IsNullOrEmpty(regionName))
             {
                 region = String.Empty;
                 return x.ToString() + separator + y.ToString() + separator + z.ToString();

--- a/OpenSim/Framework/Util.cs
+++ b/OpenSim/Framework/Util.cs
@@ -742,7 +742,7 @@ namespace OpenSim.Framework
                 m_log.WarnFormat("[UTIL]: An error occurred while resolving host name {0}, {1}", dnsAddress, e);
 
                 // Still going to throw the exception on for now, since this was what was happening in the first place
-                throw e;
+                throw;
             }
 
             foreach (IPAddress host in hosts)
@@ -2221,7 +2221,7 @@ namespace OpenSim.Framework
                     if (i == retryCount)
                     {
                         //cant retry anymore. rethrow
-                        throw e;
+                        throw;
                     }
 
                     if (passthroughExceptions != null)
@@ -2263,7 +2263,7 @@ namespace OpenSim.Framework
                     if (i == retryCount)
                     {
                         //cant retry anymore. rethrow
-                        throw e;
+                        throw;
                     }
 
                     if (passthroughExceptions != null)

--- a/OpenSim/Grid/GridServer.Modules/GridXmlRpcModule.cs
+++ b/OpenSim/Grid/GridServer.Modules/GridXmlRpcModule.cs
@@ -602,7 +602,7 @@ namespace OpenSim.Grid.GridServer.Modules
                 //TheSim = GetRegion(new UUID((string) requestData["UUID"]));
                 uuid = requestData["UUID"].ToString();
                 m_log.InfoFormat("[LOGOUT]: Logging out region: {0}", uuid);
-                //                logToDB((new LLUUID((string)requestData["UUID"])).ToString(),"XmlRpcDeleteRegionMethod","", 5,"Attempting delete with UUID.");
+                //logToDB((new LLUUID((string)requestData["UUID"])).ToString(),"XmlRpcDeleteRegionMethod",String.Empty, 5,"Attempting delete with UUID.");
             }
             else
             {
@@ -612,7 +612,7 @@ namespace OpenSim.Grid.GridServer.Modules
 
             DataResponse insertResponse = m_gridDBService.DeleteRegion(uuid);
 
-            string insertResp = "";
+            string insertResp = String.Empty;
             switch (insertResponse)
             {
                 case DataResponse.RESPONSE_OK:

--- a/OpenSim/Grid/GridServer/GridServerBase.cs
+++ b/OpenSim/Grid/GridServer/GridServerBase.cs
@@ -121,7 +121,7 @@ namespace OpenSim.Grid.GridServer
             {
                 m_log.ErrorFormat("[RADMIN] Shutdown: failed: {0}", e.Message);
                 m_log.DebugFormat("[RADMIN] Shutdown: failed: {0}", e.ToString());
-                throw e;
+                throw;
             }
 
             m_log.Info("[RADMIN]: Shutdown Administrator Request complete");

--- a/OpenSim/Grid/GridServer/Program.cs
+++ b/OpenSim/Grid/GridServer/Program.cs
@@ -30,7 +30,7 @@ using log4net.Config;
 
 namespace OpenSim.Grid.GridServer
 {
-    public class Program
+    public static class Program
     {
         public static void Main(string[] args)
         {

--- a/OpenSim/Grid/MessagingServer.Modules/MessageService.cs
+++ b/OpenSim/Grid/MessagingServer.Modules/MessageService.cs
@@ -545,7 +545,7 @@ namespace OpenSim.Grid.MessagingServer.Modules
             }
             catch(Exception e) {
                 m_log.Error("[PRESENCE]: Got exception:", e);
-                throw e;
+                throw;
             }
         }
 

--- a/OpenSim/Grid/MessagingServer/Main.cs
+++ b/OpenSim/Grid/MessagingServer/Main.cs
@@ -165,7 +165,7 @@ namespace OpenSim.Grid.MessagingServer
             {
                 m_log.ErrorFormat("[RADMIN] Shutdown: failed: {0}", e.Message);
                 m_log.DebugFormat("[RADMIN] Shutdown: failed: {0}", e.ToString());
-                throw e;
+                throw;
             }
 
             m_log.Info("[RADMIN]: Shutdown Administrator Request complete");

--- a/OpenSim/Grid/UserServer.Modules/UserManager.cs
+++ b/OpenSim/Grid/UserServer.Modules/UserManager.cs
@@ -195,7 +195,7 @@ namespace OpenSim.Grid.UserServer.Modules
             // any Unicode character, excluding the surrogate blocks, FFFE, and FFFF.
             // string re = @"[^\x09\x0A\x0D\x20-\xD7FF\xE000-\xFFFD\x10000-x10FFFF]";
             string re = @"[^a-zA-Z0-9\s\p{P}]";
-            return Regex.Replace(text, re, "");
+            return Regex.Replace(text, re, String.Empty);
         }
 
         /// <summary>

--- a/OpenSim/Grid/UserServer/Main.cs
+++ b/OpenSim/Grid/UserServer/Main.cs
@@ -281,7 +281,7 @@ namespace OpenSim.Grid.UserServer
             {
                 m_log.ErrorFormat("[RADMIN] Shutdown: failed: {0}", e.Message);
                 m_log.DebugFormat("[RADMIN] Shutdown: failed: {0}", e.ToString());
-                throw e;
+                throw;
             }
 
             m_log.Info("[RADMIN]: Shutdown Administrator Request complete");

--- a/OpenSim/Grid/UserServer/UserServerCommandModule.cs
+++ b/OpenSim/Grid/UserServer/UserServerCommandModule.cs
@@ -203,7 +203,7 @@ namespace OpenSim.Grid.UserServer
             else regY = Convert.ToUInt32(cmdparams[5]);
 
             if (cmdparams.Length < 7)
-                email = MainConsole.Instance.CmdPrompt("Email", "");
+                email = MainConsole.Instance.CmdPrompt("Email", String.Empty);
             else email = cmdparams[6];
 
             if (null == m_userDataBaseService.GetUserProfile(firstName, lastName))
@@ -290,7 +290,7 @@ namespace OpenSim.Grid.UserServer
                     UserLoginService loginService;
                     if (m_core.TryGet<UserLoginService>(out loginService))
                     {
-                        string filename = cmdparams.Length > 1 ? cmdparams[1] : "";
+                        string filename = cmdparams.Length > 1 ? cmdparams[1] : String.Empty;
                         m_loginService = loginService;
                         m_loginService.LoadDefaultRegionsFromFile(filename);
                     }
@@ -300,7 +300,7 @@ namespace OpenSim.Grid.UserServer
                     UserLoginService loginService;
                     if (m_core.TryGet<UserLoginService>(out loginService))
                     {
-                        string filename = cmdparams.Length > 1 ? cmdparams[1] : "";
+                        string filename = cmdparams.Length > 1 ? cmdparams[1] : String.Empty;
                         m_loginService = loginService;
                         m_loginService.LoadDefaultLoginsFromFile(filename);
                     }
@@ -341,7 +341,7 @@ namespace OpenSim.Grid.UserServer
                     {
                         string firstname = cmdparams[0];
                         string lastname = cmdparams[1];
-                        string message = "";
+                        string message = String.Empty;
 
                         for (int i = 2; i < cmdparams.Length; i++)
                             message += " " + cmdparams[i];

--- a/OpenSim/Region/ClientStack/ClientStackManager.cs
+++ b/OpenSim/Region/ClientStack/ClientStackManager.cs
@@ -54,9 +54,7 @@ namespace OpenSim.Region.ClientStack
                 {
                     if (pluginType.IsPublic)
                     {
-                        Type typeInterface = pluginType.GetInterface("IClientNetworkServer", true);
-
-                        if (typeInterface != null)
+                        if (typeof(IClientNetworkServer).IsAssignableFrom(pluginType))
                         {
                             m_log.Info("[CLIENTSTACK]: Added IClientNetworkServer Interface");
                             plugin = pluginType;

--- a/OpenSim/Region/ClientStack/ClientStackManager.cs
+++ b/OpenSim/Region/ClientStack/ClientStackManager.cs
@@ -62,13 +62,14 @@ namespace OpenSim.Region.ClientStack
                         }
                     }
                 }
-            } catch (ReflectionTypeLoadException e)
+            }
+            catch (ReflectionTypeLoadException e)
             {
                 foreach (Exception e2 in e.LoaderExceptions)
                 {
                     m_log.Error(e2.ToString());
                 }
-                throw e;
+                throw;
             }
         }
         

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -12297,7 +12297,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 default:
                     break;
             }
-            return string.Empty;
+            return String.Empty;
         }
 
         public void SendDirPlacesReply(UUID queryID, DirPlacesReplyData[] data)

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -303,7 +303,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
 
         private bool m_frozenUser = false;
         private UUID m_frozenBy = UUID.Zero;
-        private string m_frozenByName = "";
+        private string m_frozenByName = String.Empty;
 
         protected uint m_agentFOVCounter;
 
@@ -4260,7 +4260,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             updateMessage.AuctionID = landData.AuctionID;
             updateMessage.AuthBuyerID = landData.AuthBuyerID;
             updateMessage.Bitmap = landData.Bitmap;
-            updateMessage.Desc = Util.TruncateString(landData.Description == null ? "" : landData.Description, 254);
+            updateMessage.Desc = Util.TruncateString(landData.Description == null ? String.Empty : landData.Description, 254);
             updateMessage.Category = landData.Category;
             updateMessage.ClaimDate = Util.UnixToLocalDateTime(landData.ClaimDate);
             updateMessage.ClaimPrice = landData.ClaimPrice;
@@ -8446,7 +8446,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             }
             else
             {
-                SendUserInfoReply(false, true, "");
+                SendUserInfoReply(false, true, String.Empty);
             }
             return true;
 
@@ -11069,8 +11069,8 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                     {
                         UUID invoice = messagePacket.MethodData.Invoice;
                         UUID sessionID = messagePacket.AgentData.SessionID;
-                        string Message = "";
-                        string SenderName = "";
+                        string Message = String.Empty;
+                        string SenderName = String.Empty;
                         UUID SenderID = UUID.Zero;
                         if (messagePacket.ParamList.Length < 5)
                         {
@@ -11125,7 +11125,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                         handlerLandStatRequest = OnLandStatRequest;
                         if (handlerLandStatRequest != null)
                         {
-                            handlerLandStatRequest(0, 1, 0, "", this);
+                            handlerLandStatRequest(0, 1, 0, String.Empty, this);
                         }
                     }
                     return true;
@@ -11135,7 +11135,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                         handlerLandStatRequest = OnLandStatRequest;
                         if (handlerLandStatRequest != null)
                         {
-                            handlerLandStatRequest(0, 0, 0, "", this);
+                            handlerLandStatRequest(0, 0, 0, String.Empty, this);
                         }
                     }
                     return true;
@@ -12240,7 +12240,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             reply.Data.OwnerID = land.OwnerID;
             reply.Data.Name = Utils.StringToBytes(land.Name);
             // Viewer has an off-by-one overflow/corruption problem if you send 255 characters.
-            string viewerDesc = Util.TruncateString(land.Description == null ? "" : land.Description, 254);
+            string viewerDesc = Util.TruncateString(land.Description == null ? String.Empty : land.Description, 254);
             reply.Data.Desc = Utils.StringToBytes(viewerDesc);
             reply.Data.ActualArea = land.Area;
             reply.Data.BillableArea = land.Area; // TODO: what is this?
@@ -13125,7 +13125,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 } else {
                     SendAgentAlertMessage(whoName + " has unfrozen you. You are free to move and interact again.",true);
                     m_frozenBy = UUID.Zero;
-                    m_frozenByName = "";
+                    m_frozenByName = String.Empty;
                     m_log.WarnFormat("{0} has unfrozen {1} [{2}].", this.Name, whoName, whoKey);
                 }
             }
@@ -13133,12 +13133,12 @@ namespace OpenSim.Region.ClientStack.LindenUDP
 
         public string Report()
         {
-            return "";
+            return String.Empty;
         }
         
         public string XReport(string uptime, string version) 
         {
-            return  "";
+            return  String.Empty;
         }
 
         #region IClientIPEndpoint Members

--- a/OpenSim/Region/ClientStack/LindenUDP/LLUDPServer.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLUDPServer.cs
@@ -553,7 +553,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                     OutgoingPacket outgoingPacket = packetList[i];
 
                     /*m_log.DebugFormat("[LLUDPSERVER]: {0} Resending packet #{1} (attempt {2}), {3}ms have passed",
-                        (expiredPackets.Key & UnackedPacketCollection.ResendReason.FastRetransmit) != 0 ? "(Fast)" : "",
+                        (expiredPackets.Key & UnackedPacketCollection.ResendReason.FastRetransmit) != 0 ? "(Fast)" : String.Empty,
                         outgoingPacket.SequenceNumber, outgoingPacket.ResendCount, Environment.TickCount - outgoingPacket.TickCount);
                     */
 
@@ -574,7 +574,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 if (packetList.Count != 0)
                 {
                     m_log.DebugFormat("[LLUDPSERVER]: {0} Resent {1} packet(s) for {2}",
-                        (expiredPackets.Key & UnackedPacketCollection.ResendReason.FastRetransmit) != 0 ? "(Fast)" : "",
+                        (expiredPackets.Key & UnackedPacketCollection.ResendReason.FastRetransmit) != 0 ? "(Fast)" : String.Empty,
                         packetList.Count, udpClient.AgentID);
                 }*/
             }
@@ -881,7 +881,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
         // Number of seconds to log for
         static TimeSpan binStatsMaxFilesize = TimeSpan.FromSeconds(300);
         static object binStatsLogLock = new object();
-        static string binStatsDir = "";
+        static string binStatsDir = String.Empty;
 
         public static void LogPacketHeader(bool incoming, uint circuit, byte flags, PacketType packetType, ushort size)
         {
@@ -917,7 +917,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                         // First log file or time has expired, start writing to a new log file
                         PacketLog = new PacketLogger();
                         PacketLog.StartTime = now;
-                        PacketLog.Path = (binStatsDir.Length > 0 ? binStatsDir + System.IO.Path.DirectorySeparatorChar.ToString() : "")
+                        PacketLog.Path = (binStatsDir.Length > 0 ? binStatsDir + System.IO.Path.DirectorySeparatorChar.ToString() : String.Empty)
                                 + String.Format("packets-{0}.log", now.ToString("yyyyMMddHHmmss"));
                         PacketLog.Log = new BinaryWriter(File.Open(PacketLog.Path, FileMode.Append, FileAccess.Write));
                     }

--- a/OpenSim/Region/Communications/Local/LocalUserServices.cs
+++ b/OpenSim/Region/Communications/Local/LocalUserServices.cs
@@ -68,7 +68,7 @@ namespace OpenSim.Region.Communications.Local
             }
 
             m_log.Debug("Unknown Master User. Sandbox Mode: Creating Account");
-            AddUser(firstName, lastName, password, "", m_defaultHomeX, m_defaultHomeY);
+            AddUser(firstName, lastName, password, String.Empty, m_defaultHomeX, m_defaultHomeY);
             return GetUserProfile(firstName, lastName);
         }
 

--- a/OpenSim/Region/Communications/OGS1/OGS1GridServices.cs
+++ b/OpenSim/Region/Communications/OGS1/OGS1GridServices.cs
@@ -618,7 +618,7 @@ namespace OpenSim.Region.Communications.OGS1
                     return null;
                 }
 
-                regionInfo = buildRegionInfo(responseData, "");
+                regionInfo = buildRegionInfo(responseData, String.Empty);
 
                 if (m_useRemoteRegionCache)
                 {

--- a/OpenSim/Region/Communications/OGS1/OGS1UserDataPlugin.cs
+++ b/OpenSim/Region/Communications/OGS1/OGS1UserDataPlugin.cs
@@ -1108,9 +1108,9 @@ namespace OpenSim.Region.Communications.OGS1
             if (data.Contains("custom_type"))
                 userData.CustomType = (string)data["custom_type"];
             else
-                userData.CustomType = "";
+                userData.CustomType = String.Empty;
             if (userData.CustomType == null)
-                userData.CustomType = "";
+                userData.CustomType = String.Empty;
 
             if (data.Contains("partner"))
                 userData.Partner = new UUID((string)data["partner"]);
@@ -1119,9 +1119,9 @@ namespace OpenSim.Region.Communications.OGS1
 
             if (data.Contains("profileURL"))
                 userData.ProfileURL = (string)data["profileURL"];
-            else userData.ProfileURL = "";
+            else userData.ProfileURL = String.Empty;
             if (userData.ProfileURL == null)
-                userData.ProfileURL = "";
+                userData.ProfileURL = String.Empty;
 
             return userData;
         }            

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
@@ -313,7 +313,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
             int x = (int)Math.Floor(posx);
             int y = (int)Math.Floor(posy);
             int z = (int)Math.Floor(posz);
-            string prefix = includePrefix ? "http://places.inworldz.com/" : "";
+            string prefix = includePrefix ? "http://places.inworldz.com/" : String.Empty;
 
             return prefix + Util.EscapeUriDataStringRfc3986(m_scene.RegionInfo.RegionName) + "/" + x.ToString() + "/" + y.ToString() + "/" + z.ToString();
         }
@@ -332,7 +332,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
                 return;
 
             // check if destination is an avatar
-            if (m_scene.CommsManager.UserService.Key2Name(destId, false) != String.Empty)
+            if (!String.IsNullOrEmpty(m_scene.CommsManager.UserService.Key2Name(destId, false)))
             {
                 if (m_scene.GetScenePresence(destId) == null || m_scene.GetScenePresence(destId).IsChildAgent)
                     return;//Only allow giving items to users in the sim
@@ -399,7 +399,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
 
         public string ActiveGroupName
         {
-            get { return ""; }
+            get { return String.Empty; }
         }
 
         public ulong ActiveGroupPowers
@@ -973,7 +973,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
             agentData.AgentID = AgentId;
             // agentData.Appearance
             // agentData.BaseFolder
-            agentData.CapsPath = "";
+            agentData.CapsPath = String.Empty;
             agentData.child = false;
             agentData.CircuitCode = m_circuitCode;
             agentData.ClientVersion = "Bot";
@@ -1371,7 +1371,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
 
         public string GetClientOption(string option)
         {
-            return "";
+            return String.Empty;
         }
 
         public void SendSetFollowCamProperties(OpenMetaverse.UUID objectID, Dictionary<int, float> parameters)

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
@@ -142,7 +142,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
 
                 AvatarAppearance appearance;
                 UUID originalOwner = UUID.Zero;
-                string ownerName = "";
+                string ownerName = String.Empty;
                 bool isSavedOutfit = !string.IsNullOrEmpty(outfitName);
 
                 if (!isSavedOutfit)
@@ -157,7 +157,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
                             return UUID.Zero;
                         }
                         ownerName = m_scene.CommsManager.UserService.Key2Name(owner,false);
-                        if (ownerName == String.Empty)
+                        if (String.IsNullOrEmpty(ownerName))
                         {
                             reason = "Owner could not be found.";
                             return UUID.Zero;
@@ -185,7 +185,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
                         return UUID.Zero;
                     }
                     ownerName = m_scene.CommsManager.UserService.Key2Name(owner, false);
-                    if (ownerName == String.Empty)
+                    if (String.IsNullOrEmpty(ownerName))
                     {
                         reason = "Owner could not be found.";
                         return UUID.Zero;
@@ -213,7 +213,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
                     BaseFolder = UUID.Zero,
                     child = false,
                     CircuitCode = client.CircuitCode,
-                    ClientVersion = "",
+                    ClientVersion = String.Empty,
                     FirstName = client.FirstName,
                     InventoryFolder = UUID.Zero,
                     LastName = client.LastName,
@@ -237,14 +237,14 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
                         AboutText = defaultAbout,
                         Created = Util.ToUnixTime(client.TimeCreated),
                         CustomType = "Bot",
-                        Email = "",
+                        Email = String.Empty,
                         FirstLifeAboutText = defaultAbout,
                         FirstLifeImage = UUID.Zero,
                         FirstName = client.FirstName,
                         GodLevel = 0,
                         ID = client.AgentID,
                         Image = UUID.Zero,
-                        ProfileURL = "",
+                        ProfileURL = String.Empty,
                         SurName = client.LastName,
                     });
 
@@ -411,7 +411,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
         {
             IBot bot;
             if ((bot = GetBot(botID)) == null)
-                return "";
+                return String.Empty;
 
             return bot.Name;
         }

--- a/OpenSim/Region/CoreModules/Agent/TextureSender/J2KDecoderFileCache.cs
+++ b/OpenSim/Region/CoreModules/Agent/TextureSender/J2KDecoderFileCache.cs
@@ -100,7 +100,7 @@ namespace OpenSim.Region.CoreModules.Agent.TextureSender
                             for (int i = 0; i < Layers.Length; i++)
                             {
                                 if (i == (Layers.Length - 1))
-                                    strEnd = "";
+                                    strEnd = String.Empty;
 
                                 stringResult.AppendFormat("{0}|{1}|{2}{3}", Layers[i].Start, Layers[i].End, Layers[i].End - Layers[i].Start, strEnd);
                             }

--- a/OpenSim/Region/CoreModules/Agent/TextureSender/J2KDecoderFileCache.cs
+++ b/OpenSim/Region/CoreModules/Agent/TextureSender/J2KDecoderFileCache.cs
@@ -138,7 +138,7 @@ namespace OpenSim.Region.CoreModules.Agent.TextureSender
             if ((File.Exists(filename) == false) || (enabled == false))
                 return false;
 
-            string readResult = string.Empty;
+            string readResult = String.Empty;
 
             try
             {

--- a/OpenSim/Region/CoreModules/Avatar/Chat/ChatModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Chat/ChatModule.cs
@@ -389,7 +389,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
         {
             List<SceneObjectGroup> results = new List<SceneObjectGroup>();
 
-            string target = "";
+            string target = String.Empty;
             UUID targetID;
             if (!UUID.TryParse(name, out targetID))
             {
@@ -633,7 +633,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
 
         private void ShowUpdates(IClientAPI client, string[] args)
         {
-            string[] inArgs = { "", args[2] };
+            string[] inArgs = { String.Empty, args[2] };
             foreach (Scene scene in m_scenes)
             {
                 string output = scene.GetTopUpdatesOutput(inArgs);

--- a/OpenSim/Region/CoreModules/Avatar/Combat/CombatModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Combat/CombatModule.cs
@@ -94,7 +94,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Combat.CombatModule
             else
             {
                 bool foundResult = false;
-                string resultstring = "";
+                string resultstring = String.Empty;
                 List<ScenePresence> allav = DeadAvatar.Scene.GetScenePresences();
                 try
                 {

--- a/OpenSim/Region/CoreModules/Avatar/Currency/AvatarCurrency.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Currency/AvatarCurrency.cs
@@ -478,7 +478,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Currency
         // Send a pure balance notification only.
         private void SendMoneyBalance(IClientAPI client)
         {
-            SendMoneyBalanceTransaction(client, UUID.Zero, true, string.Empty, null);
+            SendMoneyBalanceTransaction(client, UUID.Zero, true, String.Empty, null);
         }
 
         public bool ObjectGiveMoney(UUID objectID, UUID sourceAvatarID, UUID destAvatarID, int amount)

--- a/OpenSim/Region/CoreModules/Avatar/Currency/AvatarCurrency.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Currency/AvatarCurrency.cs
@@ -255,7 +255,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Currency
                 transInfo.ItemDescription = Util.StringToBytes256(transDesc);
 
                 string message;
-                if ((transDesc == null) || (transDesc == String.Empty))
+                if (String.IsNullOrEmpty(transDesc))
                     message = "You paid $" + transAmount.ToString() + ".";
                 else
                     message = "You paid $" + transAmount.ToString() + " for " + transDesc + ".";
@@ -616,8 +616,8 @@ namespace OpenSim.Region.CoreModules.Avatar.Currency
             int transAmount = e.amount;
             IClientAPI sourceAvatarClient;
             IClientAPI destAvatarClient;
-            string sourceText = "";
-            string destText = "";
+            string sourceText = String.Empty;
+            string destText = String.Empty;
 
             TransactionInfoBlock transInfo = new TransactionInfoBlock();
             transInfo.Amount = transAmount;
@@ -738,7 +738,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Currency
                 int avatarFunds = getCurrentBalance(e.mBuyerID);
                 if (avatarFunds < costToApply)
                 {
-                    string costText = "";
+                    string costText = String.Empty;
                     if (e.mOrigPrice != 0) // this is an updated classified
                         costText = "increase ";
                     remoteClient.SendAgentAlertMessage("The classified price " + costText + " (I'z$" + costToApply.ToString() + ") exceeds your current balance (" + avatarFunds.ToString() + ").", true);
@@ -841,7 +841,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Currency
                 // we'll let them test the buy, but nothing happens money wise.
                 if (!s.PerformObjectBuy(remoteClient, categoryID, localID, saleType))
                     return;
-                sourceAvatarClient.SendBlueBoxMessage(agentID, "", sourceAlertText);
+                sourceAvatarClient.SendBlueBoxMessage(agentID, String.Empty, sourceAlertText);
             }
             else
             {
@@ -960,14 +960,14 @@ namespace OpenSim.Region.CoreModules.Avatar.Currency
             if (sourceClient != null)
             {
                 string destName = resolveAgentName(destClientID);
-                if (destName == String.Empty) destName = "a group (or unknown user)";
+                if (String.IsNullOrEmpty(destName)) destName = "a group (or unknown user)";
                 string sourceText = "You paid Iz$" + transAmount + " to " + destName + " for a parcel of land.";
                 SendMoneyBalanceTransaction(sourceClient, transID, true, sourceText, transInfo);
             }
             if (destClient != null)
             {
                 string destName = resolveAgentName(sourceClientID);
-                if (destName == String.Empty) destName = "a group (or unknown user)";
+                if (String.IsNullOrEmpty(destName)) destName = "a group (or unknown user)";
                 string destText = "You were paid Iz$" + transAmount + " by " + destName + " for a parcel of land.";
                 SendMoneyBalanceTransaction(destClient, transID, true, destText, transInfo);
             }
@@ -1036,7 +1036,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Currency
             // try avatar username surname
             Scene scene = GetRandomScene();
             string name = scene.CommsManager.UserService.Key2Name(agentID,false);
-            if (name == String.Empty)
+            if (String.IsNullOrEmpty(name))
                 m_log.ErrorFormat("[MONEY]: Could not resolve user {0}", agentID);
 
             return name;
@@ -1107,7 +1107,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Currency
 
 /*
 +class MoneyTransactionType(object):
-+    """ Money transaction type constants """
++    String.Empty" Money transaction type constants String.Empty"
 +
 +    Null                   = 0
 +

--- a/OpenSim/Region/CoreModules/Avatar/Dialog/DialogModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Dialog/DialogModule.cs
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using log4net;

--- a/OpenSim/Region/CoreModules/Avatar/Dialog/DialogModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Dialog/DialogModule.cs
@@ -223,7 +223,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Dialog
 
         private string CombineParams(string[] commandParams, int pos)
         {
-            string result = string.Empty;
+            string result = String.Empty;
             for (int i = pos; i < commandParams.Length; i++)
             {
                 result += commandParams[i] + " ";

--- a/OpenSim/Region/CoreModules/Avatar/Friends/FriendsModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Friends/FriendsModule.cs
@@ -504,7 +504,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
         public void OfferFriendship(UUID fromUserId, IClientAPI toUserClient, string offerMessage)
         {
             string name = m_initialScene.CommsManager.UserService.Key2Name(fromUserId,false);
-            if (name != String.Empty)
+            if (!String.IsNullOrEmpty(name))
             {
                 GridInstantMessage msg = new GridInstantMessage(
                     toUserClient.Scene, fromUserId, name, toUserClient.AgentId,
@@ -564,7 +564,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
 
             // 1.20 protocol sends an UUID in the message field, instead of the friendship offer text.
             // For interoperability, we have to clear that
-            if (Util.isUUID(im.message)) im.message = "";
+            if (Util.isUUID(im.message)) im.message = String.Empty;
 
             // be sneeky and use the initiator-UUID as transactionID. This means we can be stateless.
             // we have to look up the agent name on friendship-approval, though.
@@ -733,7 +733,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
                 string name = m_initialScene.CommsManager.UserService.Key2Name(friendID,false);
 
                 // create calling card
-                if (name != String.Empty)
+                if (!String.IsNullOrEmpty(name))
                     CreateCallingCard(client, friendID, callingCardFolders[0], name);
 
                 // Compose (remote) response to friend.
@@ -860,7 +860,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
             item.CreationDate = Util.UnixTimeSinceEpoch();
             item.CreatorId = creator.ToString();
             item.CurrentPermissions = item.BasePermissions;
-            item.Description = "";
+            item.Description = String.Empty;
             item.EveryOnePermissions = (uint)PermissionMask.None;
             item.Flags = 0;
             item.Folder = folder;

--- a/OpenSim/Region/CoreModules/Avatar/InstantMessage/InstantMessageModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/InstantMessage/InstantMessageModule.cs
@@ -126,8 +126,8 @@ namespace OpenSim.Region.CoreModules.Avatar.InstantMessage
 
             if (m_TransferModule != null)
             {
-                if (client != null && client.FirstName != null && client.FirstName != string.Empty
-                    && client.LastName != null && client.LastName != string.Empty)
+                if (client != null && client.FirstName != null && client.FirstName != String.Empty
+                    && client.LastName != null && client.LastName != String.Empty)
                 {
                     im.fromAgentName = client.Name;
                 }

--- a/OpenSim/Region/CoreModules/Avatar/InstantMessage/InstantMessageModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/InstantMessage/InstantMessageModule.cs
@@ -24,6 +24,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using log4net;

--- a/OpenSim/Region/CoreModules/Avatar/InstantMessage/MessageTransferModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/InstantMessage/MessageTransferModule.cs
@@ -226,8 +226,8 @@ namespace OpenSim.Region.CoreModules.Avatar.InstantMessage
                 UUID toAgentID = UUID.Zero;
                 UUID imSessionID = UUID.Zero;
                 uint timestamp = 0;
-                string fromAgentName = "";
-                string message = "";
+                string fromAgentName = String.Empty;
+                string message = String.Empty;
                 byte dialog = (byte)0;
                 bool fromGroup = false;
                 byte offline = (byte)0;

--- a/OpenSim/Region/CoreModules/Avatar/InstantMessage/MuteListModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/InstantMessage/MuteListModule.cs
@@ -59,7 +59,7 @@ namespace OpenSim.Region.CoreModules.Avatar.MuteList
             public uint m_Flags;
             public MuteListEntry()
             {
-                m_Type = (int)MuteType.AGENT; m_Name = ""; m_Flags = 0;
+                m_Type = (int)MuteType.AGENT; m_Name = String.Empty; m_Flags = 0;
             }
             public MuteListEntry(int type, string name, uint flags)
             {
@@ -303,7 +303,7 @@ namespace OpenSim.Region.CoreModules.Avatar.MuteList
         private byte[] GetMuteListFileData(UUID AgentID)
         {
             Dictionary<UUID, MuteListEntry> MuteList;
-            string data = "";
+            string data = String.Empty;
             int lines = 0;
 
             MuteList = GetMuteList(AgentID);

--- a/OpenSim/Region/CoreModules/Avatar/InstantMessage/OfflineMessageModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/InstantMessage/OfflineMessageModule.cs
@@ -81,8 +81,8 @@ namespace OpenSim.Region.CoreModules.Avatar.InstantMessage
             {
                 if (m_SceneList.Count == 0)
                 {
-                    m_RestURL = cnf.GetString("OfflineMessageURL", "");
-                    if (m_RestURL == "")
+                    m_RestURL = cnf.GetString("OfflineMessageURL", String.Empty);
+                    if (String.IsNullOrEmpty(m_RestURL))
                     {
                         m_log.Error("[OFFLINE MESSAGING]: Module was enabled, but no URL is given, disabling");
                         enabled = false;

--- a/OpenSim/Region/CoreModules/Avatar/Inventory/Archiver/InventoryArchiveReadRequest.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Inventory/Archiver/InventoryArchiveReadRequest.cs
@@ -237,7 +237,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Inventory.Archiver
                             m_log.DebugFormat(
                                 "[INVENTORY ARCHIVER]: Found no previously created fs path for {0}",
                                 originalFsPath);
-                            fsPath = string.Empty;
+                            fsPath = String.Empty;
                             foundFolder = rootDestinationFolder;
                         }
                     }

--- a/OpenSim/Region/CoreModules/Avatar/Profiles/AvatarProfilesModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Profiles/AvatarProfilesModule.cs
@@ -98,7 +98,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Profiles
             if (null != profile)
             {
                 Byte[] charterMember;
-                if (profile.CustomType == "")
+                if (String.IsNullOrEmpty(profile.CustomType))
                 {
                     charterMember = new Byte[1];
                     charterMember[0] = (Byte)((profile.UserFlags & 0xf00) >> 8);

--- a/OpenSim/Region/CoreModules/Avatar/Search/AvatarSearchModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Search/AvatarSearchModule.cs
@@ -836,7 +836,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
                 sqlAddTerms += " AND category=?category";
             }
 
-            if(userText != String.Empty)
+            if(!String.IsNullOrEmpty(userText))
             {
                 sqlAddTerms += " AND (description LIKE ?userText OR name LIKE ?userText)";
             }

--- a/OpenSim/Region/CoreModules/Avatar/Search/AvatarSearchModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Search/AvatarSearchModule.cs
@@ -65,7 +65,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
 
 //        private IConfigSource profileConfig;
         private List<Scene> m_Scenes = new List<Scene>();
-        //private string m_SearchServer = "";
+        //private string m_SearchServer = String.Empty;
         private bool m_Enabled = true;
 
         // NOTE: RDB-related code is all grouped here and is copied in LandManagementModule (for now).
@@ -206,7 +206,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
             Dictionary<string, string> best = null;
             RDBConnectionQuery bestDB = null;
             float bestValue = 0f;
-            string bestText = "";
+            string bestText = String.Empty;
 
             foreach (RDBConnectionQuery rdb in rdbQueries)
             {
@@ -317,7 +317,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
                 // Initialize the RDB connection and initial results lists
 
                 ConnectionFactory rdbFactory;
-                if ((++whichDB == 1) || (_rdbConnectionTemplateDebug.Trim() == String.Empty))
+                if ((++whichDB == 1) || String.IsNullOrWhiteSpace(_rdbConnectionTemplateDebug))
                     rdbFactory = new ConnectionFactory("MySQL", String.Format(_rdbConnectionTemplate, host));
                 else  // Special debugging support for multiple RDBs on one machine ("inworldz_rdb2", etc)
                     rdbFactory = new ConnectionFactory("MySQL", String.Format(_rdbConnectionTemplateDebug, host, whichDB));
@@ -437,7 +437,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
 
             queryText = queryText.Trim();   // newer viewers sometimes append a space
 
-            string query = "";
+            string query = String.Empty;
 
             //string newQueryText = "%" + queryText + "%";
             Dictionary<string, object> parms = new Dictionary<string, object>();
@@ -544,11 +544,11 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
                 int queryStart)
         {
             //m_log.DebugFormat("[LAND SEARCH]: In Land Search, queryFlag = " + queryFlags.ToString("X"));
-            string query = "";
+            string query = String.Empty;
             int count = MAX_RESULTS + 1;    // +1 so that the viewer knows to enable the NEXT button (it seems)
             int queryEnd = queryStart + count - 1;  // 0-based
             int i = 0;
-            string sqlTerms = "";
+            string sqlTerms = String.Empty;
 
             if ((queryFlags & ((uint)DirFindFlags.NameSort|(uint)DirFindFlags.AreaSort|(uint)DirFindFlags.PricesSort|(uint)DirFindFlags.PerMeterSort)) == 0)
             {
@@ -715,7 +715,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
                 data[i].agentID = item.AvatarID;
                 data[i].firstName = item.firstName;
                 data[i].lastName = item.lastName;
-                data[i].group = "";
+                data[i].group = String.Empty;
                 data[i].online = false;
                 data[i].reputation = 0;
                 i++;
@@ -730,9 +730,9 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
             // We also know text comes in 3 segments X|Y|Text where X is the day difference from 
             // the current day, Y is the category to search, Text is the user input for search string
             // so let's 'split up the queryText to get our values we need first off
-            string eventTime = "";
-            string eventCategory = "";
-            string userText = "";
+            string eventTime = String.Empty;
+            string eventCategory = String.Empty;
+            string userText = String.Empty;
 
             queryText = queryText.Trim();   // newer viewers sometimes append a space
 
@@ -748,7 +748,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
             }
 
             // Ok we have values, now we need to do something with all this lovely information
-            string query = "";
+            string query = String.Empty;
             string searchStart = Convert.ToString(queryStart);
             int count = 100;
             DirEventsReplyData[] data = new DirEventsReplyData[count];
@@ -760,7 +760,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
             int unixEventDateToCheckMidnight = 0;
             int unixEventEndDateToCheckMidnight = 0;
 
-            string sqlAddTerms = "";
+            string sqlAddTerms = String.Empty;
 
             DateTime saveNow = DateTime.Now;
             int startDateCheck;
@@ -836,7 +836,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
                 sqlAddTerms += " AND category=?category";
             }
 
-            if(userText != "")
+            if(userText != String.Empty)
             {
                 sqlAddTerms += " AND (description LIKE ?userText OR name LIKE ?userText)";
             }
@@ -844,7 +844,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
             // Events results should come back sorted by date
             sqlAddTerms += " order by dateUTC ASC";
 
-             query = "select owneruuid, name, eventid, dateUTC, eventflags from events" + sqlAddTerms + " limit " + searchStart + ", " + searchEnd + "";
+             query = "select owneruuid, name, eventid, dateUTC, eventflags from events" + sqlAddTerms + " limit " + searchStart + ", " + searchEnd + String.Empty;
 
              Dictionary<string, object> parms = new Dictionary<string, object>();
              parms.Add("?startDateCheck", Convert.ToString(startDateCheck));
@@ -883,8 +883,8 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
                 int queryStart)
         {
             // This is pretty straightforward here, get the input, set up the query, run it through, send back to viewer.
-            string query = "";
-            string sqlAddTerms = "";
+            string query = String.Empty;
+            string sqlAddTerms = String.Empty;
             string userText = queryText.Trim(); // newer viewers sometimes append a space
 
             string searchStart = Convert.ToString(queryStart);
@@ -896,7 +896,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
             //  parcel information is never displayed correctly within in the classified ad.
 
             //stop blank queries here before they explode mysql
-            if (userText == "")
+            if (String.IsNullOrEmpty(userText))
             {
                 remoteClient.SendDirClassifiedReply(queryID, new DirClassifiedReplyData[0]);
                 return;
@@ -922,7 +922,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
              //        "where name LIKE '" + userText + "' OR description LIKE '" + userText + "' " + sqlAddTerms;
 
             query = "select classifieduuid, name, classifiedflags, creationdate, expirationdate, priceforlisting from classifieds " +
-                    "where (description REGEXP ?userText OR name REGEXP ?userText) " +sqlAddTerms + " order by priceforlisting DESC limit " + searchStart + ", " + searchEnd + "";
+                    "where (description REGEXP ?userText OR name REGEXP ?userText) " +sqlAddTerms + " order by priceforlisting DESC limit " + searchStart + ", " + searchEnd + String.Empty;
 
             using (ISimpleDB db = _connFactory.GetConnection())
             {

--- a/OpenSim/Region/CoreModules/Capabilities/AssetCapsModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/AssetCapsModule.cs
@@ -88,7 +88,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
             {
                 m_useAperture = true;
                 m_apPort = startupConfig.GetString("aperture_server_port", "8000");
-                m_apToken = startupConfig.GetString("aperture_server_caps_token", "");
+                m_apToken = startupConfig.GetString("aperture_server_caps_token", String.Empty);
             }
             else
             {
@@ -291,7 +291,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
             {
                 string externalBaseURL = caps.HostName + ":" + m_apPort;
                 string externalURL = caps.CapsHandlers[which].ExternalHandlerURL;
-                string capuuid = externalURL.Replace(externalBaseURL + "/CAPS/HTT/", "");
+                string capuuid = externalURL.Replace(externalBaseURL + "/CAPS/HTT/", String.Empty);
                 UUID capID = UUID.Zero;
 
                 // parse the path and search for the avatar with it registered

--- a/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
@@ -428,7 +428,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                     if ((m_SimulatorFeatures == null) || (m_SimulatorFeatures.MeshEnabled == false))
                     {
                         OSDMap errorResponse = new OSDMap();
-                        errorResponse["uploader"] = "";
+                        errorResponse["uploader"] = String.Empty;
                         errorResponse["state"] = "error";
                         return (errorResponse);
                     }
@@ -451,7 +451,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                         client.SendAgentAlertMessage("Unable to upload asset. Insufficient funds.", false);
 
                     OSDMap errorResponse = new OSDMap();
-                    errorResponse["uploader"] = "";
+                    errorResponse["uploader"] = String.Empty;
                     errorResponse["state"] = "error";
                     return OSDParser.SerializeLLSDXmlString(errorResponse);
                 }
@@ -502,7 +502,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                 catch (Exception)
                 {
                     OSDMap errorResponse = new OSDMap();
-                    errorResponse["uploader"] = "";
+                    errorResponse["uploader"] = String.Empty;
                     errorResponse["state"] = "error";
                     return OSDParser.SerializeLLSDXmlString(errorResponse);
                 }
@@ -650,7 +650,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                 List<UUID> textures = new List<UUID>();
                 for (int i = 0; i < texture_list.Count; i++)
                 {
-                    AssetBase textureAsset = new AssetBase(UUID.Random(), assetName, (sbyte)AssetType.Texture, "");
+                    AssetBase textureAsset = new AssetBase(UUID.Random(), assetName, (sbyte)AssetType.Texture, String.Empty);
                     textureAsset.Data = texture_list[i].AsBinary();
 
                     try
@@ -737,7 +737,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                     }
                     pbs.Textures = textureEntry;
 
-                    AssetBase meshAsset = new AssetBase(UUID.Random(), assetName, (sbyte)AssetType.Mesh, "");
+                    AssetBase meshAsset = new AssetBase(UUID.Random(), assetName, (sbyte)AssetType.Mesh, String.Empty);
                     meshAsset.Data = mesh_data;
 
                     try
@@ -780,7 +780,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                     SceneObjectPart prim = new SceneObjectPart(owner_id, pbs, position, Quaternion.Identity, Vector3.Zero, false);
 
                     prim.Name = assetName;
-                    prim.Description = "";
+                    prim.Description = String.Empty;
 
                     rotations.Add(rotation);
                     positions.Add(position);
@@ -869,7 +869,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                             }
 
                             byte[] ret = this.FetchInventoryDescendentsRequest((string)req.RequestData["body"],
-                                (string)req.RequestData["uri"], "", req.HttpRequest, req.HttpResponse);
+                                (string)req.RequestData["uri"], String.Empty, req.HttpRequest, req.HttpResponse);
 
                             var respData = new Hashtable();
                             respData["response_binary"] = ret;
@@ -1281,7 +1281,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                 Hashtable response = new Hashtable();
                 response["int_response_code"] = 404;
                 response["content_type"] = "text/plain";
-                response["str_response_string"] = "";
+                response["str_response_string"] = String.Empty;
 
                 IClientAPI client = null;
                 m_Scene.TryGetClient(m_Caps.AgentID, out client); 
@@ -1384,7 +1384,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                 Hashtable response = new Hashtable();
                 response["int_response_code"] = 404;
                 response["content_type"] = "text/plain";
-                response["str_response_string"] = ""; 
+                response["str_response_string"] = String.Empty; 
                 
                 OSDMap map = (OSDMap)OSDParser.DeserializeLLSDXml(request);
                 UUID folder_id = map["folder_id"].AsUUID();

--- a/OpenSim/Region/CoreModules/Capabilities/RenderMaterialsModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/RenderMaterialsModule.cs
@@ -156,7 +156,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
 
         private void OnRegisterCaps(UUID agentID, OpenSim.Framework.Communications.Capabilities.Caps caps)
         {
-            string renderCap = CapsUtil.CreateCAPS("RenderMaterials", "");
+            string renderCap = CapsUtil.CreateCAPS("RenderMaterials", String.Empty);
 
             // OpenSimulator CAPs infrastructure seems to be somewhat hostile towards any CAP that requires both GET
             // and POST handlers, so we first set up a POST handler normally and then add a GET/PUT handler via MainServer

--- a/OpenSim/Region/CoreModules/Capabilities/SimulatorFeaturesModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/SimulatorFeaturesModule.cs
@@ -68,8 +68,8 @@ namespace OpenSim.Region.CoreModules.Capabilities
         /// </summary>
         private OSDMap m_features = new OSDMap();
 
-        private string m_MapImageServerURL = string.Empty;
-        private string m_SearchURL = string.Empty;
+        private string m_MapImageServerURL = String.Empty;
+        private string m_SearchURL = String.Empty;
         private bool m_MeshEnabled = true;
         private bool m_PhysicsMaterialsEnabled = true;
         private bool m_DynamicPathfindingEnabled = false;
@@ -84,15 +84,15 @@ namespace OpenSim.Region.CoreModules.Capabilities
             IConfig config = source.Configs["SimulatorFeatures"];
             if (config != null)
             {
-                m_MapImageServerURL = config.GetString("MapImageServerURI", string.Empty);
-                if (m_MapImageServerURL != string.Empty)
+                m_MapImageServerURL = config.GetString("MapImageServerURI", String.Empty);
+                if (m_MapImageServerURL != String.Empty)
                 {
                     m_MapImageServerURL = m_MapImageServerURL.Trim();
                     if (!m_MapImageServerURL.EndsWith("/"))
                         m_MapImageServerURL = m_MapImageServerURL + "/";
                 }
 
-                m_SearchURL = config.GetString("SearchServerURI", string.Empty);
+                m_SearchURL = config.GetString("SearchServerURI", String.Empty);
                 m_MeshEnabled = config.GetBoolean("MeshEnabled", m_MeshEnabled);
                 m_PhysicsMaterialsEnabled = config.GetBoolean("PhysicsMaterialsEnabled", m_MeshEnabled);
                 m_DynamicPathfindingEnabled = config.GetBoolean("DynamicPathfindingEnabled", m_DynamicPathfindingEnabled);
@@ -171,9 +171,9 @@ namespace OpenSim.Region.CoreModules.Capabilities
     
                 // Extra information for viewers that want to use it
                 OSDMap opensimFeatures = new OSDMap();
-                if (m_MapImageServerURL != string.Empty)
+                if (m_MapImageServerURL != String.Empty)
                     opensimFeatures["map-server-url"] = OSD.FromString(m_MapImageServerURL);
-                if (m_SearchURL != string.Empty)
+                if (m_SearchURL != String.Empty)
                     opensimFeatures["search-server-url"] = OSD.FromString(m_SearchURL);
                 opensimFeatures["ExportSupported"] = m_ExportSupported;
                 opensimFeatures["whisper-range"] = m_whisperdistance;

--- a/OpenSim/Region/CoreModules/Plus/PlusModule.cs
+++ b/OpenSim/Region/CoreModules/Plus/PlusModule.cs
@@ -170,7 +170,7 @@ namespace OpenSim.Region.CoreModules.Plus
             int x = (int)Math.Floor(posx);
             int y = (int)Math.Floor(posy);
             int z = (int)Math.Floor(posz);
-            string prefix = includePrefix ? "http://places.inworldz.com/" : "";
+            string prefix = includePrefix ? "http://places.inworldz.com/" : String.Empty;
 
             return prefix + Util.EscapeUriDataStringRfc3986(region) + "/" + x.ToString() + "/" + y.ToString() + "/" + z.ToString();
         }

--- a/OpenSim/Region/CoreModules/Scripting/EMailModules/EmailModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/EMailModules/EmailModule.cs
@@ -278,7 +278,7 @@ namespace OpenSim.Region.CoreModules.Scripting.EmailModules
                 SmtpServer smtpServer=new SmtpServer(SMTP_SERVER_HOSTNAME,SMTP_SERVER_PORT);
                 // Add authentication only when requested
                 //
-                if (SMTP_SERVER_LOGIN != String.Empty && SMTP_SERVER_PASSWORD != String.Empty)
+                if (!(String.IsNullOrEmpty(SMTP_SERVER_LOGIN) || String.IsNullOrEmpty(SMTP_SERVER_PASSWORD)))
                 {
                     //Authentication
                     smtpServer.SmtpAuthToken=new SmtpAuthToken(SMTP_SERVER_LOGIN, SMTP_SERVER_PASSWORD);

--- a/OpenSim/Region/CoreModules/Scripting/EMailModules/EmailModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/EMailModules/EmailModule.cs
@@ -50,12 +50,12 @@ namespace OpenSim.Region.CoreModules.Scripting.EmailModules
         // Module vars
         //
         private IConfigSource m_Config;
-        private string m_HostName = string.Empty;
-        //private string m_RegionName = string.Empty;
-        private string SMTP_SERVER_HOSTNAME = string.Empty;
+        private string m_HostName = String.Empty;
+        //private string m_RegionName = String.Empty;
+        private string SMTP_SERVER_HOSTNAME = String.Empty;
         private int SMTP_SERVER_PORT = 25;
-        private string SMTP_SERVER_LOGIN = string.Empty;
-        private string SMTP_SERVER_PASSWORD = string.Empty;
+        private string SMTP_SERVER_LOGIN = String.Empty;
+        private string SMTP_SERVER_PASSWORD = String.Empty;
 
         private Dictionary<UUID, DateTime> m_LastGetEmailCall = new Dictionary<UUID, DateTime>();
         private TimeSpan m_QueueTimeout = new TimeSpan(2, 0, 0); // 2 hours without llGetNextEmail drops the queue
@@ -186,7 +186,7 @@ namespace OpenSim.Region.CoreModules.Scripting.EmailModules
                     }
                 }
             }
-            ObjectRegionName = string.Empty;
+            ObjectRegionName = String.Empty;
             return null;
         }
 
@@ -226,7 +226,7 @@ namespace OpenSim.Region.CoreModules.Scripting.EmailModules
         public void SendEmail(UUID objectID, string address, string subject, string body)
         {
             //Check if address is empty
-            if (address == string.Empty)
+            if (address == String.Empty)
                 return;
 
             //FIXED:Check the email is correct form in REGEX
@@ -243,9 +243,9 @@ namespace OpenSim.Region.CoreModules.Scripting.EmailModules
                 return;
             }
 
-            string LastObjectName = string.Empty;
-            string LastObjectPosition = string.Empty;
-            string LastObjectRegionName = string.Empty;
+            string LastObjectName = String.Empty;
+            string LastObjectPosition = String.Empty;
+            string LastObjectRegionName = String.Empty;
 
             resolveNamePositionRegionName(objectID, out LastObjectName, out LastObjectPosition, out LastObjectRegionName);
 

--- a/OpenSim/Region/CoreModules/Scripting/EMailModules/GetEmailModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/EMailModules/GetEmailModule.cs
@@ -304,12 +304,12 @@ namespace OpenSim.Region.CoreModules.Scripting.EmailModules
                 Dictionary<string, object> parms = new Dictionary<string, object>();
                 string query = "SELECT * FROM emailmessages WHERE uuid = ?uuid";
                 parms.Add("?uuid", uuid);
-                if (sender != String.Empty)
+                if (!String.IsNullOrEmpty(sender))
                 {
                     query += " AND from = ?from";
                     parms.Add("?from", sender);
                 }
-                if (subject != String.Empty)
+                if (!String.IsNullOrEmpty(subject))
                 {
                     query += " AND subject = ?subject";
                     parms.Add("?subject", subject);

--- a/OpenSim/Region/CoreModules/Scripting/EMailModules/GetEmailModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/EMailModules/GetEmailModule.cs
@@ -58,7 +58,7 @@ namespace OpenSim.Region.CoreModules.Scripting.EmailModules
 
         // Database support
         private ConnectionFactory _connectionFactory;
-        private string _connectString = "";
+        private string _connectString = String.Empty;
         private static long mTicksToEpoch = new DateTime(1970, 1, 1).Ticks;
 
         // Scenes by Region Handle
@@ -121,8 +121,8 @@ namespace OpenSim.Region.CoreModules.Scripting.EmailModules
                 }
 
                 // Database support
-                _connectString = SMTPConfig.GetString("inbound_storage_connection", "");
-                if (_connectString == "")
+                _connectString = SMTPConfig.GetString("inbound_storage_connection", String.Empty);
+                if (String.IsNullOrEmpty(_connectString))
                 {
                     m_log.ErrorFormat("[InboundEmail]: Could not find SMTP inbound_storage_connection.");
                     m_Enabled = false;
@@ -304,12 +304,12 @@ namespace OpenSim.Region.CoreModules.Scripting.EmailModules
                 Dictionary<string, object> parms = new Dictionary<string, object>();
                 string query = "SELECT * FROM emailmessages WHERE uuid = ?uuid";
                 parms.Add("?uuid", uuid);
-                if (sender != "")
+                if (sender != String.Empty)
                 {
                     query += " AND from = ?from";
                     parms.Add("?from", sender);
                 }
-                if (subject != "")
+                if (subject != String.Empty)
                 {
                     query += " AND subject = ?subject";
                     parms.Add("?subject", subject);

--- a/OpenSim/Region/CoreModules/Scripting/HttpRequest/ScriptsHttpRequests.cs
+++ b/OpenSim/Region/CoreModules/Scripting/HttpRequest/ScriptsHttpRequests.cs
@@ -130,8 +130,8 @@ namespace OpenSim.Region.CoreModules.Scripting.HttpRequest
         /// </summary>
         private const int PRIORITY_TIMEOUT_SECS = 600;
 
-        private string m_proxyurl = "";
-        private string m_proxyexcepts = "";
+        private string m_proxyurl = String.Empty;
+        private string m_proxyexcepts = String.Empty;
 
         // <request id, HttpRequestClass>
         private Dictionary<UUID, HttpRequestObject> m_pendingRequests;
@@ -254,7 +254,7 @@ namespace OpenSim.Region.CoreModules.Scripting.HttpRequest
             if (RequestQueueFreeSpacePercentage == 0.0f) return UUID.Zero;
 
             // fast exit for the common case of scripter error passing an empty URL
-            if (url == String.Empty) return UUID.Zero;
+            if (String.IsNullOrEmpty(url)) return UUID.Zero;
 
             if (BlockedByBlacklist(url)) return UUID.Zero;
 
@@ -664,9 +664,9 @@ namespace OpenSim.Region.CoreModules.Scripting.HttpRequest
                 if (config == null)
                     return;
 
-                string hostBlacklist = config.GetString("HostBlacklist", "");
-                string portBlacklist = config.GetString("PortBlacklist", "");
-                string hostnameAndPortBlacklist = config.GetString("HostnameAndPortBlacklist", "");
+                string hostBlacklist = config.GetString("HostBlacklist", String.Empty);
+                string portBlacklist = config.GetString("PortBlacklist", String.Empty);
+                string hostnameAndPortBlacklist = config.GetString("HostnameAndPortBlacklist", String.Empty);
 
                 if (!string.IsNullOrEmpty(hostBlacklist))
                 {

--- a/OpenSim/Region/CoreModules/Scripting/LSLHttp/UrlModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/LSLHttp/UrlModule.cs
@@ -147,7 +147,7 @@ namespace OpenSim.Region.CoreModules.Scripting.LSLHttp
             {
                 if (m_UrlMap.Count >= m_TotalUrls)
                 {
-                    engine.PostScriptEvent(itemID, "http_request", new Object[] { urlcode.ToString(), "URL_REQUEST_DENIED", "" });
+                    engine.PostScriptEvent(itemID, "http_request", new Object[] { urlcode.ToString(), "URL_REQUEST_DENIED", String.Empty });
                     return urlcode;
                 }
 
@@ -182,7 +182,7 @@ namespace OpenSim.Region.CoreModules.Scripting.LSLHttp
 
             if (m_HttpsServer == null)
             {
-                engine.PostScriptEvent(itemID, "http_request", new Object[] { urlcode.ToString(), "URL_REQUEST_DENIED", "" });
+                engine.PostScriptEvent(itemID, "http_request", new Object[] { urlcode.ToString(), "URL_REQUEST_DENIED", String.Empty });
                 return urlcode;
             }
 
@@ -190,7 +190,7 @@ namespace OpenSim.Region.CoreModules.Scripting.LSLHttp
             {
                 if (m_UrlMap.Count >= m_TotalUrls)
                 {
-                    engine.PostScriptEvent(itemID, "http_request", new Object[] { urlcode.ToString(), "URL_REQUEST_DENIED", "" });
+                    engine.PostScriptEvent(itemID, "http_request", new Object[] { urlcode.ToString(), "URL_REQUEST_DENIED", String.Empty });
                     return urlcode;
                 }
 
@@ -453,7 +453,7 @@ namespace OpenSim.Region.CoreModules.Scripting.LSLHttp
             {
                 Hashtable headers = (Hashtable)request["headers"];
                 //HTTP server code doesn't provide us with QueryStrings
-                string queryString = "";
+                string queryString = String.Empty;
 
                 int pos1 = uri.IndexOf("/");// /lslhttp
                 int pos2 = uri.IndexOf("/", pos1 + 1);// /lslhttp/

--- a/OpenSim/Region/CoreModules/Scripting/LoadImageURL/LoadImageURLModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/LoadImageURL/LoadImageURLModule.cs
@@ -47,8 +47,8 @@ namespace OpenSim.Region.CoreModules.Scripting.LoadImageURL
         private Scene m_scene;
         private IDynamicTextureManager m_textureManager;
 
-        private string m_proxyurl = "";
-        private string m_proxyexcepts = "";
+        private string m_proxyurl = String.Empty;
+        private string m_proxyexcepts = String.Empty;
 
         #region IDynamicTextureRender Members
 

--- a/OpenSim/Region/CoreModules/Scripting/VectorRender/VectorRenderModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/VectorRender/VectorRenderModule.cs
@@ -166,8 +166,8 @@ namespace OpenSim.Region.CoreModules.Scripting.VectorRender
             foreach (string pair in nvps)
             {
                 string[] nvp = pair.Split(nvpDelimiter);
-                string name = "";
-                string value = "";
+                string name = String.Empty;
+                string value = String.Empty;
                 
                 if (nvp[0] != null)
                 {    
@@ -567,7 +567,7 @@ namespace OpenSim.Region.CoreModules.Scripting.VectorRender
                 x = Convert.ToSingle(xVal, CultureInfo.InvariantCulture);
                 y = Convert.ToSingle(yVal, CultureInfo.InvariantCulture);
 
-                line = "";
+                line = String.Empty;
                 for (int i = 2; i < parts.Length; i++)
                 {
                     line = line + parts[i].Trim();

--- a/OpenSim/Region/CoreModules/Scripting/XMLRPC/XMLRPCModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/XMLRPC/XMLRPCModule.cs
@@ -662,7 +662,7 @@ namespace OpenSim.Region.CoreModules.Scripting.XMLRPC
             // if not, use as method name
             UUID parseUID;
             string mName = "llRemoteData";
-            if ((Channel != null) && (Channel != ""))
+            if ((Channel != null) && (Channel != String.Empty))
                 if (!UUID.TryParse(Channel, out parseUID))
                     mName = Channel;
                 else

--- a/OpenSim/Region/CoreModules/Scripting/XMLRPC/XMLRPCModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/XMLRPC/XMLRPCModule.cs
@@ -662,7 +662,7 @@ namespace OpenSim.Region.CoreModules.Scripting.XMLRPC
             // if not, use as method name
             UUID parseUID;
             string mName = "llRemoteData";
-            if ((Channel != null) && (Channel != String.Empty))
+            if (!String.IsNullOrEmpty(Channel))
                 if (!UUID.TryParse(Channel, out parseUID))
                     mName = Channel;
                 else

--- a/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/RESTInterregionComms.cs
+++ b/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/RESTInterregionComms.cs
@@ -1083,8 +1083,8 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
 
         public static bool GetAuthentication(Hashtable request, out string authority, out string authKey)
         {
-            authority = string.Empty;
-            authKey = string.Empty;
+            authority = String.Empty;
+            authKey = String.Empty;
 
             Uri authUri;
             Hashtable headers = (Hashtable)request["headers"];

--- a/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/RESTInterregionComms.cs
+++ b/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/RESTInterregionComms.cs
@@ -583,7 +583,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
                 if (agent != null) // just to make sure
                 {
                     map = agent.Pack();
-                    string strBuffer = "";
+                    string strBuffer = String.Empty;
                     try
                     {
                         strBuffer = OSDParser.SerializeJsonString(map);
@@ -616,7 +616,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
             //m_log.Debug(" >>> DoDelete action:" + action + "; regionHandle:" + regionHandle);
             
             if (action.Equals("release"))
-                m_localBackend.SendReleaseAgent(regionHandle, id, "");
+                m_localBackend.SendReleaseAgent(regionHandle, id, String.Empty);
             else
                 m_localBackend.SendCloseAgent(regionHandle, id);
 
@@ -693,7 +693,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
             }
             
             Vector3 pos = Vector3.Zero;
-            string sogXmlStr = "", extraStr = "", stateXmlStr = "";
+            string sogXmlStr = String.Empty, extraStr = String.Empty, stateXmlStr = String.Empty;
             if (args.ContainsKey("sog"))
                 sogXmlStr = args["sog"].AsString();
             if (args.ContainsKey("extra"))
@@ -729,7 +729,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
             if ((args.ContainsKey("state")) && m_aScene.m_allowScriptCrossings)
             {
                 stateXmlStr = args["state"].AsString();
-                if (stateXmlStr != "")
+                if (stateXmlStr != String.Empty)
                 {
                     try
                     {
@@ -784,7 +784,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
             try
             {
                 string nonceStr = headers["x-nonce-id"];
-                if (nonceStr != String.Empty)
+                if (!String.IsNullOrEmpty(nonceStr))
                     return Convert.ToInt64(nonceStr);
             }
             catch(Exception)
@@ -1058,7 +1058,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
         public static bool GetParams(string uri, out UUID uuid, out ulong regionHandle, out string action)
         {
             uuid = UUID.Zero;
-            action = "";
+            action = String.Empty;
             regionHandle = 0;
 
             uri = uri.Trim(new char[] { '/' });

--- a/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/RESTInterregionComms.cs
+++ b/OpenSim/Region/CoreModules/ServiceConnectors/Interregion/RESTInterregionComms.cs
@@ -729,7 +729,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.Interregion
             if ((args.ContainsKey("state")) && m_aScene.m_allowScriptCrossings)
             {
                 stateXmlStr = args["state"].AsString();
-                if (stateXmlStr != String.Empty)
+                if (!String.IsNullOrEmpty(stateXmlStr))
                 {
                     try
                     {

--- a/OpenSim/Region/CoreModules/ServiceConnectors/User/LocalUserServiceConnector.cs
+++ b/OpenSim/Region/CoreModules/ServiceConnectors/User/LocalUserServiceConnector.cs
@@ -61,7 +61,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.User
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
-                string name = moduleConfig.GetString("UserServices", "");
+                string name = moduleConfig.GetString("UserServices", String.Empty);
                 if (name == Name)
                 {
                     IConfig userConfig = source.Configs["UserService"];
@@ -74,7 +74,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.User
                     string serviceDll = userConfig.GetString("LocalServiceModule",
                             String.Empty);
 
-                    if (serviceDll == String.Empty)
+                    if (String.IsNullOrEmpty(serviceDll))
                     {
                         m_log.Error("[USER CONNECTOR]: No LocalServiceModule named in section UserService");
                         return;

--- a/OpenSim/Region/CoreModules/ServiceConnectors/User/RemoteUserServiceConnector.cs
+++ b/OpenSim/Region/CoreModules/ServiceConnectors/User/RemoteUserServiceConnector.cs
@@ -52,7 +52,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectors.User
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
-                string name = moduleConfig.GetString("UserServices", "");
+                string name = moduleConfig.GetString("UserServices", String.Empty);
                 if (name == Name)
                 {
                     m_Enabled = true;

--- a/OpenSim/Region/CoreModules/World/Archiver/AssetsArchiver.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/AssetsArchiver.cs
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;

--- a/OpenSim/Region/CoreModules/World/Archiver/AssetsArchiver.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/AssetsArchiver.cs
@@ -92,7 +92,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
 //                {
 //                    xtw.WriteStartElement("asset");
 //
-//                    string extension = string.Empty;
+//                    string extension = String.Empty;
 //
 //                    if (ArchiveConstants.ASSET_TYPE_TO_EXTENSION.ContainsKey(asset.Type))
 //                    {
@@ -125,7 +125,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
             // It appears that gtar, at least, doesn't need the intermediate directory entries in the tar
             //archive.AddDir("assets");
 
-            string extension = string.Empty;
+            string extension = String.Empty;
 
             if (ArchiveConstants.ASSET_TYPE_TO_EXTENSION.ContainsKey(asset.Type))
             {

--- a/OpenSim/Region/CoreModules/World/Environment/EnvironmentModule.cs
+++ b/OpenSim/Region/CoreModules/World/Environment/EnvironmentModule.cs
@@ -150,7 +150,7 @@ namespace OpenSim.Region.CoreModules.World.LightShare
                     {
                         string result = SetEnvironmentSettings(request, path, param, agentID, caps);
                         if (result == null)
-                            return string.Empty;
+                            return String.Empty;
                         return result;
                     }));
         }

--- a/OpenSim/Region/CoreModules/World/Estate/EstateManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Estate/EstateManagementModule.cs
@@ -1327,7 +1327,7 @@ namespace OpenSim.Region.CoreModules.World.Estate
             Telehub telehub = m_scene.StorageManager.EstateDataStore.FindTelehub(client.Scene.RegionInfo.RegionID);
             if (telehub == null)
             {
-                client.SendTelehubInfo(Vector3.Zero, Quaternion.Identity, new List<Vector3>(), UUID.Zero, "");
+                client.SendTelehubInfo(Vector3.Zero, Quaternion.Identity, new List<Vector3>(), UUID.Zero, String.Empty);
             }
             else
             {

--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -167,7 +167,7 @@ namespace OpenSim.Region.CoreModules.World.Land
             foreach (string host in rdbHosts)
             {
                 ConnectionFactory rdbFactory;
-                if ((++whichDB == 1) || (_rdbConnectionTemplateDebug.Trim() == String.Empty))
+                if ((++whichDB == 1) || String.IsNullOrWhiteSpace(_rdbConnectionTemplateDebug))
                     rdbFactory = new ConnectionFactory("MySQL", String.Format(_rdbConnectionTemplate, host));
                 else  // Special debugging support for multiple RDBs on one machine ("inworldz_rdb2", etc)
                     rdbFactory = new ConnectionFactory("MySQL", String.Format(_rdbConnectionTemplateDebug, host, whichDB));

--- a/OpenSim/Region/CoreModules/World/Media/Moap/MoapModule.cs
+++ b/OpenSim/Region/CoreModules/World/Media/Moap/MoapModule.cs
@@ -325,11 +325,11 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
                 m_log.WarnFormat(
                     "[MOAP]: Received a GET ObjectMediaRequest for prim {0} but this doesn't exist in region {1}",
                     primId, m_scene.RegionInfo.RegionName);
-                return string.Empty;
+                return String.Empty;
             }
 
             if (null == part.Shape.Media)
-                return string.Empty;
+                return String.Empty;
 
             ObjectMediaResponse resp = new ObjectMediaResponse();
 
@@ -364,7 +364,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
                 m_log.WarnFormat(
                     "[MOAP]: Received an UPDATE ObjectMediaRequest for prim {0} but this doesn't exist in region {1}",
                     primId, m_scene.RegionInfo.RegionName);
-                return string.Empty;
+                return String.Empty;
             }
 
             //            m_log.DebugFormat("[MOAP]: Received {0} media entries for prim {1}", omu.FaceMedia.Length, primId);
@@ -381,7 +381,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
                 m_log.WarnFormat(
                     "[MOAP]: Received {0} media entries from client for prim {1} {2} but this prim has only {3} faces.  Dropping request.",
                     omu.FaceMedia.Length, part.Name, part.UUID, part.GetNumberOfSides());
-                return string.Empty;
+                return String.Empty;
             }
 
             UUID agentId = default(UUID);
@@ -456,7 +456,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
 
             part.TriggerScriptChangedEvent(Changed.MEDIA);
 
-            return string.Empty;
+            return String.Empty;
         }
 
         /// <summary>
@@ -486,7 +486,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
                 m_log.WarnFormat(
                     "[MOAP]: Received an ObjectMediaNavigateMessage for prim {0} but this doesn't exist in region {1}",
                     primId, m_scene.RegionInfo.RegionName);
-                return string.Empty;
+                return String.Empty;
             }
 
             UUID agentId = default(UUID);
@@ -495,7 +495,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
                 agentId = m_omuCapUsers[path];
 
             if (!m_scene.Permissions.CanInteractWithPrimMedia(agentId, part.UUID, omn.Face))
-                return string.Empty;
+                return String.Empty;
 
             //            m_log.DebugFormat(
             //                "[MOAP]: Received request to update media entry for face {0} on prim {1} {2} to {3}", 
@@ -503,7 +503,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
 
             // If media has never been set for this prim, then just return.
             if (null == part.Shape.Media)
-                return string.Empty;
+                return String.Empty;
 
             MediaEntry me = null;
 
@@ -512,7 +512,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
 
             // Do the same if media has not been set up for a specific face
             if (null == me)
-                return string.Empty;
+                return String.Empty;
 
             if (me.EnableWhiteList)
             {
@@ -522,7 +522,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
                     //                        "[MOAP]: Blocking change of face {0} on prim {1} {2} to {3} since it's not on the enabled whitelist", 
                     //                        omn.Face, part.Name, part.UUID, omn.URL);
 
-                    return string.Empty;
+                    return String.Empty;
                 }
             }
 

--- a/OpenSim/Region/CoreModules/World/Permissions/PermissionsModule.cs
+++ b/OpenSim/Region/CoreModules/World/Permissions/PermissionsModule.cs
@@ -1649,7 +1649,7 @@ namespace OpenSim.Region.CoreModules.World.Permissions
             // Optional test for land impact limits.
             if (landImpact > 0)
             {
-                string reason = "";
+                string reason = String.Empty;
                 return m_scene.CheckLandImpact(parcel, landImpact, out reason);
             }
 

--- a/OpenSim/Region/CoreModules/World/Sun/SunModule.cs
+++ b/OpenSim/Region/CoreModules/World/Sun/SunModule.cs
@@ -291,10 +291,10 @@ namespace OpenSim.Region.CoreModules
             m_scene.AddCommand(this, String.Empty, "sun", "Usage: sun [param] [value] - Get or Update Sun module paramater", null);
 
             // This one enables the ability to type just "sun" without any parameters
-            m_scene.AddCommand(this, "sun", "", "", HandleSunConsoleCommand);
+            m_scene.AddCommand(this, "sun", String.Empty, String.Empty, HandleSunConsoleCommand);
             foreach (KeyValuePair<string, string> kvp in GetParamList())
             {
-                m_scene.AddCommand(this, String.Format("sun {0}", kvp.Key), String.Format("{0} - {1}", kvp.Key, kvp.Value), "", HandleSunConsoleCommand);
+                m_scene.AddCommand(this, String.Format("sun {0}", kvp.Key), String.Format("{0} - {1}", kvp.Key, kvp.Value), String.Empty, HandleSunConsoleCommand);
             }
 
 

--- a/OpenSim/Region/CoreModules/World/Terrain/PaintBrushes/OlsenSphere.cs
+++ b/OpenSim/Region/CoreModules/World/Terrain/PaintBrushes/OlsenSphere.cs
@@ -224,7 +224,7 @@ namespace OpenSim.Region.CoreModules.World.Terrain.PaintBrushes
                             }
                         }
 
-                        double T = nConst / ((map.Width + map.Height) / 2);
+                        double T = nConst / ((map.Width + map.Height) / 2); // Assuming the width and height are both nonzero positive powers of two, and therefore are even numbers, the integer div/2 never loses precision.
                         // Apply results
                         if (0 < max && max <= T)
                         {

--- a/OpenSim/Region/CoreModules/World/Terrain/TerrainModule.cs
+++ b/OpenSim/Region/CoreModules/World/Terrain/TerrainModule.cs
@@ -1014,7 +1014,7 @@ namespace OpenSim.Region.CoreModules.World.Terrain
         private void InstallInterfaces()
         {
             // Load / Save
-            string supportedFileExtensions = "";
+            string supportedFileExtensions = String.Empty;
             foreach (KeyValuePair<string, ITerrainLoader> loader in m_loaders)
                 supportedFileExtensions += " " + loader.Key + " (" + loader.Value + ")";
 

--- a/OpenSim/Region/CoreModules/World/Terrain/TerrainModule.cs
+++ b/OpenSim/Region/CoreModules/World/Terrain/TerrainModule.cs
@@ -365,13 +365,13 @@ namespace OpenSim.Region.CoreModules.World.Terrain
 
                             string typeName = pluginType.Name;
 
-                            if (pluginType.GetInterface("ITerrainEffect", false) != null)
+                            if (typeof(ITerrainEffect).IsAssignableFrom(pluginType))
                             {
                                 ITerrainEffect terEffect = (ITerrainEffect) Activator.CreateInstance(library.GetType(pluginType.ToString()));
 
                                 InstallPlugin(typeName, terEffect);
                             }
-                            else if (pluginType.GetInterface("ITerrainLoader", false) != null)
+                            else if (typeof(ITerrainLoader).IsAssignableFrom(pluginType))
                             {
                                 ITerrainLoader terLoader = (ITerrainLoader) Activator.CreateInstance(library.GetType(pluginType.ToString()));
                                 m_loaders[terLoader.FileExtension] = terLoader;

--- a/OpenSim/Region/CoreModules/World/Wind/WindModule.cs
+++ b/OpenSim/Region/CoreModules/World/Wind/WindModule.cs
@@ -122,17 +122,17 @@ namespace OpenSim.Region.CoreModules
                 m_scene.AddCommand(this, String.Empty, "wind", "Usage: wind <plugin> <param> [value] - Get or Update Wind paramaters", null);
                 
                 // This one enables the ability to type just the base command without any parameters
-                m_scene.AddCommand(this, "wind", "", "", HandleConsoleCommand);
+                m_scene.AddCommand(this, "wind", String.Empty, String.Empty, HandleConsoleCommand);
 
                 // Get a list of the parameters for each plugin
                 foreach (IWindModelPlugin windPlugin in m_availableWindPlugins.Values)
                 {
-                    m_scene.AddCommand(this, String.Format("wind base wind_plugin {0}", windPlugin.Name), String.Format("{0} - {1}", windPlugin.Name, windPlugin.Description), "", HandleConsoleBaseCommand);
-                    m_scene.AddCommand(this, String.Format("wind base wind_update_rate"), "Change the wind update rate.", "", HandleConsoleBaseCommand);
+                    m_scene.AddCommand(this, String.Format("wind base wind_plugin {0}", windPlugin.Name), String.Format("{0} - {1}", windPlugin.Name, windPlugin.Description), String.Empty, HandleConsoleBaseCommand);
+                    m_scene.AddCommand(this, String.Format("wind base wind_update_rate"), "Change the wind update rate.", String.Empty, HandleConsoleBaseCommand);
                     
                     foreach (KeyValuePair<string, string> kvp in windPlugin.WindParams())
                     {
-                        m_scene.AddCommand(this, String.Format("wind {0} {1}", windPlugin.Name, kvp.Key), String.Format("{0} : {1} - {2}", windPlugin.Name, kvp.Key, kvp.Value), "", HandleConsoleParamCommand);
+                        m_scene.AddCommand(this, String.Format("wind {0} {1}", windPlugin.Name, kvp.Key), String.Format("{0} : {1} - {2}", windPlugin.Name, kvp.Key, kvp.Value), String.Empty, HandleConsoleParamCommand);
                     }
                 }
 

--- a/OpenSim/Region/CoreModules/World/WorldMap/WorldMapModule.cs
+++ b/OpenSim/Region/CoreModules/World/WorldMap/WorldMapModule.cs
@@ -164,7 +164,7 @@ namespace OpenSim.Region.CoreModules.World.WorldMap
             myMapImageJPEG = new byte[0];
 
             string regionimage = "regionImage" + m_scene.RegionInfo.RegionID.ToString();
-            regionimage = regionimage.Replace("-", "");
+            regionimage = regionimage.Replace("-", String.Empty);
             m_log.Info("[WORLD MAP]: JPEG Map location: http://" + m_scene.RegionInfo.ExternalHostName + ":" + m_scene.RegionInfo.HttpPort.ToString() + "/index.php?method=" + regionimage);
 
             m_scene.CommsManager.HttpServer.AddHTTPHandler(regionimage, OnHTTPGetMapImage);
@@ -188,10 +188,10 @@ namespace OpenSim.Region.CoreModules.World.WorldMap
             m_scene.EventManager.OnRegisterCaps -= OnRegisterCaps;
 
             string regionimage = "regionImage" + m_scene.RegionInfo.RegionID.ToString();
-            regionimage = regionimage.Replace("-", "");
+            regionimage = regionimage.Replace("-", String.Empty);
             m_scene.CommsManager.HttpServer.RemoveLLSDHandler("/MAP/MapItems/" + m_scene.RegionInfo.RegionHandle.ToString(),
                                                               HandleRemoteMapItemRequest);
-            m_scene.CommsManager.HttpServer.RemoveHTTPHandler("", regionimage);
+            m_scene.CommsManager.HttpServer.RemoveHTTPHandler(String.Empty, regionimage);
         }
 
         public void OnRegisterCaps(UUID agentID, Caps caps)
@@ -376,7 +376,7 @@ namespace OpenSim.Region.CoreModules.World.WorldMap
                 }
                 else
                 {
-                    RequestMapItems("",remoteClient.AgentId,flags,EstateID,godlike,itemtype,regionhandle);
+                    RequestMapItems(String.Empty,remoteClient.AgentId,flags,EstateID,godlike,itemtype,regionhandle);
                 }
             }
         }

--- a/OpenSim/Region/Framework/ModuleLoader.cs
+++ b/OpenSim/Region/Framework/ModuleLoader.cs
@@ -227,7 +227,7 @@ namespace OpenSim.Region.Framework
                         pluginAssembly.FullName, e.Message, e.StackTrace);
                     
                     // justincc: Right now this is fatal to really get the user's attention
-                    throw e;
+                    throw;
                 }
             }
 

--- a/OpenSim/Region/Framework/ModuleLoader.cs
+++ b/OpenSim/Region/Framework/ModuleLoader.cs
@@ -212,7 +212,7 @@ namespace OpenSim.Region.Framework
                         {
                             if (!pluginType.IsAbstract)
                             {
-                                if (pluginType.GetInterface("IRegionModule") != null)
+                                if (typeof(IRegionModule).IsAssignableFrom(pluginType))
                                 {
                                     modules.Add((IRegionModule)Activator.CreateInstance(pluginType));
                                 }

--- a/OpenSim/Region/Framework/Scenes/AvatarAnimations.cs
+++ b/OpenSim/Region/Framework/Scenes/AvatarAnimations.cs
@@ -60,7 +60,7 @@ namespace OpenSim.Region.Framework.Scenes
 
                             AnimsUUID.Add(name, id);
                             AnimsNames.Add(id, name);
-                            if (animState != String.Empty)
+                            if (!String.IsNullOrEmpty(animState))
                                 AnimStateNames.Add(id, animState);
                         }
                     }

--- a/OpenSim/Region/Framework/Scenes/AvatarAnimations.cs
+++ b/OpenSim/Region/Framework/Scenes/AvatarAnimations.cs
@@ -60,7 +60,7 @@ namespace OpenSim.Region.Framework.Scenes
 
                             AnimsUUID.Add(name, id);
                             AnimsNames.Add(id, name);
-                            if (animState != "")
+                            if (animState != String.Empty)
                                 AnimStateNames.Add(id, animState);
                         }
                     }

--- a/OpenSim/Region/Framework/Scenes/BinBVHAnimation.cs
+++ b/OpenSim/Region/Framework/Scenes/BinBVHAnimation.cs
@@ -149,7 +149,7 @@ namespace OpenSim.Region.Framework.Scenes
             unknown1 = 0;
             Priority = 1;
             Length = 0;
-            ExpressionName = string.Empty;
+            ExpressionName = String.Empty;
             InPoint = 0;
             OutPoint = 0;
             Loop = false;
@@ -263,7 +263,7 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 // advance the 1 null character
                 i++;
-                return string.Empty;
+                return String.Empty;
             }
             else
             {

--- a/OpenSim/Region/Framework/Scenes/BinBVHAnimation.cs
+++ b/OpenSim/Region/Framework/Scenes/BinBVHAnimation.cs
@@ -66,7 +66,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// <summary>
         /// Expression set in the client.  Null if [None] is selected
         /// </summary>
-        public string ExpressionName; // "" (null)
+        public string ExpressionName; // String.Empty (null)
 
         /// <summary>
         /// The time in seconds to start the animation

--- a/OpenSim/Region/Framework/Scenes/RegionStatsHandler.cs
+++ b/OpenSim/Region/Framework/Scenes/RegionStatsHandler.cs
@@ -106,7 +106,7 @@ namespace OpenSim.Region.Framework.Scenes
             args["Memory"] = OSD.FromReal(Math.Round(GC.GetTotalMemory(false) / 1024.0 / 1024.0));
             args["Version"] = OSD.FromString(VersionInfo.FullVersion);
             
-            string strBuffer = "";
+            string strBuffer = String.Empty;
             strBuffer = OSDParser.SerializeJsonString(args);
 
             return strBuffer;

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -2173,7 +2173,7 @@ namespace OpenSim.Region.Framework.Scenes
             ReplaceItemArgs replaceArgs = new ReplaceItemArgs(destTaskItem, running, start_param);
             destPart.Inventory.AddReplaceInventoryItem(destTaskItem, false, true, replaceArgs);
 
-            return string.Empty;    // success, no error
+            return String.Empty;    // success, no error
         }
 
         /// <summary>

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -1025,7 +1025,7 @@ namespace OpenSim.Region.Framework.Scenes
             }
 
             m_log.DebugFormat("[AGENT INVENTORY]: CopyInventoryItem {0} '{1}' asset {2}", oldItemID, item.Name, item.AssetID);
-            if (newName == String.Empty)
+            if (String.IsNullOrEmpty(newName))
             {
                 newName = item.Name;
             }
@@ -1090,7 +1090,7 @@ namespace OpenSim.Region.Framework.Scenes
                     return;
                 }
 
-                if (newName != String.Empty)
+                if (!String.IsNullOrEmpty(newName))
                 {
                     InventoryItemBase item = userInfo.FindItem(itemID);
 
@@ -3235,7 +3235,7 @@ namespace OpenSim.Region.Framework.Scenes
                 return true;
             }
 
-            string reason = "";
+            string reason = String.Empty;
             bool allowed = true;
             int landImpactNeeded = group.LandImpact;
 

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -591,7 +591,7 @@ namespace OpenSim.Region.Framework.Scenes
                     while ((line = file.ReadLine()) != null)
                     {
                         line = line.Trim();
-                        if ((line != String.Empty) && !line.StartsWith(";") && !line.StartsWith("//"))
+                        if (!String.IsNullOrEmpty(line) && !line.StartsWith(";") && !line.StartsWith("//"))
                         {
                             theList.Add(line);
                         }

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -591,7 +591,7 @@ namespace OpenSim.Region.Framework.Scenes
                     while ((line = file.ReadLine()) != null)
                     {
                         line = line.Trim();
-                        if ((line != "") && !line.StartsWith(";") && !line.StartsWith("//"))
+                        if ((line != String.Empty) && !line.StartsWith(";") && !line.StartsWith("//"))
                         {
                             theList.Add(line);
                         }
@@ -848,7 +848,7 @@ namespace OpenSim.Region.Framework.Scenes
         public string GetEnv(string name)
         {
             IConfig config = null;
-            string ret = "";
+            string ret = String.Empty;
 
             // NOTE: All case values in must be lowercase for case-insensitive compare.
             switch (name.ToLower())
@@ -874,12 +874,12 @@ namespace OpenSim.Region.Framework.Scenes
                 case "dynamic_pathfinding": // (integer) Get the region's dynamic_pathfinding status, "1" or "0".
                     ret = "disabled";
                     break;
-                case "inworldz": // (integer) Is this an InWorldz server? "1" or "".
+                case "inworldz": // (integer) Is this an InWorldz server? "1" or String.Empty.
                     config = m_config.Configs["GridInfo"];
-                    ret = (config.GetString("gridmanagement", VersionInfo.DefaultGrid).Trim() == "InWorldz") ? "1" : "";
+                    ret = (config.GetString("gridmanagement", VersionInfo.DefaultGrid).Trim() == "InWorldz") ? "1" : String.Empty;
                     break;
-                case "halcyon": // (integer) Is this a Halcyon server? "1" or "".
-                    ret = (VersionInfo.SoftwareName == "Halcyon") ? "1" : "";
+                case "halcyon": // (integer) Is this a Halcyon server? "1" or String.Empty.
+                    ret = (VersionInfo.SoftwareName == "Halcyon") ? "1" : String.Empty;
                     break;
                 case "script_engine":
                     ret = "Phlox";  // always Phlox in Halcyon
@@ -953,19 +953,19 @@ namespace OpenSim.Region.Framework.Scenes
                     break;
                 case "platform":
                     config = m_config.Configs["GridInfo"];    // Halcyon, OpenSim, SecondLife
-                    return (config == null) ? "" : config.GetString("platform", VersionInfo.SoftwareName).Trim();
+                    return (config == null) ? String.Empty : config.GetString("platform", VersionInfo.SoftwareName).Trim();
                 case "grid_management":
                     config = m_config.Configs["GridInfo"];    // InWorldz, ARL, LindenLab, etc.
-                    return (config == null) ? "" : config.GetString("gridmanagement", VersionInfo.DefaultGrid).Trim();
+                    return (config == null) ? String.Empty : config.GetString("gridmanagement", VersionInfo.DefaultGrid).Trim();
                 case "grid_nick":
                     config = m_config.Configs["GridInfo"];    // InWorldz, InWorldzBeta, SecondLife, etc.
-                    return (config == null) ? "" : config.GetString("gridnick", VersionInfo.DefaultGrid).Trim();
+                    return (config == null) ? String.Empty : config.GetString("gridnick", VersionInfo.DefaultGrid).Trim();
                 case "grid_name":
                     config = m_config.Configs["GridInfo"];    // InWorldz, InWorldz Beta, Second Life, etc.
-                    return (config == null) ? "" : config.GetString("gridname", VersionInfo.DefaultGrid).Trim();
+                    return (config == null) ? String.Empty : config.GetString("gridname", VersionInfo.DefaultGrid).Trim();
                 case "shard":
                     config = m_config.Configs["Network"];    // "InWorldz", "Beta", "Some Other Grid", "Testing", etc.
-                    return (config == null) ? "" : config.GetString("shard", VersionInfo.DefaultGrid).Trim();
+                    return (config == null) ? String.Empty : config.GetString("shard", VersionInfo.DefaultGrid).Trim();
             }
             return ret;
         }
@@ -2283,7 +2283,7 @@ namespace OpenSim.Region.Framework.Scenes
                 return false;
             }
 
-            reason = "";
+            reason = String.Empty;
             return true;
         }
 
@@ -2326,7 +2326,7 @@ namespace OpenSim.Region.Framework.Scenes
                                        byte RayEndIsIntersection, IClientAPI remoteClient)
         {
             Vector3 pos = GetNewRezLocation(RayStart, RayEnd, RayTargetID, rot, bypassRaycast, RayEndIsIntersection, true, new Vector3(0.5f, 0.5f, 0.5f), false, remoteClient.AgentId);
-            string reason = "";
+            string reason = String.Empty;
             int landImpact = 1;
 
             if (IsBadUser(ownerID))
@@ -3249,7 +3249,7 @@ namespace OpenSim.Region.Framework.Scenes
             UserPreferencesData prefs = CommsManager.UserService.RetrieveUserPreferences(client.AgentId);
             if (prefs != null)
             {
-                client.SendUserInfoReply(prefs.ReceiveIMsViaEmail, prefs.ListedInDirectory, "");
+                client.SendUserInfoReply(prefs.ReceiveIMsViaEmail, prefs.ListedInDirectory, String.Empty);
             }
         }
 
@@ -3973,7 +3973,7 @@ namespace OpenSim.Region.Framework.Scenes
             reason = String.Empty;
             if (!m_strictAccessControl) return true;
 
-            if (!AuthorizeUserInRegion(sog.OwnerID, "", "", null, out reason))
+            if (!AuthorizeUserInRegion(sog.OwnerID, String.Empty, String.Empty, null, out reason))
             {
                 m_log.WarnFormat("[SCENE]: Object denied entry at {0} because user {1} does not have region access.", RegionInfo.RegionName, sog.OwnerID);
                 reason = String.Format("Object owner does not have access to {0}.", RegionInfo.RegionName);
@@ -3982,7 +3982,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             Vector3 pos = sog.AbsolutePosition;
             ILandObject land = LandChannel.GetLandObject(pos.X, pos.Y);
-            if (!AuthorizeUserInParcel(sog.OwnerID, "", "", land, pos, out reason))
+            if (!AuthorizeUserInParcel(sog.OwnerID, String.Empty, String.Empty, land, pos, out reason))
             {
                 m_log.WarnFormat("[SCENE]: Object denied entry at {0} because user {1} does not have parcel access.", RegionInfo.RegionName, sog.OwnerID);
                 reason = String.Format("Object owner {0} does not have access to that parcel.", sog.OwnerID);
@@ -3997,14 +3997,14 @@ namespace OpenSim.Region.Framework.Scenes
                     if (agentID == sog.OwnerID)
                         continue;   // we already checked above
 
-                    if (!AuthorizeUserInRegion(agentID, "", "", null, out reason))
+                    if (!AuthorizeUserInRegion(agentID, String.Empty, String.Empty, null, out reason))
                     {
                         m_log.WarnFormat("[SCENE]: Object denied entry at {0} because user {1} does not have region access.", RegionInfo.RegionName, agentID);
                         reason = String.Format("User {0} does not have access to {1}.", agentID, RegionInfo.RegionName);
                         return false;
                     }
 
-                    if (!AuthorizeUserInParcel(agentID, "", "", land, pos, out reason))
+                    if (!AuthorizeUserInParcel(agentID, String.Empty, String.Empty, land, pos, out reason))
                     {
                         m_log.WarnFormat("[SCENE]: Object denied entry at {0} because user {1} {2}", RegionInfo.RegionName, agentID, reason);
                         reason = String.Format("Object entry denied: user {0} {1}", agentID, reason);

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2305,7 +2305,7 @@ namespace OpenSim.Region.Framework.Scenes
                 else
                     return REZ_NOT_PERMITTED;
             }
-            string reason = string.Empty;
+            string reason = String.Empty;
             ILandObject parcel = LandChannel.GetLandObject(pos.X, pos.Y);
             if (parcel == null)
                 return REZ_NO_LAND_PARCEL;

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -4921,14 +4921,14 @@ namespace OpenSim.Region.Framework.Scenes
 
 #region Script Engine
 
-        private List<ScriptEngineInterface> ScriptEngines = new List<ScriptEngineInterface>();
+        private List<IScriptEngineInterface> ScriptEngines = new List<IScriptEngineInterface>();
         private AvatarTransit.AvatarTransitController m_transitController;
 
         /// <summary>
         ///
         /// </summary>
         /// <param name="scriptEngine"></param>
-        public void AddScriptEngine(ScriptEngineInterface scriptEngine)
+        public void AddScriptEngine(IScriptEngineInterface scriptEngine)
         {
             ScriptEngines.Add(scriptEngine);
             scriptEngine.InitializeEngine(this);

--- a/OpenSim/Region/Framework/Scenes/SceneCommunicationService.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneCommunicationService.cs
@@ -429,7 +429,7 @@ namespace OpenSim.Region.Framework.Scenes
 //            return false;   // for testing failures
             int count = 100;
 
-            int now = NextTickCheck(0, ""); 
+            int now = NextTickCheck(0, String.Empty); 
             lock (m_agentsInTransit)
             {
                 now = NextTickCheck(now, "[SCENE COMM]: WaitForCallback - lock (m_agentsInTransit)");

--- a/OpenSim/Region/Framework/Scenes/SceneManager.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneManager.cs
@@ -1031,7 +1031,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         private static string OarStatusNameFromRegionName(string regionName)
         {
-            return regionName.Replace(" ", "").Replace("\'", "") + ".oarstatus";
+            return regionName.Replace(" ", String.Empty).Replace("\'", String.Empty) + ".oarstatus";
         }
 
         public Scene FindSceneByName(string name)

--- a/OpenSim/Region/Framework/Scenes/SceneManager.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneManager.cs
@@ -573,7 +573,7 @@ namespace OpenSim.Region.Framework.Scenes
                     case BlacklistOp.User:
                     case BlacklistOp.Owner:
                         // accepts either UUID or First Last
-                        if (param2 == string.Empty)
+                        if (param2 == String.Empty)
                         {
                             if (!UUID.TryParse(param, out targetID))
                             {
@@ -609,7 +609,7 @@ namespace OpenSim.Region.Framework.Scenes
                     case BlacklistOp.Remove:
                         if (UUID.TryParse(param, out targetID))
                         {
-                            targetName = string.Empty;
+                            targetName = String.Empty;
                         }
                         else
                         {
@@ -651,7 +651,7 @@ namespace OpenSim.Region.Framework.Scenes
                             scene.AddBlacklistedUser(targetID);
                             break;
                         case BlacklistOp.Remove:
-                            if (targetName != string.Empty)
+                            if (targetName != String.Empty)
                                 scene.BlacklistRemove(targetName);
                             else
                                 scene.BlacklistRemove(targetID);

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.Inventory.cs
@@ -373,28 +373,28 @@ namespace OpenSim.Region.Framework.Scenes
             }
 
             if (states.Count < 1)
-                return "";
+                return String.Empty;
 
             XmlDocument xmldoc = new XmlDocument();
 
             XmlNode xmlnode = xmldoc.CreateNode(XmlNodeType.XmlDeclaration,
-                    "", "");
+                    String.Empty, String.Empty);
 
             xmldoc.AppendChild(xmlnode);
-            XmlElement rootElement = xmldoc.CreateElement("", "PhloxScriptData", "");
+            XmlElement rootElement = xmldoc.CreateElement(String.Empty, "PhloxScriptData", String.Empty);
             
             xmldoc.AppendChild(rootElement);
 
-            XmlElement wrapper = xmldoc.CreateElement("", "PhloxSS",
-                    "");
+            XmlElement wrapper = xmldoc.CreateElement(String.Empty, "PhloxSS",
+                    String.Empty);
             
             rootElement.AppendChild(wrapper);
 
             foreach (KeyValuePair<UUID, string> state in states)
             {
-                XmlElement stateData = xmldoc.CreateElement("", "State", "");
+                XmlElement stateData = xmldoc.CreateElement(String.Empty, "State", String.Empty);
 
-                XmlAttribute stateID = xmldoc.CreateAttribute("", "UUID", "");
+                XmlAttribute stateID = xmldoc.CreateAttribute(String.Empty, "UUID", String.Empty);
                 stateID.Value = state.Key.ToString();
                 stateData.Attributes.Append(stateID);
 
@@ -407,7 +407,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         public void SetState(string objXMLData, UUID RegionID)
         {
-            if (objXMLData == String.Empty)
+            if (String.IsNullOrEmpty(objXMLData))
                 return;
 
             XmlDocument doc = new XmlDocument();

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -205,7 +205,7 @@ namespace OpenSim.Region.Framework.Scenes
             get
             {
                 if (RootPart == null)
-                    return "";
+                    return String.Empty;
                 return RootPart.Name;
             }
             set { RootPart.Name = value; }
@@ -2354,7 +2354,7 @@ namespace OpenSim.Region.Framework.Scenes
                         coords.Add(target.X.ToString());
                         coords.Add(target.Y.ToString());
                         coords.Add(target.Z.ToString());
-                        avatar.DoMoveToPosition(avatar, "", coords);
+                        avatar.DoMoveToPosition(avatar, String.Empty, coords);
                     }
                 }
                 else
@@ -4317,8 +4317,8 @@ namespace OpenSim.Region.Framework.Scenes
         public virtual void ExtraFromXmlString(string xmlstr)
         {
             string id = xmlstr.Substring(xmlstr.IndexOf("<ExtraFromAssetID>"));
-            id = xmlstr.Replace("<ExtraFromAssetID>", "");
-            id = id.Replace("</ExtraFromAssetID>", "");
+            id = xmlstr.Replace("<ExtraFromAssetID>", String.Empty);
+            id = id.Replace("</ExtraFromAssetID>", String.Empty);
 
             UUID uuid = UUID.Zero;
             UUID.TryParse(id, out uuid);

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
@@ -1206,7 +1206,7 @@ namespace OpenSim.Region.Framework.Scenes
                 if (item.InvType == (int)InventoryType.LSL)
                 {
                     string n = engine.GetXMLState(item.ItemID, stopScriptReason);
-                    if (n != String.Empty)
+                    if (!String.IsNullOrEmpty(n))
                     {
                         ret[item.ItemID] = n;
                     }

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
@@ -478,7 +478,7 @@ namespace OpenSim.Region.Framework.Scenes
         protected void AddInventoryItem(string name, TaskInventoryItem item, bool allowedDrop, bool fireEvents, ReplaceItemArgs replaceArgs)
         {
             name = FindAvailableInventoryName(name);
-            if (name == String.Empty)
+            if (String.IsNullOrEmpty(name))
                 return;
 
             item.ParentID = m_part.UUID;
@@ -840,14 +840,14 @@ namespace OpenSim.Region.Framework.Scenes
         // This function initializes or updates the member variable m_inventoryFileName as needed.
         private void UpdateInventoryTempFileName(IXfer xferManager)
         {
-            bool needNew = (m_inventoryFileName == String.Empty);   // if first instance
+            bool needNew = String.IsNullOrEmpty(m_inventoryFileName);   // if first instance
 
             // If the version has changed, we need a new file name even if we have one
             needNew |= (m_inventoryFileNameSerial < m_inventorySerial); // or new version
 
             if (needNew)
             {
-                // if (m_inventoryFileName != String.Empty) xferManager.RemoveNewFile(m_inventoryFileName); // replace existing with new update
+                // if (!String.IsNullOrEmpty(m_inventoryFileName)) xferManager.RemoveNewFile(m_inventoryFileName); // replace existing with new update
                 m_inventoryFileName = "inventory_" + UUID.Random().ToString() + ".tmp";
             }
         }
@@ -1206,7 +1206,7 @@ namespace OpenSim.Region.Framework.Scenes
                 if (item.InvType == (int)InventoryType.LSL)
                 {
                     string n = engine.GetXMLState(item.ItemID, stopScriptReason);
-                    if (n != "")
+                    if (n != String.Empty)
                     {
                         ret[item.ItemID] = n;
                     }

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -178,7 +178,7 @@ namespace OpenSim.Region.Framework.Scenes
         private bool m_setAlwaysRun;
 
         private string m_movementAnimation = "DEFAULT";
-        private string m_previousMovement = "";        // this doubles as our thread reentrancy lock (critical region) on anim updates
+        private string m_previousMovement = String.Empty;        // this doubles as our thread reentrancy lock (critical region) on anim updates
         private long m_animPersistUntil = 0;
         private bool m_allowFalling = false;
         private bool m_useFlySlow = false;
@@ -1431,7 +1431,7 @@ namespace OpenSim.Region.Framework.Scenes
                     // Release the lock before calling PostProcessMakeRootAgent, it calls functions that use lock
                     PostProcessMakeRootAgent(parent, m_flying);
 
-                    if ((m_callbackURI != null) && !m_callbackURI.Equals(""))
+                    if ((m_callbackURI != null) && !m_callbackURI.Equals(String.Empty))
                     {
                         m_log.DebugFormat("[SCENE PRESENCE]: Releasing agent in URI {0}", m_callbackURI);
                         Scene.SendReleaseAgent(m_rootRegionHandle, UUID, m_callbackURI);

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -213,7 +213,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         public bool IsRestrictedToRegion;
 
-        public string JID = string.Empty;
+        public string JID = String.Empty;
 
         // Agent moves with a PID controller causing a force to be exerted.
         private float m_health = 100f;

--- a/OpenSim/Region/Framework/Scenes/Scripting/IScriptEngineInterface.cs
+++ b/OpenSim/Region/Framework/Scenes/Scripting/IScriptEngineInterface.cs
@@ -29,7 +29,7 @@
 
 namespace OpenSim.Region.Framework.Scenes.Scripting
 {
-    public interface ScriptEngineInterface
+    public interface IScriptEngineInterface
     {
         void InitializeEngine(Scene Sceneworld);
         void Shutdown();

--- a/OpenSim/Region/Framework/Scenes/Scripting/ScriptEngineLoader.cs
+++ b/OpenSim/Region/Framework/Scenes/Scripting/ScriptEngineLoader.cs
@@ -57,61 +57,24 @@ namespace OpenSim.Region.Framework.Scenes.Scripting
         }
 
         /// <summary>
-        /// Does actual loading and initialization of script Assembly
+        /// Does actual loading and initialization of script Assembly. Can throw many kinds of errors, depending on what problem was run across during loading.
         /// </summary>
-        /// <param name="FreeAppDomain">AppDomain to load script into</param>
-        /// <param name="FileName">FileName of script assembly (.dll)</param>
+        /// <param name="file_name">File name of script assembly (.dll)</param>
+        /// <param name="namespace_class">The namespace and type in the assembly to initialize and return</param>
         /// <returns></returns>
-        private ScriptEngineInterface LoadAndInitAssembly(string FileName, string NameSpace)
+        private ScriptEngineInterface LoadAndInitAssembly(string file_name, string namespace_class)
         {
             //Common.SendToDebug("Loading ScriptEngine Assembly " + FileName);
-            // Load .Net Assembly (.dll)
-            // Initialize and return it
 
-            // TODO: Add error handling
+            // Load .Net Assembly (.dll), initialize and return it
 
-            Assembly a;
-            //try
-            //{
+            // All error checking is expected to be handled by caller.
 
+            Assembly a = Assembly.LoadFrom(file_name);
 
-            // Load to default appdomain (temporary)
-            a = Assembly.LoadFrom(FileName);
-            // Load to specified appdomain
-            // TODO: Insert security
-            //a = FreeAppDomain.Load(FileName);
-            //}
-            //catch (Exception e)
-            //{
-            //    m_log.Error("[ScriptEngine]: Error loading assembly \String.Empty + FileName + "\": " + e.ToString());
-            //}
+            Type t = a.GetType(namespace_class, true);
 
-
-            //m_log.Debug("Loading: " + FileName);
-            //foreach (Type _t in a.GetTypes())
-            //{
-            //    m_log.Debug("Type: " + _t.ToString());
-            //}
-
-            Type t;
-            //try
-            //{
-            t = a.GetType(NameSpace, true);
-            //}
-            //catch (Exception e)
-            //{
-            //    m_log.Error("[ScriptEngine]: Error initializing type \String.Empty + NameSpace + "\" from \String.Empty + FileName + "\": " + e.ToString());
-            //}
-
-            ScriptEngineInterface ret;
-            //try
-            //{
-            ret = (ScriptEngineInterface) Activator.CreateInstance(t);
-            //}
-            //catch (Exception e)
-            //{
-            //    m_log.Error("[ScriptEngine]: Error initializing type \String.Empty + NameSpace + "\" from \String.Empty + FileName + "\": " + e.ToString());
-            //}
+            ScriptEngineInterface ret = (ScriptEngineInterface) Activator.CreateInstance(t);
 
             return ret;
         }

--- a/OpenSim/Region/Framework/Scenes/Scripting/ScriptEngineLoader.cs
+++ b/OpenSim/Region/Framework/Scenes/Scripting/ScriptEngineLoader.cs
@@ -37,9 +37,9 @@ namespace OpenSim.Region.Framework.Scenes.Scripting
     {
         private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        public ScriptEngineInterface LoadScriptEngine(string EngineName)
+        public IScriptEngineInterface LoadScriptEngine(string EngineName)
         {
-            ScriptEngineInterface ret = null;
+            IScriptEngineInterface ret = null;
             try
             {
                 ret =
@@ -62,7 +62,7 @@ namespace OpenSim.Region.Framework.Scenes.Scripting
         /// <param name="file_name">File name of script assembly (.dll)</param>
         /// <param name="namespace_class">The namespace and type in the assembly to initialize and return</param>
         /// <returns></returns>
-        private ScriptEngineInterface LoadAndInitAssembly(string file_name, string namespace_class)
+        private IScriptEngineInterface LoadAndInitAssembly(string file_name, string namespace_class)
         {
             //Common.SendToDebug("Loading ScriptEngine Assembly " + FileName);
 
@@ -74,7 +74,7 @@ namespace OpenSim.Region.Framework.Scenes.Scripting
 
             Type t = a.GetType(namespace_class, true);
 
-            ScriptEngineInterface ret = (ScriptEngineInterface) Activator.CreateInstance(t);
+            IScriptEngineInterface ret = (IScriptEngineInterface) Activator.CreateInstance(t);
 
             return ret;
         }

--- a/OpenSim/Region/Framework/Scenes/SimStatsReporter.cs
+++ b/OpenSim/Region/Framework/Scenes/SimStatsReporter.cs
@@ -119,7 +119,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         public SimStatsReporter(Scene scene)
         {
-            statsUpdateFactor = (float)(statsUpdatesEveryMS / 1000);
+            statsUpdateFactor = statsUpdatesEveryMS / 1000.0f;
             m_scene = scene;
             ReportingRegion = scene.RegionInfo;
 
@@ -135,7 +135,7 @@ namespace OpenSim.Region.Framework.Scenes
         public void SetUpdateMS(int ms)
         {
             statsUpdatesEveryMS = ms;
-            statsUpdateFactor = (float)(statsUpdatesEveryMS / 1000);
+            statsUpdateFactor = statsUpdatesEveryMS / 1000.0f;
             m_report.Interval = statsUpdatesEveryMS;
         }
 

--- a/OpenSim/Region/Framework/Scenes/TerrainChannel.cs
+++ b/OpenSim/Region/Framework/Scenes/TerrainChannel.cs
@@ -440,7 +440,7 @@ namespace OpenSim.Region.Framework.Scenes
             if (slope.Z == 0.0f)
                 slope.Z = 1.0f;
             else
-                slope.Z = (float)(((normal.X * normal.X) + (normal.Y * normal.Y)) / (-1.0f * normal.Z));
+                slope.Z = ((normal.X * normal.X) + (normal.Y * normal.Y)) / (-1.0f * normal.Z);
             return slope;
         }
 

--- a/OpenSim/Region/Framework/StorageManager.cs
+++ b/OpenSim/Region/Framework/StorageManager.cs
@@ -64,9 +64,7 @@ namespace OpenSim.Region.Framework
             {
                 if (pluginType.IsPublic)
                 {
-                    Type typeInterface = pluginType.GetInterface("IRegionDataStore", true);
-
-                    if (typeInterface != null)
+                    if (typeof(IRegionDataStore).IsAssignableFrom(pluginType))
                     {
                         IRegionDataStore plug =
                             (IRegionDataStore) Activator.CreateInstance(pluginAssembly.GetType(pluginType.ToString()));
@@ -77,9 +75,7 @@ namespace OpenSim.Region.Framework
                         m_log.Info("[DATASTORE]: Added IRegionDataStore Interface");
                     }
 
-                    typeInterface = pluginType.GetInterface("IEstateDataStore", true);
-
-                    if (typeInterface != null)
+                    if (typeof(IEstateDataStore).IsAssignableFrom(pluginType))
                     {
                         IEstateDataStore estPlug =
                             (IEstateDataStore) Activator.CreateInstance(pluginAssembly.GetType(pluginType.ToString()));

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
@@ -1080,13 +1080,13 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public void GroupRoleUpdate(IClientAPI remoteClient, UUID groupID, UUID roleID, string name, string description, string title, ulong powers, byte updateType)
         {
-            name = Regex.Replace(name, @"[\u000A]", "");
-            description = Regex.Replace(description, @"[\u000A]", "");
-            title = Regex.Replace(title, @"[\u000A]", "");
+            name = Regex.Replace(name, @"[\u000A]", String.Empty);
+            description = Regex.Replace(description, @"[\u000A]", String.Empty);
+            title = Regex.Replace(title, @"[\u000A]", String.Empty);
 
-            name = Regex.Replace(name, @"[\u000B]", "");
-            description = Regex.Replace(description, @"[\u000B]", "");
-            title = Regex.Replace(title, @"[\u000B]", "");
+            name = Regex.Replace(name, @"[\u000B]", String.Empty);
+            description = Regex.Replace(description, @"[\u000B]", String.Empty);
+            title = Regex.Replace(title, @"[\u000B]", String.Empty);
 
             if (m_debugEnabled) m_log.DebugFormat("[GROUPS]: {0} called", System.Reflection.MethodBase.GetCurrentMethod().Name);
 
@@ -1181,7 +1181,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                 notice.noticeData.AssetType = 0;
                 notice.noticeData.OwnerID = UUID.Zero;
                 notice.noticeData.ItemID = UUID.Zero;
-                notice.noticeData.Attachment = "";
+                notice.noticeData.Attachment = String.Empty;
             }
             else
             {   // we have enough attachment data
@@ -1461,7 +1461,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             int rc = m_groupData.AddAgentToGroupInvite(grID, agentID, InviteID, groupID, roleID, invitedAgentID, out reason);
             if (rc != 0)
             {
-                if ((remoteClient != null) && (reason != String.Empty))
+                if (!(remoteClient == null || String.IsNullOrEmpty(reason)))
                     remoteClient.SendAlertMessage(reason);
                 return rc;
             }
@@ -1495,7 +1495,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             msg.binaryBucket = new byte[20];
 
             OutgoingInstantMessage(msg, invitedAgentID);
-            if ((remoteClient != null) && (reason != String.Empty))
+            if (!(remoteClient == null || String.IsNullOrEmpty(reason)))
                 remoteClient.SendAlertMessage(reason);
             return (int)Constants.GenericReturnCodes.SUCCESS;
         }

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
@@ -296,8 +296,8 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             if (m_debugEnabled) m_log.DebugFormat("[GROUPS]: {0} called", System.Reflection.MethodBase.GetCurrentMethod().Name);
 
             UUID activeGroupID = UUID.Zero;
-            string activeGroupTitle = string.Empty;
-            string activeGroupName = string.Empty;
+            string activeGroupTitle = String.Empty;
+            string activeGroupName = String.Empty;
             ulong activeGroupPowers  = (ulong)0;
 
             GroupMembershipData membership = m_groupData.GetAgentActiveMembership(GetClientGroupRequestID(remoteClient), dataForAgentID);
@@ -1058,7 +1058,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             {
                 return membership.GroupTitle;
             } 
-            return string.Empty;
+            return String.Empty;
         }
 
         /// <summary>

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/IGroupDataProvider.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/IGroupDataProvider.cs
@@ -89,7 +89,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
     public class GroupRequestID
     {
         public UUID AgentID = UUID.Zero;
-        public string UserServiceURL = string.Empty;
+        public string UserServiceURL = String.Empty;
         public UUID SessionID = UUID.Zero;
     }
 
@@ -97,7 +97,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
     {
         public GroupNoticeData noticeData = new GroupNoticeData();
         public UUID GroupID = UUID.Zero;
-        public string Message = string.Empty;
+        public string Message = String.Empty;
         public byte[] BinaryBucket = null;
     }
 

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/NativeGroupDataProvider.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/NativeGroupDataProvider.cs
@@ -1493,7 +1493,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                 if (db == null)
                     return false;
 
-                string binBucketString = OpenMetaverse.Utils.BytesToHexString(binaryBucket, "");
+                string binBucketString = OpenMetaverse.Utils.BytesToHexString(binaryBucket, String.Empty);
 
                 string query = " INSERT INTO osgroupnotice" +
                                 " (GroupID, NoticeID, Timestamp, FromName, Subject, Message, BinaryBucket)" +
@@ -1588,7 +1588,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                 data.AssetType = 0;
                 data.OwnerID = UUID.Zero;
                 data.ItemID = UUID.Zero;
-                data.Attachment = "";
+                data.Attachment = String.Empty;
             } else {
                 data.HasAttachment = true;
                 data.AssetType = bucket[1];

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/NativeGroupDataProvider.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/NativeGroupDataProvider.cs
@@ -220,7 +220,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                     query += " osgroup.GroupID = ?groupID ";
                     parms.Add("?groupID", GroupID);
                 }
-                else if ((GroupName != null) && (GroupName != string.Empty))
+                else if ((GroupName != null) && (GroupName != String.Empty))
                 {
                     query += " osgroup.Name = ?groupName ";
                     parms.Add("?groupName", GroupName);
@@ -1611,7 +1611,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             data.noticeData.FromName = result["FromName"];
             data.noticeData.Subject = result["Subject"];
             if (data.Message == null)
-                data.Message = string.Empty;
+                data.Message = String.Empty;
 
             data.BinaryBucket = Utils.HexStringToBytes(result["BinaryBucket"], true);
 

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/ProviderFactory.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/ProviderFactory.cs
@@ -47,8 +47,8 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                     string ServiceURL = groupsConfig.GetString("XmlRpcServiceURL");
                     bool DisableKeepAlive = groupsConfig.GetBoolean("XmlRpcDisableKeepAlive", false);
 
-                    string ServiceReadKey = groupsConfig.GetString("XmlRpcServiceReadKey", string.Empty);
-                    string ServiceWriteKey = groupsConfig.GetString("XmlRpcServiceWriteKey", string.Empty);
+                    string ServiceReadKey = groupsConfig.GetString("XmlRpcServiceReadKey", String.Empty);
+                    string ServiceWriteKey = groupsConfig.GetString("XmlRpcServiceWriteKey", String.Empty);
 
                     log.InfoFormat("[GROUPS]: XmlRpc Service URL set to: {0}", ServiceURL);
 

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/XmlRpcGroupData.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/XmlRpcGroupData.cs
@@ -49,17 +49,17 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
         private static readonly ILog m_log =
             LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        private string m_serviceURL = string.Empty;
+        private string m_serviceURL = String.Empty;
 
-        private string m_groupReadKey  = string.Empty;
-        private string m_groupWriteKey = string.Empty;
+        private string m_groupReadKey  = String.Empty;
+        private string m_groupWriteKey = String.Empty;
 
         public XmlRpcGroupDataProvider(string serviceURL, bool disableKeepAlive, string groupReadKey, string groupWriteKey)
         {
             m_serviceURL = serviceURL.Trim();
 
             if ((serviceURL == null) ||
-                (serviceURL == string.Empty))
+                (serviceURL == String.Empty))
             {
                 throw new Exception("Please specify a valid ServiceURL for XmlRpcGroupDataProvider in Halcyon.ini, [Groups], XmlRpcServiceURL");
             }
@@ -181,7 +181,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             {
                 param["GroupID"] = GroupID.ToString();
             }
-            if ((GroupName != null) && (GroupName != string.Empty))
+            if ((GroupName != null) && (GroupName != String.Empty))
             {
                 param["Name"] = GroupName.ToString();
             }
@@ -683,7 +683,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
             if (data.Message == null)
             {
-                data.Message = string.Empty;
+                data.Message = String.Empty;
             }
 
             return data;

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/XmlRpcGroupData.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/XmlRpcGroupData.cs
@@ -690,7 +690,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
         }
         public bool AddGroupNotice(GroupRequestID requestID, UUID groupID, UUID noticeID, string fromName, string subject, string message, byte[] binaryBucket)
         {
-            string binBucket = OpenMetaverse.Utils.BytesToHexString(binaryBucket, "");
+            string binBucket = OpenMetaverse.Utils.BytesToHexString(binaryBucket, String.Empty);
 
             Hashtable param = new Hashtable();
             param["GroupID"] = groupID.ToString();

--- a/OpenSim/Region/OptionalModules/Avatar/Voice/FreeSwitchVoice/FreeSwitchDirectory.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Voice/FreeSwitchVoice/FreeSwitchDirectory.cs
@@ -96,7 +96,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
                      m_log.ErrorFormat("[FreeSwitchVoice] HandleDirectoryRequest unknown sip_auth_method {0}",sipAuthMethod);
                      response["int_response_code"] = 404;
                      response["content_type"] = "text/xml";
-                     response["str_response_string"] = "";
+                     response["str_response_string"] = String.Empty;
                  }
              }
              else if (eventCallingFunction == "switch_xml_locate_user")
@@ -121,7 +121,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
                  response["int_response_code"] = 404;
                  response["keepalive"] = false;
                  response["content_type"] = "text/xml";
-                 response["str_response_string"] = "";
+                 response["str_response_string"] = String.Empty;
              }
              else
              {
@@ -129,7 +129,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
                  response["int_response_code"] = 404;
                  response["keepalive"] = false;
                  response["content_type"] = "text/xml";
-                 response["str_response_string"] = "";
+                 response["str_response_string"] = String.Empty;
              }
              return response;   
         }

--- a/OpenSim/Region/OptionalModules/Avatar/Voice/FreeSwitchVoice/FreeSwitchVoiceModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Voice/FreeSwitchVoice/FreeSwitchVoiceModule.cs
@@ -754,7 +754,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
 
             foreach (string s in nvps) {
     
-                if (s.Trim() != String.Empty)
+                if (!String.IsNullOrWhiteSpace(s))
                 {
                     string [] nvp = s.Split(new Char [] {'='});
                     bodyParams.Add(HttpUtility.UrlDecode(nvp[0]), HttpUtility.UrlDecode(nvp[1]));

--- a/OpenSim/Region/OptionalModules/Avatar/Voice/FreeSwitchVoice/FreeSwitchVoiceModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Voice/FreeSwitchVoice/FreeSwitchVoiceModule.cs
@@ -501,7 +501,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
             m_log.Debug("[PROXYING]: -------------------------------proxying request");
             Hashtable response = new Hashtable();
             response["content_type"] = "text/xml";
-            response["str_response_string"] = "";
+            response["str_response_string"] = String.Empty;
             response["int_response_code"] = 200;
 
             string forwardaddress = "https://www.bhr.vivox.com/api2/";
@@ -509,11 +509,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
             string method = (string) request["http-method"];
             string contenttype = (string) request["content-type"];
             string uri = (string) request["uri"];
-            uri = uri.Replace("/api/", "");
+            uri = uri.Replace("/api/", String.Empty);
             forwardaddress += uri;
 
 
-            string fwdresponsestr = "";
+            string fwdresponsestr = String.Empty;
             int fwdresponsecode = 200;
             string fwdresponsecontenttype = "text/xml";
             
@@ -574,7 +574,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
                 m_freeSwitchRealm, m_freeSwitchSIPProxy, m_freeSwitchAttemptUseSTUN,
                 m_freeSwitchSTUNServer, m_freeSwitchEchoServer, m_freeSwitchEchoPort,
                 m_freeSwitchDefaultWellKnownIP, m_freeSwitchDefaultTimeout, 
-                m_freeSwitchUrlResetPassword, "");
+                m_freeSwitchUrlResetPassword, String.Empty);
             
             response["int_response_code"] = 200;
 
@@ -742,7 +742,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
             //      -> TODO Initialize(): keep track of avatars via events
             Regex normalizeEndLines = new Regex(@"\r\n", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.Multiline);
 
-            m_log.DebugFormat("[FreeSwitchVoice] FreeSwitchConfigHTTPHandler return {0}",normalizeEndLines.Replace(((string)response["str_response_string"]), ""));
+            m_log.DebugFormat("[FreeSwitchVoice] FreeSwitchConfigHTTPHandler return {0}",normalizeEndLines.Replace(((string)response["str_response_string"]), String.Empty));
             return response;
         }
         
@@ -754,7 +754,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
 
             foreach (string s in nvps) {
     
-                if (s.Trim() != "")
+                if (s.Trim() != String.Empty)
                 {
                     string [] nvp = s.Split(new Char [] {'='});
                     bodyParams.Add(HttpUtility.UrlDecode(nvp[0]), HttpUtility.UrlDecode(nvp[1]));

--- a/OpenSim/Region/OptionalModules/Avatar/Voice/FreeSwitchVoice/FreeSwitchVoiceModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Voice/FreeSwitchVoice/FreeSwitchVoiceModule.cs
@@ -586,7 +586,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
         {
             Hashtable response = new Hashtable();
             response["int_response_code"] = 200;
-            response["str_response_string"] = string.Empty;
+            response["str_response_string"] = String.Empty;
             response["content-type"] = "text/xml";
 
             Hashtable requestBody = parseRequestBody((string)request["body"]);
@@ -666,7 +666,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
             //string pwd = (string) requestBody["pwd"];
             string userid = (string) requestBody["userid"];
 
-            string avatarName = string.Empty;
+            string avatarName = String.Empty;
             int pos = -1;
             lock (m_UUIDName)
             {
@@ -720,7 +720,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
             m_log.DebugFormat("[FreeSwitchVoice] FreeSwitchConfigHTTPHandler called with {0}", (string)request["body"]);
             
             Hashtable response = new Hashtable();
-            response["str_response_string"] = string.Empty;
+            response["str_response_string"] = String.Empty;
             // all the params come as NVPs in the request body
             Hashtable requestBody = parseRequestBody((string) request["body"]);
 

--- a/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/IGroupDataProvider.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/IGroupDataProvider.cs
@@ -84,7 +84,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups
     public class GroupRequestID
     {
         public UUID AgentID = UUID.Zero;
-        public string UserServiceURL = string.Empty;
+        public string UserServiceURL = String.Empty;
         public UUID SessionID = UUID.Zero;
     }
 }

--- a/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/XmlRpcGroupData.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/XmlRpcGroupData.cs
@@ -681,7 +681,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups
         }
         public void AddGroupNotice(GroupRequestID requestID, UUID groupID, UUID noticeID, string fromName, string subject, string message, byte[] binaryBucket)
         {
-            string binBucket = OpenMetaverse.Utils.BytesToHexString(binaryBucket, "");
+            string binBucket = OpenMetaverse.Utils.BytesToHexString(binaryBucket, String.Empty);
 
             Hashtable param = new Hashtable();
             param["GroupID"] = groupID.ToString();

--- a/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/XmlRpcGroupData.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/XmlRpcGroupData.cs
@@ -49,12 +49,12 @@ namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups
         private static readonly ILog m_log =
             LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        private string m_serviceURL = string.Empty;
+        private string m_serviceURL = String.Empty;
 
         private bool m_disableKeepAlive = false;
 
-        private string m_groupReadKey  = string.Empty;
-        private string m_groupWriteKey = string.Empty;
+        private string m_groupReadKey  = String.Empty;
+        private string m_groupWriteKey = String.Empty;
 
         public XmlRpcGroupDataProvider(string serviceURL, bool disableKeepAlive, string groupReadKey, string groupWriteKey)
         {
@@ -62,7 +62,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups
             m_disableKeepAlive = disableKeepAlive;
 
             if ((serviceURL == null) ||
-                (serviceURL == string.Empty))
+                (serviceURL == String.Empty))
             {
                 throw new Exception("Please specify a valid ServiceURL for XmlRpcGroupDataProvider in Halcyon.ini, [Groups], XmlRpcServiceURL");
             }
@@ -184,7 +184,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups
             {
                 param["GroupID"] = GroupID.ToString();
             }
-            if ((GroupName != null) && (GroupName != string.Empty))
+            if ((GroupName != null) && (GroupName != String.Empty))
             {
                 param["Name"] = GroupName.ToString();
             }
@@ -674,7 +674,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups
 
             if (data.Message == null)
             {
-                data.Message = string.Empty;
+                data.Message = String.Empty;
             }
 
             return data;
@@ -797,7 +797,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups
     {
         public GroupNoticeData noticeData = new GroupNoticeData();
         public UUID GroupID = UUID.Zero;
-        public string Message = string.Empty;
+        public string Message = String.Empty;
         public byte[] BinaryBucket = new byte[0];
     }
 }

--- a/OpenSim/Region/OptionalModules/Scripting/XmlRpcRouterModule/XmlRpcGridRouterModule.cs
+++ b/OpenSim/Region/OptionalModules/Scripting/XmlRpcRouterModule/XmlRpcGridRouterModule.cs
@@ -69,7 +69,7 @@ namespace OpenSim.Region.OptionalModules.Scripting.XmlRpcGridRouterModule
                     "XmlRpcRouterModule") == "XmlRpcGridRouterModule")
             {
                 m_ServerURI = startupConfig.GetString("XmlRpcHubURI", String.Empty);
-                if (m_ServerURI == String.Empty)
+                if (String.IsNullOrEmpty(m_ServerURI))
                 {
                     m_log.Error("[XMLRPC GRID ROUTER] Module configured but no URI given. Disabling");
                     return;

--- a/OpenSim/Region/Physics/Manager/PhysicsPluginManager.cs
+++ b/OpenSim/Region/Physics/Manager/PhysicsPluginManager.cs
@@ -170,9 +170,7 @@ namespace OpenSim.Region.Physics.Manager
                         {
                             if (!pluginType.IsAbstract)
                             {
-                                Type physTypeInterface = pluginType.GetInterface("IPhysicsPlugin", true);
-
-                                if (physTypeInterface != null)
+                                if (typeof(IPhysicsPlugin).IsAssignableFrom(pluginType))
                                 {
                                     IPhysicsPlugin plug =
                                         (IPhysicsPlugin)Activator.CreateInstance(pluginAssembly.GetType(pluginType.ToString()));
@@ -184,9 +182,7 @@ namespace OpenSim.Region.Physics.Manager
                                     }
                                 }
 
-                                Type meshTypeInterface = pluginType.GetInterface("IMeshingPlugin", true);
-
-                                if (meshTypeInterface != null)
+                                if (typeof(IMeshingPlugin).IsAssignableFrom(pluginType))
                                 {
                                     IMeshingPlugin plug =
                                         (IMeshingPlugin)Activator.CreateInstance(pluginAssembly.GetType(pluginType.ToString()));
@@ -196,9 +192,6 @@ namespace OpenSim.Region.Physics.Manager
                                         m_log.Info("[PHYSICS]: Added meshing engine: " + plug.GetName());
                                     }
                                 }
-
-                                physTypeInterface = null;
-                                meshTypeInterface = null;
                             }
                         }
                     }

--- a/OpenSim/Region/Physics/Meshing/PrimMesher.cs
+++ b/OpenSim/Region/Physics/Meshing/PrimMesher.cs
@@ -1570,7 +1570,7 @@ namespace PrimMesher
 
     public class PrimMesh
     {
-        public string errorMessage = "";
+        public string errorMessage = String.Empty;
         private const float twoPi = 2.0f * (float)Math.PI;
 
         public List<Coord> coords;
@@ -1619,7 +1619,7 @@ namespace PrimMesher
         /// <returns></returns>
         public string ParamsToDisplayString()
         {
-            string s = "";
+            string s = String.Empty;
             s += "sides..................: " + this.sides.ToString();
             s += "\nhollowSides..........: " + this.hollowSides.ToString();
             s += "\nprofileStart.........: " + this.profileStart.ToString();

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/SensorRepeat.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/SensorRepeat.cs
@@ -336,7 +336,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
 
             Vector3 ZeroVector = new Vector3(0, 0, 0);
 
-            bool nameSearch = (ts.name != null && ts.name != String.Empty);
+            bool nameSearch = !String.IsNullOrEmpty(ts.name);
 
             foreach (EntityBase ent in Entities)
             {
@@ -490,7 +490,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
             double mag_fwd = Vector3.Mag(forward_dir);
 
             bool attached = (GetAttachmentPoint(SensePoint) != 0);
-            bool nameSearch = (ts.name != null && ts.name != String.Empty);
+            bool nameSearch = !String.IsNullOrEmpty(ts.name);
             Vector3 toRegionPos;
             double dis;
 

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/SensorRepeat.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/SensorRepeat.cs
@@ -336,7 +336,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
 
             Vector3 ZeroVector = new Vector3(0, 0, 0);
 
-            bool nameSearch = (ts.name != null && ts.name != "");
+            bool nameSearch = (ts.name != null && ts.name != String.Empty);
 
             foreach (EntityBase ent in Entities)
             {
@@ -490,7 +490,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
             double mag_fwd = Vector3.Mag(forward_dir);
 
             bool attached = (GetAttachmentPoint(SensePoint) != 0);
-            bool nameSearch = (ts.name != null && ts.name != "");
+            bool nameSearch = (ts.name != null && ts.name != String.Empty);
             Vector3 toRegionPos;
             double dis;
 

--- a/OpenSim/Region/ScriptEngine/Shared/LSL_Types.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/LSL_Types.cs
@@ -898,10 +898,10 @@ namespace OpenSim.Region.ScriptEngine.Shared
 
             public string ToCSV()
             {
-                string ret = "";
+                string ret = String.Empty;
                 foreach (object o in this.Data)
                 {
-                    if (ret == "")
+                    if (String.IsNullOrEmpty(ret))
                     {
                         ret = o.ToString();
                     }
@@ -1484,7 +1484,7 @@ namespace OpenSim.Region.ScriptEngine.Shared
             public LSLInteger(string s)
             {
                 //if string begins with + remove it (fixes mantis 522)
-                if (s != String.Empty && s[0] == '+')
+                if (!String.IsNullOrEmpty(s) && s[0] == '+')
                 {
                     s = s.Remove(0, 1);
                 }
@@ -1493,7 +1493,7 @@ namespace OpenSim.Region.ScriptEngine.Shared
                 Match m = r.Match(s);
                 string v = m.Groups[0].Value;
 
-                if (v == String.Empty)
+                if (String.IsNullOrEmpty(v))
                 {
                     value = 0;
                 }
@@ -1782,7 +1782,7 @@ namespace OpenSim.Region.ScriptEngine.Shared
             public LSLFloat(string s)
             {
                 //if string begins with + remove it (fixes mantis 522)
-                if (s != String.Empty && s[0] == '+')
+                if (!String.IsNullOrEmpty(s) && s[0] == '+')
                 {
                     s = s.Remove(0, 1);
                 }
@@ -1793,7 +1793,7 @@ namespace OpenSim.Region.ScriptEngine.Shared
 
                 v = v.Trim();
 
-                if (v == String.Empty || v == null)
+                if (String.IsNullOrEmpty(v))
                     v = "0.0";
                 else
                     if (!v.Contains(".") && !v.ToLower().Contains("e"))

--- a/OpenSim/ScriptEngine/Shared/ScriptMetaData.cs
+++ b/OpenSim/ScriptEngine/Shared/ScriptMetaData.cs
@@ -40,7 +40,7 @@ namespace OpenSim.ScriptEngine.Shared
                 return ret;
 
             // Process it line by line
-            string Line = "";
+            string Line = String.Empty;
             for (int i = 0; i < Script.Length + 1; i++)
             {
                 // Found a line separator?
@@ -57,7 +57,7 @@ namespace OpenSim.ScriptEngine.Shared
                     if (!_GetMetaFromLine(ret, Line))
                         continue;
                     // Empty for next round
-                    Line = "";
+                    Line = String.Empty;
                 }
             }
             return ret;
@@ -68,7 +68,7 @@ namespace OpenSim.ScriptEngine.Shared
             line = line.Trim();
 
             // Empty line? We may find more later
-            if (line == "")
+            if (String.IsNullOrEmpty(line))
                 return true;
 
             // Is this a comment? If not, then return false
@@ -81,7 +81,7 @@ namespace OpenSim.ScriptEngine.Shared
             keyval[1] = keyval[1].Trim();
 
             // Add it
-            if (keyval[0] != "")
+            if (keyval[0] != String.Empty)
                 if (!ret.ContainsKey(keyval[0]))
                 {
                     //m_log.DebugFormat("[DotNetEngine] Script metadata: Key: \"{0}\", Value: \"{1}\".", keyval[0], keyval[1]);

--- a/OpenSim/ScriptEngine/Shared/ScriptMetaData.cs
+++ b/OpenSim/ScriptEngine/Shared/ScriptMetaData.cs
@@ -81,12 +81,11 @@ namespace OpenSim.ScriptEngine.Shared
             keyval[1] = keyval[1].Trim();
 
             // Add it
-            if (keyval[0] != String.Empty)
-                if (!ret.ContainsKey(keyval[0]))
-                {
-                    //m_log.DebugFormat("[DotNetEngine] Script metadata: Key: \"{0}\", Value: \"{1}\".", keyval[0], keyval[1]);
-                    ret.Add(keyval[0], keyval[1]);
-                }
+            if (!String.IsNullOrEmpty(keyval[0]) && !ret.ContainsKey(keyval[0]))
+            {
+                //m_log.DebugFormat("[DotNetEngine] Script metadata: Key: \"{0}\", Value: \"{1}\".", keyval[0], keyval[1]);
+                ret.Add(keyval[0], keyval[1]);
+            }
 
             return true;
         }

--- a/OpenSim/Servers/Base/HttpServerBase.cs
+++ b/OpenSim/Servers/Base/HttpServerBase.cs
@@ -95,13 +95,13 @@ namespace OpenSim.Servers.Base
             else
             {
                 string cert_path = networkConfig.GetString("cert_path", String.Empty);
-                if (cert_path == String.Empty)
+                if (String.IsNullOrEmpty(cert_path))
                 {
                     System.Console.WriteLine("Path to X509 certificate is missing, server can't start.");
                     Thread.CurrentThread.Abort();
                 }
                 string cert_pass = networkConfig.GetString("cert_pass", String.Empty);
-                if (cert_pass == String.Empty)
+                if (String.IsNullOrEmpty(cert_pass))
                 {
                     System.Console.WriteLine("Password for X509 certificate is missing, server can't start.");
                     Thread.CurrentThread.Abort();
@@ -122,13 +122,13 @@ namespace OpenSim.Servers.Base
                 uint https_port = (uint)networkConfig.GetInt("https_port", 0);
 
                 string cert_path = networkConfig.GetString("cert_path", String.Empty);
-                if (cert_path == String.Empty)
+                if (String.IsNullOrEmpty(cert_path))
                 {
                     System.Console.WriteLine("Path to X509 certificate is missing, server can't start.");
                     Thread.CurrentThread.Abort();
                 }
                 string cert_pass = networkConfig.GetString("cert_pass", String.Empty);
-                if (cert_pass == String.Empty)
+                if (String.IsNullOrEmpty(cert_pass))
                 {
                     System.Console.WriteLine("Password for X509 certificate is missing, server can't start.");
                     Thread.CurrentThread.Abort();

--- a/OpenSim/Servers/Base/ServerUtils.cs
+++ b/OpenSim/Servers/Base/ServerUtils.cs
@@ -110,7 +110,7 @@ namespace OpenSim.Servers.Base
         public static T LoadPlugin<T>(string dllName, Object[] args) where T:class
         {
             // This is good to debug configuration problems
-            //if (dllName == string.Empty)
+            //if (dllName == String.Empty)
             //    Util.PrintCallStack();
 
             string[] parts = dllName.Split(new char[] {':'});

--- a/OpenSim/Servers/Base/ServerUtils.cs
+++ b/OpenSim/Servers/Base/ServerUtils.cs
@@ -142,7 +142,7 @@ namespace OpenSim.Servers.Base
                 {
                     if (pluginType.IsPublic)
                     {
-                        if ((className != String.Empty) && 
+                        if (!String.IsNullOrEmpty(className) && 
                              (pluginType.ToString() != pluginType.Namespace + "." + className))
                             continue;
                         
@@ -253,7 +253,7 @@ namespace OpenSim.Servers.Base
                         part = System.Web.HttpUtility.UrlEncode(kvp.Key) +
                                 "[]=" + System.Web.HttpUtility.UrlEncode(s);
 
-                        if (qstring != String.Empty)
+                        if (!String.IsNullOrEmpty(qstring))
                             qstring += "&";
 
                         qstring += part;
@@ -261,7 +261,7 @@ namespace OpenSim.Servers.Base
                 }
                 else
                 {
-                    if (kvp.Value.ToString() != String.Empty)
+                    if (!String.IsNullOrEmpty(kvp.Value.ToString()))
                     {
                         part = System.Web.HttpUtility.UrlEncode(kvp.Key) +
                                 "=" + System.Web.HttpUtility.UrlEncode(kvp.Value.ToString());
@@ -271,7 +271,7 @@ namespace OpenSim.Servers.Base
                         part = System.Web.HttpUtility.UrlEncode(kvp.Key);
                     }
 
-                    if (qstring != String.Empty)
+                    if (!String.IsNullOrEmpty(qstring))
                         qstring += "&";
 
                     qstring += part;
@@ -286,12 +286,12 @@ namespace OpenSim.Servers.Base
             XmlDocument doc = new XmlDocument();
 
             XmlNode xmlnode = doc.CreateNode(XmlNodeType.XmlDeclaration,
-                    "", "");
+                    String.Empty, String.Empty);
 
             doc.AppendChild(xmlnode);
 
-            XmlElement rootElement = doc.CreateElement("", "ServerResponse",
-                    "");
+            XmlElement rootElement = doc.CreateElement(String.Empty, "ServerResponse",
+                    String.Empty);
 
             doc.AppendChild(rootElement);
 
@@ -307,13 +307,13 @@ namespace OpenSim.Servers.Base
                 if (kvp.Value == null)
                     continue;
 
-                XmlElement elem = parent.OwnerDocument.CreateElement("",
-                        XmlConvert.EncodeLocalName(kvp.Key), "");
+                XmlElement elem = parent.OwnerDocument.CreateElement(String.Empty,
+                        XmlConvert.EncodeLocalName(kvp.Key), String.Empty);
 
                 if (kvp.Value is Dictionary<string, object>)
                 {
-                    XmlAttribute type = parent.OwnerDocument.CreateAttribute("",
-                        "type", "");
+                    XmlAttribute type = parent.OwnerDocument.CreateAttribute(String.Empty,
+                        "type", String.Empty);
                     type.Value = "List";
 
                     elem.Attributes.Append(type);

--- a/OpenSim/Servers/Base/ServerUtils.cs
+++ b/OpenSim/Servers/Base/ServerUtils.cs
@@ -134,8 +134,6 @@ namespace OpenSim.Servers.Base
         /// <returns></returns>
         public static T LoadPlugin<T>(string dllName, string className, Object[] args) where T:class
         {
-            string interfaceName = typeof(T).ToString();
-
             try
             {
                 Assembly pluginAssembly = Assembly.LoadFrom(dllName);
@@ -148,9 +146,7 @@ namespace OpenSim.Servers.Base
                              (pluginType.ToString() != pluginType.Namespace + "." + className))
                             continue;
                         
-                        Type typeInterface = pluginType.GetInterface(interfaceName, true);
-
-                        if (typeInterface != null)
+                        if (typeof (T).IsAssignableFrom(pluginType))
                         {
                             T plug = null;
                             try
@@ -163,7 +159,7 @@ namespace OpenSim.Servers.Base
                                 if (!(e is System.MissingMethodException))
                                 {
                                     m_log.ErrorFormat("Error loading plugin {0} from {1}. Exception: {2}",
-                                        interfaceName, dllName, e.InnerException == null ? e.Message : e.InnerException.Message);
+                                        typeof(T).ToString(), dllName, e.InnerException == null ? e.Message : e.InnerException.Message);
                                 }
                                 return null;
                             }

--- a/OpenSim/Servers/Base/ServicesServerBase.cs
+++ b/OpenSim/Servers/Base/ServicesServerBase.cs
@@ -238,7 +238,7 @@ namespace OpenSim.Servers.Base
                 }
             }
 
-            if (startupConfig.GetString("PIDFile", String.Empty) != String.Empty)
+            if (!String.IsNullOrEmpty(startupConfig.GetString("PIDFile", String.Empty)))
             {
                 CreatePIDFile(startupConfig.GetString("PIDFile"));
             }
@@ -288,7 +288,7 @@ namespace OpenSim.Servers.Base
                 }
             }
 
-            if (m_pidFile != String.Empty)
+            if (!String.IsNullOrEmpty(m_pidFile))
                 File.Delete(m_pidFile);
             return 0;
         }
@@ -323,7 +323,7 @@ namespace OpenSim.Servers.Base
                     string currentCommand;
                     while ((currentCommand = readFile.ReadLine()) != null)
                     {
-                        if (currentCommand != String.Empty)
+                        if (!String.IsNullOrEmpty(currentCommand))
                         {
                             m_log.Info("[COMMANDFILE]: Running '" + currentCommand + "'");
                             MainConsole.Instance.RunCommand(currentCommand);

--- a/OpenSim/Services/AssetService/AssetServiceBase.cs
+++ b/OpenSim/Services/AssetService/AssetServiceBase.cs
@@ -48,7 +48,7 @@ namespace OpenSim.Services.AssetService
 
         public AssetServiceBase(IConfigSource config, string configName) : base(config)
         {
-            if (configName != string.Empty)
+            if (configName != String.Empty)
                 m_ConfigName = configName;
 
             string dllName = String.Empty;

--- a/OpenSim/Services/AssetService/AssetServiceBase.cs
+++ b/OpenSim/Services/AssetService/AssetServiceBase.cs
@@ -70,9 +70,9 @@ namespace OpenSim.Services.AssetService
             IConfig dbConfig = config.Configs["DatabaseService"];
             if (dbConfig != null)
             {
-                if (dllName == String.Empty)
+                if (String.IsNullOrEmpty(dllName))
                     dllName = dbConfig.GetString("StorageProvider", String.Empty);
-                if (connString == String.Empty)
+                if (String.IsNullOrEmpty(connString))
                     connString = dbConfig.GetString("ConnectionString", String.Empty);
             }
 
@@ -91,7 +91,7 @@ namespace OpenSim.Services.AssetService
             string loaderName = assetConfig.GetString("DefaultAssetLoader",
                     String.Empty);
 
-            if (loaderName != String.Empty)
+            if (!String.IsNullOrEmpty(loaderName))
             {
                 m_AssetLoader = LoadPlugin<IAssetLoader>(loaderName);
 

--- a/OpenSim/Services/Base/ServiceBase.cs
+++ b/OpenSim/Services/Base/ServiceBase.cs
@@ -71,7 +71,7 @@ namespace OpenSim.Services.Base
 
                     if (pluginType.IsPublic)
                     {
-                        if (className != String.Empty &&
+                        if (!String.IsNullOrEmpty(className) &&
                                 pluginType.ToString() !=
                                 pluginType.Namespace + "." + className)
                             continue;

--- a/OpenSim/Services/Base/ServiceBase.cs
+++ b/OpenSim/Services/Base/ServiceBase.cs
@@ -59,8 +59,6 @@ namespace OpenSim.Services.Base
 
         public T LoadPlugin<T>(string dllName, string className, Object[] args) where T:class
         {
-            string interfaceName = typeof(T).ToString();
-
             try
             {
                 Assembly pluginAssembly = Assembly.LoadFrom(dllName);
@@ -78,9 +76,7 @@ namespace OpenSim.Services.Base
                                 pluginType.Namespace + "." + className)
                             continue;
 
-                        Type typeInterface =
-                                pluginType.GetInterface(interfaceName, true);
-                        if (typeInterface != null)
+                        if (typeof(T).IsAssignableFrom(pluginType))
                         {
                             T plug = (T)Activator.CreateInstance(pluginType,
                                     args);
@@ -101,7 +97,7 @@ namespace OpenSim.Services.Base
                 m_log.Error(
                     string.Format(
                         "[SERVICE BASE]: Failed to load plugin {0} from {1} with args {2}", 
-                        interfaceName, dllName, string.Join(", ", strArgs.ToArray())), e);
+                        typeof (T).ToString(), dllName, string.Join(", ", strArgs.ToArray())), e);
                 
                 return null;
             }

--- a/OpenSim/Services/UserService/UserServiceBase.cs
+++ b/OpenSim/Services/UserService/UserServiceBase.cs
@@ -47,7 +47,7 @@ namespace OpenSim.Services.UserService
             string dllName = userConfig.GetString("StorageProvider",
                     String.Empty);
 
-            if (dllName == String.Empty)
+            if (String.IsNullOrEmpty(dllName))
                 throw new Exception("No StorageProvider configured");
 
             string connString = userConfig.GetString("ConnectionString",

--- a/OpenSim/TestSuite/BotManager.cs
+++ b/OpenSim/TestSuite/BotManager.cs
@@ -124,7 +124,7 @@ namespace OpenSim.TestSuite
         /// <returns></returns>
         private string CreateRandomName()
         {
-            string returnstring = "";
+            string returnstring = String.Empty;
             string chars = "abcdefghijklmnopqrstuvwxyz0123456789";
 
             for (int i = 0; i < 7; i++)

--- a/OpenSim/TestSuite/PhysicsBot.cs
+++ b/OpenSim/TestSuite/PhysicsBot.cs
@@ -181,7 +181,7 @@ namespace OpenSim.TestSuite
 
         public string[] readexcuses()
         {
-            string allexcuses = "";
+            string allexcuses = String.Empty;
 
             string file = Path.Combine(Util.configDir(), "pCampBotSentences.txt");
             if (File.Exists(file))

--- a/OpenSimProfile/Modules/OpenProfile.cs
+++ b/OpenSimProfile/Modules/OpenProfile.cs
@@ -143,10 +143,10 @@ namespace OpenSimProfile.Modules.OpenProfile
             using (ISimpleDB db = _connFactory.GetConnection())
             {
                 uint skillsMask = new uint();
-                string skillsText = "";
+                string skillsText = String.Empty;
                 uint wantToMask = new uint();
-                string wantToText = "";
-                string languagesText = "";
+                string wantToText = String.Empty;
+                string languagesText = String.Empty;
 
                 Dictionary<string, object> parms = new Dictionary<string, object>();
                 parms.Add("?avatarID", avatarID);
@@ -324,8 +324,8 @@ namespace OpenSimProfile.Modules.OpenProfile
                 // explode the GlobalPos value off the bat
 
                 string origGlobPos = queryGlobalPos.ToString();
-                string tempAGlobPos = origGlobPos.Replace("<", "");
-                string tempBGlobPos = tempAGlobPos.Replace(">", "");
+                string tempAGlobPos = origGlobPos.Replace("<", String.Empty);
+                string tempBGlobPos = tempAGlobPos.Replace(">", String.Empty);
 
                 char[] delimiterChars = { ',', ' ' };
                 string[] globalPosBits = tempBGlobPos.Split(delimiterChars);
@@ -513,12 +513,12 @@ namespace OpenSimProfile.Modules.OpenProfile
 
                 bool topPick = new bool();
                 UUID parcelUUID = new UUID();
-                string name = "";
-                string description = "";
+                string name = String.Empty;
+                string description = String.Empty;
                 UUID snapshotID = new UUID();
-                string userName = "";
-                string originalName = "";
-                string simName = "";
+                string userName = String.Empty;
+                string originalName = String.Empty;
+                string simName = String.Empty;
                 Vector3 globalPos = new Vector3();
                 int sortOrder = new int();
                 bool enabled = new bool();
@@ -629,7 +629,7 @@ namespace OpenSimProfile.Modules.OpenProfile
                 List<Dictionary <string, string>> countList = db.QueryWithResults(queryPicksCount, parms);
                 
                 string query;
-                string picksCount="";
+                string picksCount = String.Empty;
                 
                 foreach (Dictionary<string, string> row in countList)
                 {

--- a/OpenSimProfile/Modules/OpenProfile.cs
+++ b/OpenSimProfile/Modules/OpenProfile.cs
@@ -699,11 +699,11 @@ namespace OpenSimProfile.Modules.OpenProfile
                 string query = "SELECT notes from usernotes where useruuid=?avatarID AND targetuuid=?targetID";
                 List<Dictionary<string, string>> notesResult = db.QueryWithResults(query, parms);
 
-                string notes = string.Empty;
+                string notes = String.Empty;
                 if (notesResult.Count > 0)
                     notes = notesResult[0]["notes"];
                 if (notes == LEGACY_EMPTY)  // filter out the old text that said there was no text. ;)
-                    notes = string.Empty;
+                    notes = String.Empty;
 
                 remoteClient.SendAvatarNotesReply(targetAvatarID, notes);
             }
@@ -719,7 +719,7 @@ namespace OpenSimProfile.Modules.OpenProfile
 
             // filter out the old text that said there was no text. ;)
             if (notes == LEGACY_EMPTY)
-                notes = string.Empty;
+                notes = String.Empty;
 
             using (ISimpleDB db = _connFactory.GetConnection())
             {
@@ -729,7 +729,7 @@ namespace OpenSimProfile.Modules.OpenProfile
                 parms.Add("?notes", notes);
 
                 string query;
-                if (notes == string.Empty)
+                if (notes == String.Empty)
                     query = "DELETE FROM usernotes WHERE useruuid=?avatarID AND targetuuid=?targetID";
                 else
                     query = "INSERT INTO usernotes(useruuid, targetuuid, notes) VALUES(?avatarID,?targetID,?notes) ON DUPLICATE KEY UPDATE notes=?notes";


### PR DESCRIPTION
The first commit in the series, 41097cb, is where I first started running Gendarme against the codebase, and it fixes running against Mono 4.2.1.

I admit that I got a mite overzealous on commit 4c1f822, I didn't really need to go through and convert all the "" to String.Empty, but it's at least much more consistent now! If this is the way we want to go, String.Empty vs "" vs string.Empty, we should document it in the [Coding Style](https://github.com/InWorldz/halcyon/wiki/Contributing#coding-style).

Be sure to double check 17d8976 - I'm fairly certain that this didn't change functionality as these fields were not serializable anyway, but I'm not confident enough in my C#foo to be absolutely certain.