### PR TITLE
Fix modify permissions check to check via the sop.ParentGroup rather …

### DIFF
--- a/OpenSim/Region/CoreModules/Capabilities/RenderMaterialsModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/RenderMaterialsModule.cs
@@ -375,9 +375,10 @@ namespace OpenSim.Region.CoreModules.Capabilities
                 }
 
                 // Make sure we can modify it
-                if (m_scene.Permissions.CanEditObject(sop.UUID, agentID, (uint)PermissionMask.Modify) == false)
+                if (m_scene.Permissions.CanEditObject(sop.ParentGroup.UUID, agentID, (uint)PermissionMask.Modify) == false)
                 {
-                    m_log.WarnFormat("[RenderMaterials]: User {0} can't edit object {1} {2}", agentID, sop.Name, sop.UUID);
+                    m_log.WarnFormat("[RenderMaterials]: User {0} can't edit object {1} {2}", 
+                        agentID, sop.ParentGroup.Name, sop.ParentGroup.UUID);
                     continue;
                 }
 


### PR DESCRIPTION
…than the part directly.

It was causing failures to apply materials to elements in a linkset other than the root prim,