### PR TITLE
Dev/mdickson/materials lsl support

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -9750,7 +9750,15 @@ namespace InWorldz.Phlox.Engine
                             return;
 
                         face = rules.GetLSLIntegerItem(idx++);
+
                         string specular_tex = rules.Data[idx++].ToString();
+                        UUID SpecularTextureID = InventoryKey(specular_tex, (int)AssetType.Texture);
+                        if (SpecularTextureID == UUID.Zero)
+                            UUID.TryParse(specular_tex, out SpecularTextureID);
+                        if (SpecularTextureID == UUID.Zero)
+                            return;
+                        specular_tex = SpecularTextureID.ToString();
+
                         LSL_Vector specular_repeats = rules.GetVector3Item(idx++);
                         LSL_Vector specular_offsets = rules.GetVector3Item(idx++);
                         float specular_rotation = rules.GetLSLFloatItem(idx++);
@@ -9781,9 +9789,16 @@ namespace InWorldz.Phlox.Engine
                         if (remain < 5)
                             return;
 
-                        // [ string texture, vector repeats, vector offsets, float rotation_in_radians ]
                         face = rules.GetLSLIntegerItem(idx++);
+
                         string normal_tex = rules.Data[idx++].ToString();
+                        UUID NormaLTextureID = InventoryKey(normal_tex, (int)AssetType.Texture);
+                        if (NormaLTextureID == UUID.Zero)
+                            UUID.TryParse(normal_tex, out NormaLTextureID);
+                        if (NormaLTextureID == UUID.Zero)
+                            return;
+                        normal_tex = NormaLTextureID.ToString();
+
                         LSL_Vector normal_repeats = rules.GetVector3Item(idx++);
                         LSL_Vector normal_offsets = rules.GetVector3Item(idx++);
                         float normal_rotation = rules.GetLSLFloatItem(idx++);

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -10568,20 +10568,17 @@ namespace InWorldz.Phlox.Engine
                             {
                                 for (face = 0; face < part.GetNumberOfSides(); face++)
                                 {
-                                    Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
-                                    // XXX Add implementation
+                                    res.AddRange(GetRenderMaterialSpecularData(part, face));
                                 }
                             }
                             else
                             {
                                 if (face >= 0 && face < part.GetNumberOfSides())
                                 {
-                                    Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
-                                    // XXX Add implementation
+                                    res.AddRange(GetRenderMaterialSpecularData(part, face));
                                 }
                             }
                         }
-
                         break;
 
 
@@ -10590,6 +10587,7 @@ namespace InWorldz.Phlox.Engine
                             return new LSL_List(res);
 
                         face = (int)rules.GetLSLIntegerItem(idx++);
+
                         foreach (SceneObjectPart part in parts)
                         {
                             tex = part.Shape.Textures;
@@ -10597,20 +10595,17 @@ namespace InWorldz.Phlox.Engine
                             {
                                 for (face = 0; face < part.GetNumberOfSides(); face++)
                                 {
-                                    Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
-                                    // XXX Add implementation
+                                    res.AddRange(GetRenderMaterialNormalData(part, face));
                                 }
                             }
                             else
                             {
                                 if (face >= 0 && face < part.GetNumberOfSides())
                                 {
-                                    Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
-                                    // XXX Add implementation
+                                    res.AddRange(GetRenderMaterialNormalData(part, face));
                                 }
                             }
                         }
-
                         break;
 
                     case (int)ScriptBaseClass.PRIM_ALPHA_MODE:
@@ -10618,6 +10613,7 @@ namespace InWorldz.Phlox.Engine
                             return new LSL_List(res);
 
                         face = (int)rules.GetLSLIntegerItem(idx++);
+
                         foreach (SceneObjectPart part in parts)
                         {
                             tex = part.Shape.Textures;
@@ -10625,25 +10621,94 @@ namespace InWorldz.Phlox.Engine
                             {
                                 for (face = 0; face < part.GetNumberOfSides(); face++)
                                 {
-                                    Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
-                                    // XXX Add implementation
+                                    res.AddRange(GetRenderMaterialAlphaModeData(part, face));
                                 }
                             }
                             else
                             {
                                 if (face >= 0 && face < part.GetNumberOfSides())
                                 {
-                                    Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
-                                    // XXX Add implementation
+                                    res.AddRange(GetRenderMaterialAlphaModeData(part, face));
                                 }
                             }
                         }
-
                         break;
                 }
             }
 
             return new LSL_List(res);
+        }
+
+        // Returns the list: [string texture, vector repeats, vector offsets, float rot, vector specular_color, integer glossiness, integer environment]
+        private List<object> GetRenderMaterialSpecularData(SceneObjectPart part, int face)
+        {
+            List<object> res = new List<object>();
+
+            Primitive.TextureEntry tex = part.Shape.Textures;
+            Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
+            RenderMaterial mat;
+
+            if ((texface.MaterialID == UUID.Zero) ||
+                (part.Shape.RenderMaterials.ContainsMaterial(texface.MaterialID) == false))
+                mat = RenderMaterial.DefaultMaterial;
+            else
+                mat = part.Shape.RenderMaterials.GetMaterial(texface.MaterialID);
+
+            res.Add(ConditionalTextureNameOrUUID(part, mat.SpecularID).ToString());
+            res.Add(new LSL_Vector(mat.SpecularRepeatX, mat.SpecularRepeatY, 0));
+            res.Add(new LSL_Vector(mat.SpecularOffsetX, mat.SpecularOffsetY, 0));
+            res.Add(mat.SpecularRotation);
+            res.Add(new LSL_Vector(mat.SpecularLightColorR, mat.SpecularLightColorG, mat.SpecularLightColorB));
+            res.Add((int)mat.SpecularLightExponent);
+            res.Add((int)mat.EnvironmentIntensity);
+
+            return res;
+        }
+
+        //  Returns the list: [ string texture, vector repeats, vector offsets, float rot ]
+        private List<object> GetRenderMaterialNormalData(SceneObjectPart part, int face)
+        {
+
+            List<object> res = new List<object>();
+
+            Primitive.TextureEntry tex = part.Shape.Textures;
+            Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
+            RenderMaterial mat;
+
+            if ((texface.MaterialID == UUID.Zero) ||
+                (part.Shape.RenderMaterials.ContainsMaterial(texface.MaterialID) == false))
+                mat = RenderMaterial.DefaultMaterial;
+            else
+                mat = part.Shape.RenderMaterials.GetMaterial(texface.MaterialID);
+
+            res.Add(ConditionalTextureNameOrUUID(part, mat.NormalID).ToString());
+            res.Add(new LSL_Vector(mat.NormalRepeatX, mat.NormalRepeatY, 0));
+            res.Add(new LSL_Vector(mat.NormalOffsetX, mat.NormalOffsetY, 0));
+            res.Add(mat.NormalRotation);
+
+            return res;
+        }
+
+        // Returns the list: [ integer alpha_mode, integer mask_cutoff ]
+        private static List<object> GetRenderMaterialAlphaModeData(SceneObjectPart part, int face)
+        {
+
+            List<object> res = new List<object>();
+
+            Primitive.TextureEntry tex = part.Shape.Textures;
+            Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
+            RenderMaterial mat;
+
+            if ((texface.MaterialID == UUID.Zero) ||
+                (part.Shape.RenderMaterials.ContainsMaterial(texface.MaterialID) == false))
+                mat = RenderMaterial.DefaultMaterial;
+            else
+                mat = part.Shape.RenderMaterials.GetMaterial(texface.MaterialID);
+
+            res.Add((int)mat.DiffuseAlphaMode);
+            res.Add((int)mat.AlphaMaskCutoff);
+
+            return res;
         }
 
         public LSL_List llGetPrimitiveParams(LSL_List rules)

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -9744,6 +9744,72 @@ namespace InWorldz.Phlox.Engine
                         foreach (SceneObjectPart part in parts)
                             part.Description = LimitLength(primdesc, MAX_OBJ_DESC);
                         break;
+
+                    case (int)ScriptBaseClass.PRIM_SPECULAR:
+                        if (remain < 8)
+                            return;
+
+                        face = rules.GetLSLIntegerItem(idx++);
+                        string specular_tex = rules.Data[idx++].ToString();
+                        LSL_Vector specular_repeats = rules.GetVector3Item(idx++);
+                        LSL_Vector specular_offsets = rules.GetVector3Item(idx++);
+                        float specular_rotation = rules.GetLSLFloatItem(idx++);
+                        LSL_Vector specular_color = rules.GetVector3Item(idx++);
+                        int specular_glossiness = rules.GetLSLIntegerItem(idx++);
+                        int specular_environment = rules.GetLSLIntegerItem(idx++);
+
+                        // FIXME Provide an implementation
+
+                        //foreach (SceneObjectPart part in parts)
+                        //{
+                        //    SetTexture(part, tex, face);
+                        //    ScaleTexture(part, repeats.X, repeats.Y, face);
+                        //    OffsetTexture(part, offsets.X, offsets.Y, face);
+                        //    RotateTexture(part, rotation, face);
+                        //}
+                        break;
+
+                    case (int)ScriptBaseClass.PRIM_NORMAL:
+                        if (remain < 5)
+                            return;
+                        // [ string texture, vector repeats, vector offsets, float rotation_in_radians ]
+
+                        face = rules.GetLSLIntegerItem(idx++);
+                        string normal_tex = rules.Data[idx++].ToString();
+                        LSL_Vector normal_repeats = rules.GetVector3Item(idx++);
+                        LSL_Vector normal_offsets = rules.GetVector3Item(idx++);
+                        float normal_rotation = rules.GetLSLFloatItem(idx++);
+
+                        // FIXME Provide an implementation
+
+                        //foreach (SceneObjectPart part in parts)
+                        //{
+                        //    SetTexture(part, tex, face);
+                        //    ScaleTexture(part, repeats.X, repeats.Y, face);
+                        //    OffsetTexture(part, offsets.X, offsets.Y, face);
+                        //    RotateTexture(part, rotation, face);
+                        //}
+                        break;
+
+                    case (int)ScriptBaseClass.PRIM_ALPHA_MODE:
+                        if (remain < 3)
+                            return;
+
+                        face = rules.GetLSLIntegerItem(idx++);
+                        int alpha_mode = rules.GetLSLIntegerItem(idx++);
+                        int alpha_mask_cutoff = rules.GetLSLIntegerItem(idx++);
+
+                        // FIXME Provide an implementation
+
+                        //foreach (SceneObjectPart part in parts)
+                        //{
+                        //    SetTexture(part, tex, face);
+                        //    ScaleTexture(part, repeats.X, repeats.Y, face);
+                        //    OffsetTexture(part, offsets.X, offsets.Y, face);
+                        //    RotateTexture(part, rotation, face);
+                        //}
+                        break;
+
                 }
             }
         }

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -9758,37 +9758,53 @@ namespace InWorldz.Phlox.Engine
                         int specular_glossiness = rules.GetLSLIntegerItem(idx++);
                         int specular_environment = rules.GetLSLIntegerItem(idx++);
 
-                        // FIXME Provide an implementation
-
-                        //foreach (SceneObjectPart part in parts)
-                        //{
-                        //    SetTexture(part, tex, face);
-                        //    ScaleTexture(part, repeats.X, repeats.Y, face);
-                        //    OffsetTexture(part, offsets.X, offsets.Y, face);
-                        //    RotateTexture(part, rotation, face);
-                        //}
+                        foreach (SceneObjectPart part in parts)
+                        {
+                            if (face == ScriptBaseClass.ALL_SIDES)
+                            {
+                                for (face = 0; face < part.GetNumberOfSides(); face++)
+                                {
+                                    SetRenderMaterialSpecularData(part, face, specular_tex, specular_repeats, specular_offsets, specular_rotation, specular_color, specular_glossiness, specular_environment);
+                                }
+                            }
+                            else
+                            {
+                                if (face >= 0 && face < part.GetNumberOfSides())
+                                {
+                                    SetRenderMaterialSpecularData(part, face, specular_tex, specular_repeats, specular_offsets, specular_rotation, specular_color, specular_glossiness, specular_environment);
+                                }
+                            }
+                        }
                         break;
 
                     case (int)ScriptBaseClass.PRIM_NORMAL:
                         if (remain < 5)
                             return;
-                        // [ string texture, vector repeats, vector offsets, float rotation_in_radians ]
 
+                        // [ string texture, vector repeats, vector offsets, float rotation_in_radians ]
                         face = rules.GetLSLIntegerItem(idx++);
                         string normal_tex = rules.Data[idx++].ToString();
                         LSL_Vector normal_repeats = rules.GetVector3Item(idx++);
                         LSL_Vector normal_offsets = rules.GetVector3Item(idx++);
                         float normal_rotation = rules.GetLSLFloatItem(idx++);
 
-                        // FIXME Provide an implementation
-
-                        //foreach (SceneObjectPart part in parts)
-                        //{
-                        //    SetTexture(part, tex, face);
-                        //    ScaleTexture(part, repeats.X, repeats.Y, face);
-                        //    OffsetTexture(part, offsets.X, offsets.Y, face);
-                        //    RotateTexture(part, rotation, face);
-                        //}
+                        foreach (SceneObjectPart part in parts)
+                        {
+                            if (face == ScriptBaseClass.ALL_SIDES)
+                            {
+                                for (face = 0; face < part.GetNumberOfSides(); face++)
+                                {
+                                    SetRenderMaterialNormalData(part, face, normal_tex, normal_repeats, normal_offsets, normal_rotation);
+                                }
+                            }
+                            else
+                            {
+                                if (face >= 0 && face < part.GetNumberOfSides())
+                                {
+                                    SetRenderMaterialNormalData(part, face, normal_tex, normal_repeats, normal_offsets, normal_rotation);
+                                }
+                            }
+                        }
                         break;
 
                     case (int)ScriptBaseClass.PRIM_ALPHA_MODE:
@@ -9799,24 +9815,67 @@ namespace InWorldz.Phlox.Engine
                         int alpha_mode = rules.GetLSLIntegerItem(idx++);
                         int alpha_mask_cutoff = rules.GetLSLIntegerItem(idx++);
 
-                        // FIXME Provide an implementation
-
-                        //foreach (SceneObjectPart part in parts)
-                        //{
-                        //    SetTexture(part, tex, face);
-                        //    ScaleTexture(part, repeats.X, repeats.Y, face);
-                        //    OffsetTexture(part, offsets.X, offsets.Y, face);
-                        //    RotateTexture(part, rotation, face);
-                        //}
+                        foreach (SceneObjectPart part in parts)
+                        {
+                            if (face == ScriptBaseClass.ALL_SIDES)
+                            {
+                                for (face = 0; face < part.GetNumberOfSides(); face++)
+                                {
+                                    SetRenderMaterialAlphaModeData(part, face, alpha_mode, alpha_mask_cutoff);
+                                }
+                            }
+                            else
+                            {
+                                if (face >= 0 && face < part.GetNumberOfSides())
+                                {
+                                    SetRenderMaterialAlphaModeData(part, face, alpha_mode, alpha_mask_cutoff);
+                                }
+                            }
+                        }
                         break;
-
                 }
             }
         }
 
+        private void SetRenderMaterialSpecularData(
+            SceneObjectPart part, 
+            int face, 
+            string specular_tex, 
+            LSL_Vector specular_repeats, 
+            LSL_Vector specular_offsets, 
+            float specular_rotation, 
+            LSL_Vector specular_color, 
+            int specular_glossiness, 
+            int specular_environment
+            )
+        {
+            throw new NotImplementedException();
+        }
+
+        private void SetRenderMaterialNormalData(
+            SceneObjectPart part, 
+            int face, 
+            string normal_tex, 
+            LSL_Vector normal_repeats, 
+            LSL_Vector normal_offsets, 
+            float normal_rotation
+            )
+        {
+            throw new NotImplementedException();
+        }
+
+        private void SetRenderMaterialAlphaModeData(
+            SceneObjectPart part, 
+            int face, 
+            int alpha_mode, 
+            int alpha_mask_cutoff
+            )
+        {
+            throw new NotImplementedException();
+        }
+
         public string llStringToBase64(string str)
         {
-            
             try
             {
                 byte[] encData_byte = new byte[str.Length];
@@ -9833,7 +9892,6 @@ namespace InWorldz.Phlox.Engine
 
         public string llBase64ToString(string str)
         {
-            
             try
             {
                 return Util.Base64ToString(str).Replace("�", "?");
@@ -9846,7 +9904,6 @@ namespace InWorldz.Phlox.Engine
 
         public string llXorBase64Strings(string str1, string str2)
         {
-            
             Deprecated("llXorBase64Strings");
             // ScriptSleep(300);
             return String.Empty;
@@ -9854,19 +9911,16 @@ namespace InWorldz.Phlox.Engine
 
         public void llRemoteDataSetRegion()
         {
-            
             NotImplemented("llRemoteDataSetRegion");
         }
 
         public float llLog10(float val)
         {
-            
             return (float)Math.Log10(val);
         }
 
         public float llLog(float val)
         {
-
             return (float)Math.Log(val);
         }
 

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -10554,8 +10554,95 @@ namespace InWorldz.Phlox.Engine
                             }
                         }
                         break;
+
+                    case (int)ScriptBaseClass.PRIM_SPECULAR:
+                        if (remain < 1)
+                            return new LSL_List(res);
+
+                        face = (int)rules.GetLSLIntegerItem(idx++);
+
+                        foreach (SceneObjectPart part in parts)
+                        {
+                            tex = part.Shape.Textures;
+                            if (face == ScriptBaseClass.ALL_SIDES)
+                            {
+                                for (face = 0; face < part.GetNumberOfSides(); face++)
+                                {
+                                    Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
+                                    // XXX Add implementation
+                                }
+                            }
+                            else
+                            {
+                                if (face >= 0 && face < part.GetNumberOfSides())
+                                {
+                                    Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
+                                    // XXX Add implementation
+                                }
+                            }
+                        }
+
+                        break;
+
+
+                    case (int)ScriptBaseClass.PRIM_NORMAL:
+                        if (remain < 1)
+                            return new LSL_List(res);
+
+                        face = (int)rules.GetLSLIntegerItem(idx++);
+                        foreach (SceneObjectPart part in parts)
+                        {
+                            tex = part.Shape.Textures;
+                            if (face == ScriptBaseClass.ALL_SIDES)
+                            {
+                                for (face = 0; face < part.GetNumberOfSides(); face++)
+                                {
+                                    Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
+                                    // XXX Add implementation
+                                }
+                            }
+                            else
+                            {
+                                if (face >= 0 && face < part.GetNumberOfSides())
+                                {
+                                    Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
+                                    // XXX Add implementation
+                                }
+                            }
+                        }
+
+                        break;
+
+                    case (int)ScriptBaseClass.PRIM_ALPHA_MODE:
+                        if (remain < 1)
+                            return new LSL_List(res);
+
+                        face = (int)rules.GetLSLIntegerItem(idx++);
+                        foreach (SceneObjectPart part in parts)
+                        {
+                            tex = part.Shape.Textures;
+                            if (face == ScriptBaseClass.ALL_SIDES)
+                            {
+                                for (face = 0; face < part.GetNumberOfSides(); face++)
+                                {
+                                    Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
+                                    // XXX Add implementation
+                                }
+                            }
+                            else
+                            {
+                                if (face >= 0 && face < part.GetNumberOfSides())
+                                {
+                                    Primitive.TextureEntryFace texface = tex.GetFace((uint)face);
+                                    // XXX Add implementation
+                                }
+                            }
+                        }
+
+                        break;
                 }
             }
+
             return new LSL_List(res);
         }
 

--- a/OpenSim/Framework/PrimitiveBaseShape.cs
+++ b/OpenSim/Framework/PrimitiveBaseShape.cs
@@ -1622,6 +1622,55 @@ namespace OpenSim.Framework
             return data;
         }
 
+        /// <summary>
+        /// Return a single MaterialID for a given Face
+        /// </summary>
+        /// <returns>The UUID of the Material or UUID.Zero if none is set</returns>
+        public UUID GetMaterialID(int face)
+        {
+            UUID id;
+
+            if (face < 0)
+            {
+                return Textures.DefaultTexture.MaterialID;
+            }
+            else
+            {
+                var faceEntry = Textures.CreateFace((uint)face);
+                return faceEntry.MaterialID;
+            }
+        }
+
+        /// <summary>
+        /// Return a list of deduplicated materials ids from the texture entry.
+        /// We remove duplicates because a materialid may be used across faces and we only
+        /// need to represent it here once.
+        /// </summary>
+        /// <returns>The List of UUIDs found, possibly empty if no materials are in use.</returns>
+        public List<UUID> GetMaterialIDs()
+        {
+            List<UUID> matIds = new List<UUID>();
+
+            if (Textures != null)
+            {
+                if ((Textures.DefaultTexture != null) &&
+                    (Textures.DefaultTexture.MaterialID != UUID.Zero))
+                {
+                    matIds.Add(Textures.DefaultTexture.MaterialID);
+                }
+
+                foreach (var face in Textures.FaceTextures)
+                {
+                    if ((face != null) && (face.MaterialID != UUID.Zero))
+                    {
+                        if (matIds.Contains(face.MaterialID) == false)
+                            matIds.Add(face.MaterialID);
+                    }
+                }
+            }
+
+            return matIds;
+        }
 
         /// <summary>
         /// Creates a OpenMetaverse.Primitive and populates it with converted PrimitiveBaseShape values

--- a/OpenSim/Framework/RenderMaterials.cs
+++ b/OpenSim/Framework/RenderMaterials.cs
@@ -57,6 +57,8 @@ namespace OpenSim.Framework
         public static readonly Color4 DEFAULT_SPECULAR_LIGHT_COLOR = Color4.White;
         public const float  MATERIALS_MULTIPLIER = 10000.0f;
 
+        public static readonly RenderMaterial DefaultMaterial = new RenderMaterial(UUID.Zero, UUID.Zero);
+
         #region Properties
 
         public UUID NormalID;

--- a/OpenSim/Region/CoreModules/Capabilities/RenderMaterialsModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/RenderMaterialsModule.cs
@@ -471,7 +471,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                     }
                     else
                     {
-                        m_log.Warn("[RenderMaterials]: request for UNKNOWN material ID: " + id.ToString());
+                        m_log.Debug("[RenderMaterials]: request for UNKNOWN material ID: " + id.ToString());
                     }
                 }
             }

--- a/OpenSim/Region/Framework/Scenes/EventManager.cs
+++ b/OpenSim/Region/Framework/Scenes/EventManager.cs
@@ -6,7 +6,7 @@
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyrightRenderMaterialAdd
+ *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
  *     * Neither the name of the OpenSim Project nor the

--- a/OpenSim/Region/Framework/Scenes/EventManager.cs
+++ b/OpenSim/Region/Framework/Scenes/EventManager.cs
@@ -6,7 +6,7 @@
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
+ *     * Redistributions in binary form must reproduce the above copyrightRenderMaterialAdd
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
  *     * Neither the name of the OpenSim Project nor the
@@ -268,6 +268,12 @@ namespace OpenSim.Region.Framework.Scenes
 
         public delegate void ObjectBeingRemovedFromScene(SceneObjectGroup obj);
         public event ObjectBeingRemovedFromScene OnObjectBeingRemovedFromScene;
+
+        public delegate void RenderMaterialAdded(SceneObjectPart part, UUID MaterialID, RenderMaterial material);
+        public event RenderMaterialAdded OnRenderMaterialAddedToPrim;
+
+        public delegate void RenderMaterialRemoved(SceneObjectPart part, UUID matID);
+        public event RenderMaterialRemoved OnRenderMaterialRemovedFromPrim;
 
         public delegate void NoticeNoLandDataFromStorage();
         public event NoticeNoLandDataFromStorage OnNoticeNoLandDataFromStorage;
@@ -568,6 +574,9 @@ namespace OpenSim.Region.Framework.Scenes
         private RequestParcelPrimCountUpdate handlerRequestParcelPrimCountUpdate = null;
         private ParcelPrimCountTainted handlerParcelPrimCountTainted = null;
         private ObjectBeingRemovedFromScene handlerObjectBeingRemovedFromScene = null;
+        private RenderMaterialAdded handlerOnRenderMaterialAddedToPrim = null;
+        private RenderMaterialRemoved handlerOnRenderMaterialRemovedFromPrim = null;
+
         private ScriptTimerEvent handlerScriptTimerEvent = null;
         private EstateToolsSunUpdate handlerEstateToolsSunUpdate = null;
 
@@ -740,6 +749,50 @@ namespace OpenSim.Region.Framework.Scenes
             if (handlerObjectBeingRemovedFromScene != null)
             {
                 handlerObjectBeingRemovedFromScene(obj);
+            }
+        }
+
+        public void TriggerRenderMaterialAddedToPrim(SceneObjectPart part, UUID matID, RenderMaterial material)
+        {
+            RenderMaterialAdded handler = OnRenderMaterialAddedToPrim;
+            
+            if (handler != null)
+            {
+                foreach (RenderMaterialAdded d in handler.GetInvocationList())
+                {
+                    try
+                    {
+                        d(part, matID, material);
+                    }
+                    catch (Exception e)
+                    {
+                        m_log.ErrorFormat(
+                            "[EVENT MANAGER]: Delegate for TriggerRenderMaterialAddedToPrim failed - continuing.  {0} {1}",
+                            e.Message, e.StackTrace);
+                    }
+                }
+            }
+        }
+
+        public void TriggerRenderMaterialRemovedFromPrim(SceneObjectPart part, UUID MaterialID)
+        {
+            RenderMaterialRemoved handler = OnRenderMaterialRemovedFromPrim;
+
+            if (handler != null)
+            {
+                foreach (RenderMaterialRemoved d in handler.GetInvocationList())
+                {
+                    try
+                    {
+                        d(part, MaterialID);
+                    }
+                    catch (Exception e)
+                    {
+                        m_log.ErrorFormat(
+                            "[EVENT MANAGER]: Delegate for TriggerRenderMaterialRemovedFromPrim failed - continuing.  {0} {1}",
+                            e.Message, e.StackTrace);
+                    }
+                }
             }
         }
 

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
@@ -342,6 +342,10 @@ namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
         public const int PRIM_POS_LOCAL = 33;
         public const int PRIM_LINK_TARGET = 34;
         public const int PRIM_SLICE = 35;
+        public const int PRIM_SPECULAR = 36;
+        public const int PRIM_NORMAL = 37;
+        public const int PRIM_ALPHA_MODE = 38;
+
         // large out of normal range value unlikely to conflict with future LL values
         public const int IW_PRIM_ALPHA = 11001;
 
@@ -404,6 +408,11 @@ namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
         public const int PRIM_PHYSICS_SHAPE_PRIM = 0;
         public const int PRIM_PHYSICS_SHAPE_NONE = 1;
         public const int PRIM_PHYSICS_SHAPE_CONVEX = 2;
+
+        public const int PRIM_ALPHA_MODE_NONE = 0;
+        public const int PRIM_ALPHA_MODE_BLEND = 1;
+        public const int PRIM_ALPHA_MODE_MASK = 2;
+        public const int PRIM_ALPHA_MODE_EMISSIVE = 3;
 
         public const int MASK_BASE = 0;
         public const int MASK_OWNER = 1;


### PR DESCRIPTION
Updates to the RenderMaterials CAP to use scene events to maintain the RenderMaterials Cache.  Added support for LSL for llSetPrimitiveParams and llGetPrimitiveParams for PRIM_NORMAL, PRIM_SPECULAR and PRIM_ALPHA_MODE.
