### PR TITLE
Enable aging of the bufferpool

### DIFF
--- a/OpenSim/Framework/ImmutableTimestampedItem.cs
+++ b/OpenSim/Framework/ImmutableTimestampedItem.cs
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2015, InWorldz Halcyon Developers
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ * 
+ *   * Neither the name of halcyon nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenSim.Framework
+{
+    /// <summary>
+    /// Encapsulates an item that has a timestamp associated with it.
+    /// For timestamp uses where this stamp may be created and destroyed
+    /// rapidly. For these uses, this class being a struct may help 
+    /// prevent excessive garbage generation
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public struct ImmutableTimestampedItem<T>
+    {
+        private ulong _timeStamp;
+        private T _item;
+
+        public T Item
+        {
+            get
+            {
+                return _item;
+            }
+        }
+
+        public int ElapsedSeconds
+        {
+            get
+            {
+                ulong diff = Util.GetLongTickCount() - _timeStamp;
+                return (int) diff / 1000;
+            }
+        }
+
+        public ulong ElapsedMilliseconds
+        {
+            get
+            {
+                ulong diff = Util.GetLongTickCount() - _timeStamp;
+                return diff;
+            }
+        }
+
+        public ImmutableTimestampedItem(T item)
+        {
+            _item = item;
+            _timeStamp = Util.GetLongTickCount();
+        }
+    }
+}

--- a/OpenSim/Framework/ImmutableTimestampedItem.cs
+++ b/OpenSim/Framework/ImmutableTimestampedItem.cs
@@ -77,5 +77,11 @@ namespace OpenSim.Framework
             _item = item;
             _timeStamp = Util.GetLongTickCount();
         }
+
+        public ImmutableTimestampedItem(T item, ulong timeStamp)
+        {
+            _item = item;
+            _timeStamp = timeStamp;
+        }
     }
 }

--- a/OpenSim/Framework/Tests/ByteBufferPoolTests.cs
+++ b/OpenSim/Framework/Tests/ByteBufferPoolTests.cs
@@ -1,0 +1,164 @@
+﻿/*
+ * Copyright (c) 2015, InWorldz Halcyon Developers
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ * 
+ *   * Neither the name of halcyon nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using NUnit.Framework;
+using OpenSim.Framework;
+using OpenMetaverse;
+
+namespace OpenSim.Framework.Tests
+{
+    [TestFixture]
+    class ByteBufferPoolTests
+    {
+        private const int IDLE_BUFFER_MAX_AGE = 1;
+
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+        }
+
+        [Test]
+        public void TestSimpleLeaseAndReturn()
+        {
+            var buffer = new ByteBufferPool(10, new int[] { 1, 2, 3, 4 });
+            byte[] a = buffer.LeaseBytes(1);
+            byte[] b = buffer.LeaseBytes(2);
+            byte[] c = buffer.LeaseBytes(3);
+            byte[] d = buffer.LeaseBytes(4);
+
+            Assert.AreEqual(0, buffer.AllocatedBytes);
+
+            buffer.ReturnBytes(a);
+
+            Assert.AreEqual(1, buffer.AllocatedBytes);
+
+            buffer.ReturnBytes(b);
+
+            Assert.AreEqual(3, buffer.AllocatedBytes);
+
+            buffer.ReturnBytes(c);
+
+            Assert.AreEqual(6, buffer.AllocatedBytes);
+
+            buffer.ReturnBytes(d);
+
+            Assert.AreEqual(10, buffer.AllocatedBytes);
+        }
+
+        [Test]
+        public void TestOverflow()
+        {
+            var buffer = new ByteBufferPool(10, new int[] { 1, 2, 3, 4 });
+            byte[] a = buffer.LeaseBytes(1);
+            byte[] b = buffer.LeaseBytes(2);
+            byte[] c = buffer.LeaseBytes(3);
+            byte[] d = buffer.LeaseBytes(4);
+
+            Assert.AreEqual(0, buffer.AllocatedBytes);
+
+            buffer.ReturnBytes(a);
+
+            Assert.AreEqual(1, buffer.AllocatedBytes);
+
+            buffer.ReturnBytes(b);
+
+            Assert.AreEqual(3, buffer.AllocatedBytes);
+
+            buffer.ReturnBytes(c);
+
+            Assert.AreEqual(6, buffer.AllocatedBytes);
+
+            buffer.ReturnBytes(d);
+
+            Assert.AreEqual(10, buffer.AllocatedBytes);
+
+            byte[] e = buffer.LeaseBytes(4);
+            buffer.ReturnBytes(e);
+
+            Assert.AreEqual(10, buffer.AllocatedBytes);
+        }
+
+        [Test]
+        public void TestInvalidByteReturnSize()
+        {
+            var buffer = new ByteBufferPool(10, new int[] { 10, 20, 30 });
+
+            Assert.AreEqual(0, buffer.AllocatedBytes);
+
+            buffer.ReturnBytes(new byte[40]);
+
+            Assert.AreEqual(0, buffer.AllocatedBytes);
+
+            buffer.ReturnBytes(new byte[5]);
+
+            Assert.AreEqual(0, buffer.AllocatedBytes);
+        }
+
+        [Test]
+        public void TestServiceLargeBytes()
+        {
+            var buffer = new ByteBufferPool(10, new int[] { 10, 20, 30 });
+
+            Assert.AreEqual(0, buffer.AllocatedBytes);
+
+            var bytes = buffer.LeaseBytes(400);
+
+            Assert.AreEqual(400, bytes.Length);
+
+            buffer.ReturnBytes(bytes);
+
+            Assert.AreEqual(0, buffer.AllocatedBytes);
+        }
+
+        [Test]
+        public void TestAging()
+        {
+            var buffer = new ByteBufferPool(10, new int[] { 1 }, 1);
+
+            Assert.AreEqual(0, buffer.AllocatedBytes);
+
+            var bytes = buffer.LeaseBytes(1);
+            buffer.ReturnBytes(bytes);
+
+            Assert.AreEqual(1, buffer.AllocatedBytes);
+
+            System.Threading.Thread.Sleep(1000);
+
+            buffer.Maintain();
+
+            Assert.AreEqual(0, buffer.AllocatedBytes);
+        }
+    }
+}

--- a/OpenSim/Framework/Tests/LRUCacheTests.cs
+++ b/OpenSim/Framework/Tests/LRUCacheTests.cs
@@ -152,13 +152,14 @@ namespace OpenSim.Framework.Tests
         [Test]
         public void TestAgingRemovesEntriesPastExpirationInterval()
         {
-            var cache = new LRUCache<UUID, String>(10, maxAge : 1000, expireInterval : 1000);
+            var cache = new LRUCache<UUID, String>(10, maxAge : 1000);
 
             UUID firstEntryId = UUID.Random();
             String firstEntryData = "First Entry";
             cache.Add(firstEntryId, firstEntryData);
 
             Thread.Sleep(2 * 1000);
+            cache.Maintain();
 
             Assert.AreEqual(0, cache.Count);
             Assert.AreEqual(0, cache.Size);
@@ -171,7 +172,7 @@ namespace OpenSim.Framework.Tests
         [Test]
         public void TestAgingRemovesEntriesButPreservesReservedEntries()
         {
-            var cache = new LRUCache<UUID, String>(10, minSize : 1, maxAge : 1000, expireInterval : 1000);
+            var cache = new LRUCache<UUID, String>(10, minSize : 1, maxAge : 1000);
 
             UUID firstEntryId = UUID.Random();
             String firstEntryData = "First Entry";
@@ -182,6 +183,7 @@ namespace OpenSim.Framework.Tests
             cache.Add(secondEntryId, secondEntryData);
 
             Thread.Sleep(5 * 1000);
+            cache.Maintain();
 
             Assert.AreEqual(1, cache.Count);
             Assert.AreEqual(1, cache.Size);
@@ -203,11 +205,12 @@ namespace OpenSim.Framework.Tests
             UUID secondEntryId = UUID.Random();
             String secondEntryData = "Second Entry";
 
-            var cache = new LRUCache<UUID, String>(capacity: 250, useSizing: true, minSize: secondEntryData.Length, maxAge: 1000, expireInterval: 1000);
+            var cache = new LRUCache<UUID, String>(capacity: 250, useSizing: true, minSize: secondEntryData.Length, maxAge: 1000);
             cache.Add(firstEntryId, firstEntryData, firstEntryData.Length);
             cache.Add(secondEntryId, secondEntryData, secondEntryData.Length);
 
             Thread.Sleep(5 * 1000);
+            cache.Maintain();
 
             Assert.AreEqual(1, cache.Count);
             Assert.AreEqual(secondEntryData.Length, cache.Size);


### PR DESCRIPTION
This is the final step to enable increasing the asset cache sizes. The asset cache is bufferpool backed which meant we needed to prune out entries that haven't been used in a while.

Also includes a change to LRUCache to drive the maintenance of LRU from outside of the class so we don't have to make it IDisposable.