### PR TITLE
Plumb the message generator avatar ID through chat

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -11961,7 +11961,8 @@ namespace InWorldz.Phlox.Engine
         public void llOwnerSay(string msg)
         {
             World.SimChatBroadcast(Utils.StringToBytes(msg), ChatTypeEnum.Owner, 0,
-                                   m_host.AbsolutePosition, m_host.Name, m_host.UUID, false);
+                                   m_host.AbsolutePosition, m_host.Name, m_host.UUID, false,
+                                   m_host.OwnerID);
 
             ScriptSleep(15);
         }

--- a/OpenSim/Framework/OSChatMessage.cs
+++ b/OpenSim/Framework/OSChatMessage.cs
@@ -48,7 +48,6 @@ namespace OpenSim.Framework
 
         protected IScene m_scene;
         protected IClientAPI m_sender;
-        protected object m_senderObject;
         protected ChatTypeEnum m_type;
         protected UUID m_fromID;
         protected UUID m_destID;
@@ -57,6 +56,12 @@ namespace OpenSim.Framework
         {
             m_position = new Vector3();
         }
+
+        /// <summary>
+        /// The avatar ID that has generated this message regardless of
+        /// if it is a script owned by this avatar, or the avatar itself
+        /// </summary>
+        public UUID GeneratingAvatarID { get; set; }
 
         /// <summary>
         /// The message sent by the user
@@ -116,16 +121,7 @@ namespace OpenSim.Framework
             get { return m_sender; }
             set { m_sender = value; }
         }
-
-        /// <summary>
-        /// The object responsible for sending the message, or null.
-        /// </summary>
-        public object SenderObject
-        {
-            get { return m_senderObject; }
-            set { m_senderObject = value; }
-        }
-
+        
         public UUID SenderUUID
         {
             get { return m_fromID; }

--- a/OpenSim/Region/CoreModules/Avatar/Chat/ChatModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Chat/ChatModule.cs
@@ -188,7 +188,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
         {
             string fromName = c.From;
             UUID fromID = UUID.Zero;
-            UUID ownerID = UUID.Zero;
+            UUID ownerID = c.GeneratingAvatarID;
             UUID destID = c.DestinationUUID;
             string message = c.Message;
             IScene scene = c.Scene;
@@ -217,8 +217,6 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
 
                 case ChatSourceType.Object:
                     fromID = c.SenderUUID;
-                    ownerID = ((SceneObjectPart)c.SenderObject).OwnerID;
-
                 break;
             }
 
@@ -264,7 +262,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
             string fromName = c.From;
             
             UUID fromID = UUID.Zero;
-            UUID ownerID = UUID.Zero;
+            UUID ownerID = c.GeneratingAvatarID;
             ChatSourceType sourceType = ChatSourceType.Object;
             if (null != c.Sender)
             {
@@ -277,7 +275,6 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
             else if (c.SenderUUID != UUID.Zero)
             {
                 fromID = c.SenderUUID; 
-                ownerID = ((SceneObjectPart)c.SenderObject).OwnerID;
             }
 
             // m_log.DebugFormat("[CHAT] Broadcast: fromID {0} fromName {1}, cType {2}, sType {3}", fromID, fromName, cType, sourceType);
@@ -293,8 +290,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
                     // don't forward SayOwner chat from objects to
                     // non-owner agents
                     if ((c.Type == ChatTypeEnum.Owner) &&
-                        (null != c.SenderObject) &&
-                        (((SceneObjectPart)c.SenderObject).OwnerID != client.AgentId))
+                        (ownerID != client.AgentId))
                         return;
 
                     presence.Scene.EventManager.TriggerOnChatToClient(c.Message, fromID,

--- a/OpenSim/Region/CoreModules/Scripting/DynamicTexture/DynamicTextureModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/DynamicTexture/DynamicTextureModule.cs
@@ -254,7 +254,8 @@ namespace OpenSim.Region.CoreModules.Scripting.DynamicTexture
                     string msg = 
                         String.Format("DynamicTextureModule: Error preparing image using URL {0}", Url);
                     scene.SimChat(Utils.StringToBytes(msg), ChatTypeEnum.Say,
-                                  0, part.ParentGroup.RootPart.AbsolutePosition, part.Name, part.UUID, false);
+                                  0, part.ParentGroup.RootPart.AbsolutePosition, part.Name, part.UUID, false,
+                                  part.OwnerID);
                     return;
                 }
 

--- a/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
@@ -38,7 +38,7 @@ namespace OpenSim.Region.Framework.Scenes
     public partial class Scene
     {
         protected void SimChat(byte[] message, ChatTypeEnum type, int channel, Vector3 fromPos, string fromName,
-                               UUID fromID, bool fromAgent, bool broadcast, UUID destID)
+                               UUID fromID, bool fromAgent, bool broadcast, UUID destID, UUID generatingAvatarID)
         {
             OSChatMessage args = new OSChatMessage();
 
@@ -56,13 +56,9 @@ namespace OpenSim.Region.Framework.Scenes
                 if (user != null)
                     args.Sender = user.ControllingClient;
             }
-            else
-            {
-                SceneObjectPart obj = GetSceneObjectPart(fromID);
-                args.SenderObject = obj;
-            }
 
             args.From = fromName;
+            args.GeneratingAvatarID = generatingAvatarID;
 
             if (broadcast)
                 EventManager.TriggerOnChatBroadcast(this, args);
@@ -79,25 +75,26 @@ namespace OpenSim.Region.Framework.Scenes
         /// <param name="fromName"></param>
         /// <param name="fromAgentID"></param>
         public void SimChat(byte[] message, ChatTypeEnum type, int channel, Vector3 fromPos, string fromName,
-                            UUID fromID, bool fromAgent, UUID destID)
+                            UUID fromID, bool fromAgent, UUID destID, UUID generatingAvatarID)
         {
-            SimChat(message, type, channel, fromPos, fromName, fromID, fromAgent, false, destID);
+            SimChat(message, type, channel, fromPos, fromName, fromID, fromAgent, false, destID, generatingAvatarID);
         }
 
         public void SimChat(byte[] message, ChatTypeEnum type, int channel, Vector3 fromPos, string fromName,
-                            UUID fromID, bool fromAgent)
+                            UUID fromID, bool fromAgent, UUID generatingAvatarID)
         {
-            SimChat(message, type, channel, fromPos, fromName, fromID, fromAgent, false, UUID.Zero);
+            SimChat(message, type, channel, fromPos, fromName, fromID, fromAgent, false, UUID.Zero, generatingAvatarID);
         }
 
-        public void SimChat(string message, ChatTypeEnum type, Vector3 fromPos, string fromName, UUID fromID, bool fromAgent)
+        public void SimChat(string message, ChatTypeEnum type, Vector3 fromPos, string fromName, UUID fromID, 
+            bool fromAgent, UUID generatingAvatarID)
         {
-            SimChat(Utils.StringToBytes(message), type, 0, fromPos, fromName, fromID, fromAgent);
+            SimChat(Utils.StringToBytes(message), type, 0, fromPos, fromName, fromID, fromAgent, generatingAvatarID);
         }
 
-        public void SimChat(string message, string fromName)
+        public void SimChat(string message, string fromName, UUID generatingAvatarID)
         {
-            SimChat(message, ChatTypeEnum.Broadcast, Vector3.Zero, fromName, UUID.Zero, false);
+            SimChat(message, ChatTypeEnum.Broadcast, Vector3.Zero, fromName, UUID.Zero, false, generatingAvatarID);
         }
 
         /// <summary>
@@ -109,9 +106,9 @@ namespace OpenSim.Region.Framework.Scenes
         /// <param name="fromName"></param>
         /// <param name="fromAgentID"></param>
         public void SimChatBroadcast(byte[] message, ChatTypeEnum type, int channel, Vector3 fromPos, string fromName,
-                                     UUID fromID, bool fromAgent)
+                                     UUID fromID, bool fromAgent, UUID generatingAvatarID)
         {
-            SimChat(message, type, channel, fromPos, fromName, fromID, fromAgent, true, UUID.Zero);
+            SimChat(message, type, channel, fromPos, fromName, fromID, fromAgent, true, UUID.Zero, generatingAvatarID);
         }
 
         /// <summary>

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -5711,40 +5711,7 @@ namespace OpenSim.Region.Framework.Scenes
         // from within the OdePhysicsScene.
         public void jointErrorMessage(PhysicsJoint joint, string message)
         {
-            if (joint != null)
-            {
-                if (joint.ErrorMessageCount > PhysicsJoint.maxErrorMessages)
-                    return;
-
-                SceneObjectPart jointProxyObject = GetSceneObjectPart(joint.ObjectNameInScene);
-                if (jointProxyObject != null)
-                {
-                    SimChat(Utils.StringToBytes("[NINJA]: " + message),
-                        ChatTypeEnum.DebugChannel,
-                        2147483647,
-                        jointProxyObject.AbsolutePosition,
-                        jointProxyObject.Name,
-                        jointProxyObject.UUID,
-                        false);
-
-                    joint.ErrorMessageCount++;
-
-                    if (joint.ErrorMessageCount > PhysicsJoint.maxErrorMessages)
-                    {
-                        SimChat(Utils.StringToBytes("[NINJA]: Too many messages for this joint, suppressing further messages."),
-                            ChatTypeEnum.DebugChannel,
-                            2147483647,
-                            jointProxyObject.AbsolutePosition,
-                            jointProxyObject.Name,
-                            jointProxyObject.UUID,
-                            false);
-                    }
-                }
-                else
-                {
-                    // couldn't find the joint proxy object; the error message is silently suppressed
-                }
-            }
+            
         }
 
         public Scene ConsoleScene()


### PR DESCRIPTION
GeneratingAvatarID added to OSChatMessage to track the avatar that is responsible for a message regardless of of it comes from one of their objects, or the avatar itself.

Removed the field from OSChatMessage that was storing a reference to the SOP that was generating messages in the case of scripted chat. This was only being used to look up the avatar, and doing it badly.