### PR TITLE
Address an issue with duplicating calling cards each time the user logs in with some v3 viewers

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -1682,7 +1682,7 @@ namespace InWorldz.Phlox.Engine
             tmp.Y = (float)scale.Y;
             tmp.Z = (float)scale.Z;
             part.Scale = tmp;
-            part.ScheduleFullUpdate();
+            part.ScheduleFullUpdate(PrimUpdateFlags.FindBest);
 
             PhySleep();
         }
@@ -1696,7 +1696,7 @@ namespace InWorldz.Phlox.Engine
         {
             m_host.ClickAction = (byte)action;
             if (m_host.ParentGroup != null) m_host.ParentGroup.HasGroupChanged = true;
-            m_host.ScheduleFullUpdate();
+            m_host.ScheduleFullUpdate(PrimUpdateFlags.FindBest);
             return;
         }
 
@@ -1989,7 +1989,7 @@ namespace InWorldz.Phlox.Engine
             }
 
             part.ParentGroup.HasGroupChanged = true;
-            part.ScheduleFullUpdate();
+            part.ScheduleFullUpdate(PrimUpdateFlags.FullUpdate);
         }
 
         private static void SetPhantomPropertiesOnPart(SceneObjectPart part, int softness, float gravity, float friction, float wind, float tension, LSL_Vector Force)
@@ -2039,7 +2039,7 @@ namespace InWorldz.Phlox.Engine
             }
 
             part.ParentGroup.HasGroupChanged = true;
-            part.ScheduleFullUpdate();
+            part.ScheduleFullUpdate(PrimUpdateFlags.FindBest);
         }
 
         public LSL_Vector llGetColor(int face)
@@ -3315,7 +3315,7 @@ namespace InWorldz.Phlox.Engine
             if (vel != Vector3.Zero)
                 new_group.SetVelocity(vel, false);
 
-            part.ScheduleFullUpdate();
+            part.ScheduleFullUpdate(PrimUpdateFlags.FindBest);
 
             // if a script was specified, start it now
             if (includesScripts)
@@ -4689,7 +4689,7 @@ namespace InWorldz.Phlox.Engine
             group1.TriggerScriptChangedEvent(Changed.LINK);
             group1.RootPart.AddFlag(PrimFlags.CreateSelected);
             group1.HasGroupChanged = true;
-            group1.ScheduleGroupForFullUpdate();
+            group1.ScheduleGroupForFullUpdate(PrimUpdateFlags.ForcedFullUpdate);
 
             if (client != null)
                 group1.GetProperties(client);
@@ -7103,13 +7103,13 @@ namespace InWorldz.Phlox.Engine
             else
                 m_host.SoundOptions |= (byte)SoundFlags.Queue;
             m_host.ParentGroup.HasGroupChanged = true;
-            m_host.ScheduleFullUpdate();
+            m_host.ScheduleFullUpdate(PrimUpdateFlags.Sound);
         }
 
         public void llSetSoundRadius(float radius)
         {
             m_host.SoundRadius = radius;
-            m_host.ScheduleFullUpdate();
+            m_host.ScheduleFullUpdate(PrimUpdateFlags.Sound);
         }
 
         public string llKey2Name(string id)
@@ -7150,7 +7150,7 @@ namespace InWorldz.Phlox.Engine
             pTexAnim.Start = (float)start;
 
             part.AddTextureAnimation(pTexAnim);
-            part.ScheduleFullUpdate();
+            part.ScheduleFullUpdate(PrimUpdateFlags.TextureAnim);
             part.ParentGroup.HasGroupChanged = true;
         }
 
@@ -8215,7 +8215,7 @@ namespace InWorldz.Phlox.Engine
                 part.AddNewParticleSystem(prules);
                 part.ParentGroup.HasGroupChanged = true;
             }
-            part.ScheduleFullUpdate();
+            part.ScheduleFullUpdate(PrimUpdateFlags.Particles);
         }
 
         public void llParticleSystem(LSL_List rules)
@@ -9620,7 +9620,7 @@ namespace InWorldz.Phlox.Engine
                                 shape.ProjectionFocus = ford;
                                 shape.ProjectionAmbiance = ambience;
                                 part.ParentGroup.HasGroupChanged = true;
-                                part.ScheduleFullUpdate();
+                                part.ScheduleFullUpdate(PrimUpdateFlags.FindBest);
                             }
                         break;
 
@@ -9633,7 +9633,7 @@ namespace InWorldz.Phlox.Engine
                             PrimitiveBaseShape shape = part.Shape;
                             shape.ProjectionEntry = projector;
                             part.ParentGroup.HasGroupChanged = true;
-                            part.ScheduleFullUpdate();
+                            part.ScheduleFullUpdate(PrimUpdateFlags.Shape);
                         }
                         break;
 
@@ -9653,7 +9653,7 @@ namespace InWorldz.Phlox.Engine
                                 PrimitiveBaseShape shape = part.Shape;
                                 shape.ProjectionTextureUUID = textureID;
                                 part.ParentGroup.HasGroupChanged = true;
-                                part.ScheduleFullUpdate();
+                                part.ScheduleFullUpdate(PrimUpdateFlags.Shape);
                             }
                         break;
 
@@ -9666,7 +9666,7 @@ namespace InWorldz.Phlox.Engine
                             PrimitiveBaseShape shape = part.Shape;
                             shape.ProjectionFOV = fov;
                             part.ParentGroup.HasGroupChanged = true;
-                            part.ScheduleFullUpdate();
+                            part.ScheduleFullUpdate(PrimUpdateFlags.Shape);
                         }
                         break;
 
@@ -9679,7 +9679,7 @@ namespace InWorldz.Phlox.Engine
                             PrimitiveBaseShape shape = part.Shape;
                             shape.ProjectionFocus = focus;
                             part.ParentGroup.HasGroupChanged = true;
-                            part.ScheduleFullUpdate();
+                            part.ScheduleFullUpdate(PrimUpdateFlags.Shape);
                         }
                         break;
 
@@ -9692,7 +9692,7 @@ namespace InWorldz.Phlox.Engine
                             PrimitiveBaseShape shape = part.Shape;
                             shape.ProjectionAmbiance = amb;
                             part.ParentGroup.HasGroupChanged = true;
-                            part.ScheduleFullUpdate();
+                            part.ScheduleFullUpdate(PrimUpdateFlags.Shape);
                         }
                         break;
 

--- a/InWorldz/InWorldz.Testing/MockClientAPI.cs
+++ b/InWorldz/InWorldz.Testing/MockClientAPI.cs
@@ -747,7 +747,7 @@ namespace InWorldz.Testing
             
         }
 
-        public void SendPrimitiveToClient(object sop, uint clientFlags, OpenMetaverse.Vector3 lpos)
+        public void SendPrimitiveToClient(object sop, uint clientFlags, OpenMetaverse.Vector3 lpos, PrimUpdateFlags updateFlags)
         {
             
         }

--- a/OpenSim/Framework/Communications/Cache/CachedUserInfo.cs
+++ b/OpenSim/Framework/Communications/Cache/CachedUserInfo.cs
@@ -75,6 +75,15 @@ namespace OpenSim.Framework.Communications.Cache
         public bool HasReceivedInventory { get { return true; } }
 
         /// <summary>
+        /// This is a list of all of the inventory items that are of type "CallingCard" in the
+        ///   "Calling Card"/Friends/All folder to work around a bug with the viewer creating
+        ///   multiple copies of the same calling card
+        /// </summary>
+        private List<string> _namesOfCallingCardsInCallingCardsFriendsAllFolder = null;
+        private object _namesOfCallingCardsInCallingCardsFriendsAllFolderLock = new object();
+        private System.Threading.AutoResetEvent _namesOfCallingCardsInCallingCardsFriendsAllFolderWaitLock = null;
+
+        /// <summary>
         /// Holds the most appropriate folders for the given type.
         /// Note:  Thus far in the code, this folder doesn't have to be kept up to date as it will 
         /// only be used to retrieve an ID.  If this ever changes, this collection will have to be kept up to date
@@ -168,6 +177,116 @@ namespace OpenSim.Framework.Communications.Cache
             lock (_permissionsGivenByFriends)
             {
                 _permissionsGivenByFriends[friendId] = newPermissions;
+            }
+        }
+
+        /// <summary>
+        /// Check if a calling card already exists in the given folder with the name given
+        /// </summary>
+        /// <param name="folderId">Folder to check for calling cards in</param>
+        /// <param name="name">Name of user whose name may be on one of the calling cards</param>
+        /// <returns></returns>
+        public bool CheckIfCallingCardAlreadyExistsForUser(UUID folderId, string name)
+        {
+            //On 2015-12-15, a problem with calling cards occurred such that all calling cards
+            // would be duplicated by the viewer when logging in, which caused users to not
+            // display themselves and in extreme cases, would block them from doing anything
+            // along with generating 65000 calling cards for one user
+            //To address this issue, we make sure that the viewer cannot add calling cards
+            // that already exist for that user in the "Calling Cards"/Friends/All folder. 
+            // We will ignore the requests.
+            PopulateCallingCardCache(folderId);
+            lock (_namesOfCallingCardsInCallingCardsFriendsAllFolderLock)
+            {
+                if (_namesOfCallingCardsInCallingCardsFriendsAllFolder != null)
+                {
+                    return _namesOfCallingCardsInCallingCardsFriendsAllFolder.Contains(name);
+                }
+                //Something went wrong and we weren't able to populate the calling card cache
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Populates the calling card cache for the user for the given folder
+        /// </summary>
+        /// <param name="folderId"></param>
+        private void PopulateCallingCardCache(UUID folderId)
+        {
+            bool mustWait = true;
+            //Make sure that multiple threads are not trying to populate the cache at the same time
+            // as the inventory operations are heavy
+            lock (_namesOfCallingCardsInCallingCardsFriendsAllFolderLock)
+            {
+                if (_namesOfCallingCardsInCallingCardsFriendsAllFolder != null)
+                {
+                    //The cache exists, we don't need to populate it
+                    return;
+                }
+
+                if (_namesOfCallingCardsInCallingCardsFriendsAllFolderWaitLock == null)
+                {
+                    //We were the first one here, we get to create the lock and have the other threads wait
+                    // as we don't want all threads that might come in here requesting all of the folder contents multiple times
+                    mustWait = false;
+                    _namesOfCallingCardsInCallingCardsFriendsAllFolderWaitLock = new System.Threading.AutoResetEvent(false);
+                }
+            }
+
+            if (mustWait)
+            {
+                //Wait for another thread to finish populating the cache, but dDo not block indefinitely - wait a max of 10 seconds
+                // before proceeding on even though the other thread hasn't finished... this might allow some duplicate calling
+                // cards, but if something is going so wrong that after 10 seconds it hasn't gotten the folders, we should just
+                // give up and try to move on
+                _namesOfCallingCardsInCallingCardsFriendsAllFolderWaitLock.WaitOne(10000);
+                return;
+            }
+
+            List<string> callingCardItemNames = null;
+            try
+            {
+                InventoryFolderBase potentialCallingCardsFolder = FindTopLevelFolderFor(folderId);
+                if (potentialCallingCardsFolder == null || //This can happen if MySQL is used for inventory
+                    potentialCallingCardsFolder.Type == (short)InventoryType.CallingCard)
+                {
+                    InventoryFolderBase newCallingCardFolder = GetFolder(folderId);
+                    //We only check in the All folder as the bug with calling card duplication
+                    // only occurs in "Calling Cards"/Friends/All - not other folders
+                    if (newCallingCardFolder.Name == "All")
+                    {
+                        callingCardItemNames = new List<string>();
+                        foreach (InventoryItemBase itm in newCallingCardFolder.Items)
+                        {
+                            if (itm.AssetType == (int)AssetType.CallingCard)
+                            {
+                                //Add the item name to the list - as the user cannot edit this in the viewer
+                                // as it is disabled, it is safe to check just based on the name
+                                callingCardItemNames.Add(itm.Name);
+                            }
+                        }
+
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                m_log.ErrorFormat("[INVENTORY] An exception occurred finding calling cards in folderID {0}: {1}", folderId, e);
+            }
+            finally
+            {
+                //Now under the lock, set the list of calling cards and then pulse the wait lock to inform other threads
+                // that they can run now too
+                lock (_namesOfCallingCardsInCallingCardsFriendsAllFolderLock)
+                {
+                    _namesOfCallingCardsInCallingCardsFriendsAllFolder = callingCardItemNames;
+                    _namesOfCallingCardsInCallingCardsFriendsAllFolderWaitLock.Set();
+                    if (callingCardItemNames == null)
+                    {
+                        //It failed, so clear the wait lock and let someone else try later
+                        _namesOfCallingCardsInCallingCardsFriendsAllFolderWaitLock = null;
+                    }
+                }
             }
         }
 

--- a/OpenSim/Framework/IClientAPI.cs
+++ b/OpenSim/Framework/IClientAPI.cs
@@ -1000,7 +1000,7 @@ namespace OpenSim.Framework
         void AttachObject(uint localID, Quaternion rotation, byte attachPoint, UUID ownerID);
         void SetChildAgentThrottle(byte[] throttle);
 
-        void SendPrimitiveToClient(object sop, uint clientFlags, Vector3 lpos);
+        void SendPrimitiveToClient(object sop, uint clientFlags, Vector3 lpos, PrimUpdateFlags updateFlags);
 
         void SendPrimitiveToClientImmediate(object sop, uint clientFlags, Vector3 lpos);
 

--- a/OpenSim/Framework/IObjectCache.cs
+++ b/OpenSim/Framework/IObjectCache.cs
@@ -1,0 +1,63 @@
+﻿using OpenMetaverse;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenSim.Framework
+{
+    /// <summary>
+    ///     Specifies the fields that have been changed when sending a prim or
+    ///     avatar update
+    /// </summary>
+    [Flags]
+    public enum PrimUpdateFlags : uint
+    {
+        None = 0,
+        AttachmentPoint = 1 << 0,
+        Material = 1 << 1,
+        ClickAction = 1 << 2,
+        Shape = 1 << 3,
+        ParentID = 1 << 4,
+        PrimFlags = 1 << 5,
+        PrimData = 1 << 6,
+        MediaURL = 1 << 7,
+        ScratchPad = 1 << 8,
+        Textures = 1 << 9,
+        TextureAnim = 1 << 10,
+        NameValue = 1 << 11,
+        Position = 1 << 12,
+        Rotation = 1 << 13,
+        Velocity = 1 << 14,
+        Acceleration = 1 << 15,
+        AngularVelocity = 1 << 16,
+        CollisionPlane = 1 << 17,
+        Text = 1 << 18,
+        Particles = 1 << 19,
+        ExtraData = 1 << 20,
+        Sound = 1 << 21,
+        Joint = 1 << 22,
+        FindBest = 1 << 23,
+        ForcedFullUpdate = UInt32.MaxValue - 1,
+        FullUpdate = UInt32.MaxValue,
+
+        TerseUpdate = Position | Rotation | Velocity
+                      | Acceleration | AngularVelocity
+    }
+
+    public static class PrimUpdateFlagsExtensions
+    {
+        public static bool HasFlag(this PrimUpdateFlags updateFlags, PrimUpdateFlags flag)
+        {
+            return (updateFlags & flag) == flag;
+        }
+    }
+
+    public interface IObjectCache
+    {
+        bool UseCachedObject(UUID AgentID, uint localID, uint CurrentEntityCRC);
+        void AddCachedObject(UUID AgentID, uint localID, uint CurrentEntityCRC);
+        void RemoveObject(UUID AgentID, uint localID, byte cacheMissType);
+    }
+}

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -3301,7 +3301,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                                   clickAction, material, textureanim, false, 0, UUID.Zero, UUID.Zero, 0, 0, 0);
         }*/
 
-        public void SendPrimitiveToClient(object obj, uint flags, Vector3 lPos)
+        public void SendPrimitiveToClient(object obj, uint flags, Vector3 lPos, PrimUpdateFlags updateFlags)
         {
             if (m_closeActive == 1) return;
 
@@ -3740,7 +3740,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             }
 
             if (validParts.Count == 0) return false;
-
+            
             outPacket.ObjectData =
                 new ImprovedTerseObjectUpdatePacket.
                     ObjectDataBlock[validParts.Count];

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
@@ -1033,7 +1033,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
         {
         }
 
-        public void SendPrimitiveToClient(object sop, uint clientFlags, OpenMetaverse.Vector3 lpos)
+        public void SendPrimitiveToClient(object sop, uint clientFlags, OpenMetaverse.Vector3 lpos, PrimUpdateFlags updateFlags)
         {
         }
 

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
@@ -355,7 +355,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
                         UUID assetId = grp.UUID;
                         sp.Appearance.SetAttachment((int)attachment.AttachPoint, true, attachment.ItemID, assetId);
                         grp.DisableUpdates = false;
-                        grp.ScheduleGroupForFullUpdate();
+                        grp.ScheduleGroupForFullUpdate(PrimUpdateFlags.ForcedFullUpdate);
                     }
                 }
             }

--- a/OpenSim/Region/CoreModules/Agent/ObjectCache/ObjectCacheModule.cs
+++ b/OpenSim/Region/CoreModules/Agent/ObjectCache/ObjectCacheModule.cs
@@ -1,0 +1,301 @@
+﻿/*
+ * Copyright (c) Contributors, http://aurora-sim.org/
+ * See CONTRIBUTORS.TXT for a full list of copyright holders.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Aurora-Sim Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE DEVELOPERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Nini.Config;
+using OpenMetaverse;
+using OpenMetaverse.StructuredData;
+using OpenSim.Region.Framework.Interfaces;
+using OpenSim.Region.Framework.Scenes;
+using OpenSim.Framework;
+
+namespace OpenSim.Region.CoreModules.ObjectCache
+{
+    public class ObjectCacheModule : INonSharedRegionModule, IObjectCache
+    {
+        #region Declares
+
+        //private static readonly ILog MainConsole.Instance = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        private readonly Dictionary<UUID, Dictionary<uint, uint>> ObjectCacheAgents =
+            new Dictionary<UUID, Dictionary<uint, uint>>();
+
+        protected bool m_Enabled = true;
+
+        private string m_filePath = "ObjectCache/";
+        private Scene m_scene;
+
+        #endregion
+
+        #region INonSharedRegionModule
+
+        public virtual void Initialize(IConfigSource source)
+        {
+            IConfig moduleConfig = source.Configs["ObjectCache"];
+            if (moduleConfig != null)
+            {
+                m_Enabled = moduleConfig.GetString("Module", "") == Name;
+                m_filePath = moduleConfig.GetString("PathToSaveFiles", m_filePath);
+            }
+            if (!Directory.Exists(m_filePath))
+            {
+                try
+                {
+                    Directory.CreateDirectory(m_filePath);
+                }
+                catch (Exception)
+                {
+                }
+            }
+            m_Enabled = false;
+        }
+
+        public virtual void AddRegion(Scene scene)
+        {
+            if (!m_Enabled)
+                return;
+
+            m_scene = scene;
+            scene.RegisterModuleInterface<IObjectCache>(this);
+            scene.EventManager.OnNewClient += OnNewClient;
+            scene.EventManager.OnClientClosed += EventManager_OnClientClosed;
+        }
+
+        public virtual void RemoveRegion(Scene scene)
+        {
+            if (!m_Enabled)
+                return;
+
+            scene.UnregisterModuleInterface<IObjectCache>(this);
+            scene.EventManager.OnNewClient -= OnNewClient;
+            scene.EventManager.OnClientClosed -= EventManager_OnClientClosed;
+        }
+
+        public virtual void RegionLoaded(Scene scene)
+        {
+        }
+
+        public virtual void Close()
+        {
+        }
+
+        public Type ReplaceableInterface
+        {
+            get { return null; }
+        }
+
+        public virtual string Name
+        {
+            get { return "ObjectCacheModule"; }
+        }
+
+        #region Events
+
+        public void OnNewClient(IClientAPI client)
+        {
+            ScenePresence sp;
+            ((Scene)client.Scene).TryGetAvatar(client.AgentId, out sp);
+            //Create the client's cache
+            //This is shared, so all get saved into one file
+            if (sp != null && !sp.IsChildAgent)
+            {
+                Util.FireAndForget(LoadFileOnNewClient, sp.UUID);
+            }
+        }
+
+        /// <summary>
+        ///     Load the file for the client async so that we don't lock up the system for too long
+        /// </summary>
+        /// <param name="o"></param>
+        public void LoadFileOnNewClient(object o)
+        {
+            UUID agentID = (UUID) o;
+            LoadFromFileForClient(agentID);
+        }
+
+        private void EventManager_OnClientClosed(UUID clientID, Scene scene)
+        {
+            //Save the cache to the file for the client
+            ScenePresence sp;
+            scene.TryGetAvatar(clientID, out sp);
+            //This is shared, so all get saved into one file
+            if (sp != null && !sp.IsChildAgent)
+                SaveToFileForClient(clientID);
+            //Remove the client's cache
+            lock (ObjectCacheAgents)
+            {
+                ObjectCacheAgents.Remove(clientID);
+            }
+        }
+
+        #endregion
+
+        #region Serialization
+
+        public string SerializeAgentCache(Dictionary<uint, uint> cache)
+        {
+            OSDMap cachedMap = new OSDMap();
+            foreach (KeyValuePair<uint, uint> kvp in cache)
+            {
+                cachedMap.Add(kvp.Key.ToString(), OSD.FromUInteger(kvp.Value));
+            }
+            return OSDParser.SerializeJsonString(cachedMap);
+        }
+
+        public Dictionary<uint, uint> DeserializeAgentCache(string osdMap)
+        {
+            Dictionary<uint, uint> cache = new Dictionary<uint, uint>();
+            try
+            {
+                OSDMap cachedMap = (OSDMap) OSDParser.DeserializeJson(osdMap);
+                foreach (KeyValuePair<string, OSD> kvp in cachedMap)
+                {
+                    cache[uint.Parse(kvp.Key)] = kvp.Value.AsUInteger();
+                }
+            }
+            catch
+            {
+                //It has an error, destroy the cache
+                //null will tell the caller that it errored out and needs to be removed
+                cache = null;
+            }
+            return cache;
+        }
+
+        #endregion
+
+        #region Load/Save from file
+
+        public void SaveToFileForClient(UUID AgentID)
+        {
+            Dictionary<uint, uint> cache;
+            lock (ObjectCacheAgents)
+            {
+                if (!ObjectCacheAgents.ContainsKey(AgentID))
+                    return;
+                cache = new Dictionary<uint, uint>(ObjectCacheAgents[AgentID]);
+                ObjectCacheAgents[AgentID].Clear();
+                ObjectCacheAgents.Remove(AgentID);
+            }
+            FileStream stream = new FileStream(m_filePath + AgentID + m_scene.RegionInfo.RegionName + ".oc",
+                                               FileMode.Create);
+            StreamWriter m_streamWriter = new StreamWriter(stream);
+            m_streamWriter.WriteLine(SerializeAgentCache(cache));
+            m_streamWriter.Close();
+        }
+
+        public void LoadFromFileForClient(UUID AgentID)
+        {
+            FileStream stream = new FileStream(m_filePath + AgentID + m_scene.RegionInfo.RegionName + ".oc",
+                                               FileMode.OpenOrCreate);
+            StreamReader m_streamReader = new StreamReader(stream);
+            string file = m_streamReader.ReadToEnd();
+            m_streamReader.Close();
+            //Read file here
+            if (file != "") //New file
+            {
+                Dictionary<uint, uint> cache = DeserializeAgentCache(file);
+                if (cache == null)
+                {
+                    //Something went wrong, delete the file
+                    try
+                    {
+                        File.Delete(m_filePath + AgentID + m_scene.RegionInfo.RegionName + ".oc");
+                    }
+                    catch
+                    {
+                    }
+                    return;
+                }
+                lock (ObjectCacheAgents)
+                {
+                    ObjectCacheAgents[AgentID] = cache;
+                }
+            }
+        }
+
+        #endregion
+
+        public virtual void PostInitialise()
+        {
+        }
+
+        #endregion
+
+        #region IObjectCache
+
+        /// <summary>
+        ///     Check whether we can send a CachedObjectUpdate to the client
+        /// </summary>
+        /// <param name="AgentID"></param>
+        /// <param name="localID"></param>
+        /// <param name="CurrentEntityCRC"></param>
+        /// <returns></returns>
+        public bool UseCachedObject(UUID AgentID, uint localID, uint CurrentEntityCRC)
+        {
+            lock (ObjectCacheAgents)
+            {
+                if (ObjectCacheAgents.ContainsKey(AgentID))
+                {
+                    uint CurrentCachedCRC = 0;
+                    if (ObjectCacheAgents[AgentID].TryGetValue(localID, out CurrentCachedCRC))
+                    {
+                        if (CurrentEntityCRC == CurrentCachedCRC)
+                        {
+                            //The client knows of the newest version
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+        }
+
+        public void AddCachedObject(UUID AgentID, uint localID, uint CRC)
+        {
+            lock (ObjectCacheAgents)
+            {
+                if (!ObjectCacheAgents.ContainsKey(AgentID))
+                    ObjectCacheAgents[AgentID] = new Dictionary<uint, uint>();
+                ObjectCacheAgents[AgentID][localID] = CRC;
+            }
+        }
+
+        public void RemoveObject(UUID AgentID, uint localID, byte cacheMissType)
+        {
+            lock (ObjectCacheAgents)
+            {
+                if (ObjectCacheAgents.ContainsKey(AgentID))
+                    ObjectCacheAgents[AgentID].Remove(localID);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
+++ b/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
@@ -256,7 +256,7 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
             foreach (SceneObjectGroup grp in presence.GetAttachments())
             {
                 if (CheckWhetherAttachmentShouldBeSent(grp))
-                    SendGroupUpdate(grp);
+                    SendGroupUpdate(grp, PrimUpdateFlags.ForcedFullUpdate);
             }
         }
 
@@ -527,7 +527,7 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
                     return;
                 }
 
-                SendGroupUpdate(kvp.Value);
+                SendGroupUpdate(kvp.Value, PrimUpdateFlags.FindBest);
             }
         }
 
@@ -751,10 +751,12 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
                     return;
                 }
 
-                SceneObjectPart part = m_partsUpdateQueue.Dequeue();
+                KeyValuePair<SceneObjectPart, PrimUpdateFlags>? kvp = m_partsUpdateQueue.Dequeue();
 
-                if (part.ParentGroup == null || part.ParentGroup.IsDeleted)
+                if (!kvp.HasValue || kvp.Value.Key.ParentGroup == null || kvp.Value.Key.ParentGroup.IsDeleted)
                     continue;
+
+                SceneObjectPart part = kvp.Value.Key;
 
                 double distance;
 
@@ -858,14 +860,14 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
 
                     if (hasBeenUpdated)
                     {
-                        SendGroupUpdate(part.ParentGroup);
+                        SendGroupUpdate(part.ParentGroup, kvp.Value.Value);
                         lastSog = part.ParentGroup;
                         continue;
                     }
                 }
 
                 lastSog = part.ParentGroup;
-                SendPartUpdate(part);
+                SendPartUpdate(part, kvp.Value.Value);
             }
 
             /*if (queueCount > 0)
@@ -878,17 +880,17 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
             m_presence.Scene.StatsReporter.AddAgentTime(Environment.TickCount - m_perfMonMS);
         }
 
-        public void SendGroupUpdate(SceneObjectGroup sceneObjectGroup)
+        public void SendGroupUpdate(SceneObjectGroup sceneObjectGroup, PrimUpdateFlags updateFlags)
         {
-            SendPartUpdate(sceneObjectGroup.RootPart);
+            SendPartUpdate(sceneObjectGroup.RootPart, updateFlags);
             foreach (SceneObjectPart part in sceneObjectGroup.GetParts())
             {
                 if (!part.IsRootPart())
-                    SendPartUpdate(part);
+                    SendPartUpdate(part, updateFlags);
             }
         }
 
-        public void SendPartUpdate(SceneObjectPart part)
+        public void SendPartUpdate(SceneObjectPart part, PrimUpdateFlags updateFlags)
         {
             ScenePartUpdate update = null;
 
@@ -941,7 +943,7 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
             }
             if (sendFullUpdate)
             {
-                part.SendFullUpdate(m_presence.ControllingClient, m_presence.GenerateClientFlags(part.UUID));
+                part.SendFullUpdate(m_presence.ControllingClient, m_presence.GenerateClientFlags(part.UUID), updateFlags);
             }
             else if (sendTerseUpdate)
             {
@@ -956,11 +958,11 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
                     if (part != part.ParentGroup.RootPart)
                         return;
 
-                    part.ParentGroup.SendFullUpdateToClient(m_presence.ControllingClient);
+                    part.ParentGroup.SendFullUpdateToClient(m_presence.ControllingClient, PrimUpdateFlags.FullUpdate);
                     return;
                 }
 
-                part.SendFullUpdate(m_presence.ControllingClient, m_presence.GenerateClientFlags(part.UUID));
+                part.SendFullUpdate(m_presence.ControllingClient, m_presence.GenerateClientFlags(part.UUID), PrimUpdateFlags.FullUpdate);
             }
         }
 
@@ -970,12 +972,12 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// THIS METHOD SHOULD ONLY BE CALLED FROM WITHIN THE SCENE LOOP!!
         /// </summary>
         /// <param name="part"></param>
-        public void QueuePartForUpdate(SceneObjectPart part)
+        public void QueuePartForUpdate(SceneObjectPart part, PrimUpdateFlags updateFlags)
         {
             if (m_presence.IsBot) return;
 
             // m_log.WarnFormat("[ScenePresence]: {0} Queuing update for {1} {2} {3}", part.ParentGroup.Scene.RegionInfo.RegionName, part.UUID.ToString(), part.LocalId.ToString(), part.ParentGroup.Name);
-            m_partsUpdateQueue.Enqueue(part);
+            m_partsUpdateQueue.Enqueue(part, updateFlags);
         }
 
         /// <summary>

--- a/OpenSim/Region/CoreModules/Scripting/DynamicTexture/DynamicTextureModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/DynamicTexture/DynamicTextureModule.cs
@@ -314,7 +314,7 @@ namespace OpenSim.Region.CoreModules.Scripting.DynamicTexture
                 // tmptex.DefaultTexture.Fullbright = true;
 
                 part.Shape.Textures = tmptex;
-                part.ScheduleFullUpdate();
+                part.ScheduleFullUpdate(PrimUpdateFlags.Textures);
             }
 
             private byte[] BlendTextures(byte[] frontImage, byte[] backImage, bool setNewAlpha, byte newAlpha)

--- a/OpenSim/Region/CoreModules/World/Media/Moap/MoapModule.cs
+++ b/OpenSim/Region/CoreModules/World/Media/Moap/MoapModule.cs
@@ -249,7 +249,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
 
             SetPartMediaFlags(part, face, me != null);
 
-            part.ScheduleFullUpdate();
+            part.ScheduleFullUpdate(PrimUpdateFlags.FindBest);
             part.TriggerScriptChangedEvent(Changed.MEDIA);
         }
 
@@ -452,7 +452,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
             UpdateMediaUrl(part, agentId);
 
             // Arguably, we could avoid sending a full update to the avatar that just changed the texture.
-            part.ScheduleFullUpdate();
+            part.ScheduleFullUpdate(PrimUpdateFlags.MediaURL);
 
             part.TriggerScriptChangedEvent(Changed.MEDIA);
 
@@ -530,7 +530,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
 
             UpdateMediaUrl(part, agentId);
 
-            part.ScheduleFullUpdate();
+            part.ScheduleFullUpdate(PrimUpdateFlags.Shape);
 
             part.TriggerScriptChangedEvent(Changed.MEDIA);
 

--- a/OpenSim/Region/Framework/Interfaces/ISceneView.cs
+++ b/OpenSim/Region/Framework/Interfaces/ISceneView.cs
@@ -88,19 +88,22 @@ namespace OpenSim.Region.Framework.Interfaces
         /// THIS METHOD SHOULD ONLY BE CALLED FROM WITHIN THE SCENE LOOP!!
         /// </summary>
         /// <param name="part"></param>
-        void QueuePartForUpdate(SceneObjectPart sceneObjectPart);
+        /// <param name="updateFlags"></param>
+        void QueuePartForUpdate(SceneObjectPart sceneObjectPart, PrimUpdateFlags updateFlags);
 
         /// <summary>
         /// Sends a full part update to this client
         /// </summary>
         /// <param name="part"></param>
-        void SendPartUpdate(SceneObjectPart part);
+        /// <param name="updateFlags"></param>
+        void SendPartUpdate(SceneObjectPart part, PrimUpdateFlags updateFlags);
 
         /// <summary>
         /// Sends a full group update to this client
         /// </summary>
         /// <param name="sceneObjectGroup"></param>
-        void SendGroupUpdate(SceneObjectGroup sceneObjectGroup);
+        /// <param name="updateFlags"></param>
+        void SendGroupUpdate(SceneObjectGroup sceneObjectGroup, PrimUpdateFlags updateFlags);
 
         /// <summary>
         /// Informs the SceneView that the given patch has been modified and must be resent

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -3457,7 +3457,7 @@ namespace OpenSim.Region.Framework.Scenes
                     // Fire on_rez
                     group.CreateScriptInstances(startParam, ScriptStartFlags.PostOnRez, DefaultScriptEngine, (int)ScriptStateSource.PrimData, null);
 
-                    rootPart.ScheduleFullUpdate();
+                    rootPart.ScheduleFullUpdate(PrimUpdateFlags.ForcedFullUpdate);
                 }
 
             } 
@@ -4048,7 +4048,7 @@ namespace OpenSim.Region.Framework.Scenes
             }
 
             group.CreateScriptInstances(param, ScriptStartFlags.PostOnRez, DefaultScriptEngine, (int)ScriptStateSource.PrimData, null);
-            rootPart.ScheduleFullUpdate();
+            rootPart.ScheduleFullUpdate(PrimUpdateFlags.ForcedFullUpdate);
 
             reason = "success";
             return rootPart.ParentGroup;

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -1157,6 +1157,26 @@ namespace OpenSim.Region.Framework.Scenes
 
             if (userInfo != null)
             {
+                if(assetType == AssetType.CallingCard && invType == (int)OpenMetaverse.InventoryType.CallingCard)
+                {
+                    //On 2015-12-15, a problem with calling cards occurred such that all calling cards
+                    // would be duplicated by the viewer when logging in, which caused users to not
+                    // display themselves and in extreme cases, would block them from doing anything
+                    // along with generating 65000 calling cards for one user
+                    //To address this issue, we make sure that the viewer cannot add calling cards
+                    // that already exist for that user in the "Calling Cards"/Friends/All folder. 
+                    // We will ignore the requests.
+                    //We will cache the calling card folder in the CachedUserInfo as we don't want to 
+                    // call the inventory database repeatedly to get the data.
+                    if (userInfo.CheckIfCallingCardAlreadyExistsForUser(folderID, name))
+                    {
+                        m_log.WarnFormat(
+                            "[AGENT INVENTORY]: User requested to generate duplicate calling card for client {0} uuid {1} in CreateNewInventoryItem!",
+                                remoteClient.Name, remoteClient.AgentId);
+                        return;
+                    }
+                }
+
                 InventoryItemBase item = new InventoryItemBase();
                 item.Owner = remoteClient.AgentId;
                 item.CreatorId = creatorID;

--- a/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
@@ -122,7 +122,9 @@ namespace OpenSim.Region.Framework.Scenes
 
             if (obj != null)
             {
-                obj.SendFullUpdateToClient(remoteClient);
+                //The viewer didn't have the cached prim like we thought - force a full update 
+                // so that they will get the full prim
+                obj.SendFullUpdateToClient(remoteClient, PrimUpdateFlags.ForcedFullUpdate);
             }
 
             return;
@@ -190,7 +192,7 @@ namespace OpenSim.Region.Framework.Scenes
             if (part.ParentGroup.IsAttachment)
                 isAttachment = true;
             // Regardless of if it is an attachment or not, we need to resend the position in case it moved or changed.
-            part.ParentGroup.ScheduleGroupForFullUpdate();
+            part.ParentGroup.ScheduleGroupForFullUpdate(PrimUpdateFlags.FindBest);
 
             // If it's not an attachment, and we are allowed to move it,
             // then we might have done so. If we moved across a parcel

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2726,7 +2726,7 @@ namespace OpenSim.Region.Framework.Scenes
                     Vector3 safepos = NearestLegalPos(oldGroupPosition);
                     grp.OffsetForNewRegion(safepos);// no effect during transit
                 }
-                grp.ScheduleGroupForFullUpdate();
+                grp.ScheduleGroupForFullUpdate(PrimUpdateFlags.ForcedFullUpdate);
                 return false;
             }
 
@@ -4924,7 +4924,7 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 if (ent is SceneObjectGroup)
                 {
-                    ((SceneObjectGroup)ent).ScheduleGroupForFullUpdate();
+                    ((SceneObjectGroup)ent).ScheduleGroupForFullUpdate(PrimUpdateFlags.ForcedFullUpdate);
                 }
             }
         }
@@ -5610,7 +5610,7 @@ namespace OpenSim.Region.Framework.Scenes
             group.RezzedFromFolderId = UUID.Zero;
             InspectForAutoReturn(group);
             part.GetProperties(newOwner);
-            part.ScheduleFullUpdate();
+            part.ScheduleFullUpdate(PrimUpdateFlags.ForcedFullUpdate);
             return true;
         }
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
@@ -309,7 +309,7 @@ namespace OpenSim.Region.Framework.Scenes
                 }
 
                 m_part.ParentGroup.AddActiveScriptCount(1);
-                m_part.ScheduleFullUpdate();
+                m_part.ScheduleFullUpdate(PrimUpdateFlags.PrimFlags);
             }
         }
 
@@ -607,7 +607,7 @@ namespace OpenSim.Region.Framework.Scenes
                     m_part.TriggerScriptChangedEvent(Changed.INVENTORY);
                     HasInventoryChanged = true;
                     m_part.ParentGroup.HasGroupChanged = true;
-                    m_part.ScheduleFullUpdate();
+                    m_part.ScheduleFullUpdate(PrimUpdateFlags.PrimFlags);
                     return true;
                 }
                 else
@@ -680,7 +680,7 @@ namespace OpenSim.Region.Framework.Scenes
 
                     HasInventoryChanged = true;
                     m_part.ParentGroup.HasGroupChanged = true;
-                    m_part.ScheduleFullUpdate();
+                    m_part.ScheduleFullUpdate(PrimUpdateFlags.PrimFlags);
                     return true;
                 }
                 else
@@ -727,7 +727,7 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 HandleAddRunningScript(newItem, replaceArgs);
             }
-            m_part.ScheduleFullUpdate();
+            m_part.ScheduleFullUpdate(PrimUpdateFlags.PrimFlags);
         }
 
         /// <summary>

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -2009,7 +2009,7 @@ namespace OpenSim.Region.Framework.Scenes
             // Commented out this code since it could never have executed, but might still be informative.
 //            if (proxyObjectGroup != null)
 //            {
-                proxyObjectGroup.SendGroupFullUpdate();
+                proxyObjectGroup.SendGroupFullUpdate(PrimUpdateFlags.ForcedFullUpdate);
                 remote_client.SendSitResponse(proxyObjectGroup.UUID, Vector3.Zero, Quaternion.Identity, true, Vector3.Zero, Vector3.Zero, false);
                 m_scene.DeleteSceneObject(proxyObjectGroup, false);
 //            }
@@ -2504,7 +2504,7 @@ namespace OpenSim.Region.Framework.Scenes
             HandleAgentSit(remoteClient, UUID);
             ControllingClient.SendSitResponse(vParentID, vPos, vRot, false, cameraAtOffset, cameraEyeOffset, forceMouselook);
             SceneView.SendFullUpdateToAllClients();
-            part.ParentGroup.ScheduleGroupForFullUpdate();//Tell all avatars about this object, as otherwise avatars will show up at <0,0,0> on the radar if they have not seen this object before (culling)
+            part.ParentGroup.ScheduleGroupForFullUpdate(PrimUpdateFlags.ForcedFullUpdate);//Tell all avatars about this object, as otherwise avatars will show up at <0,0,0> on the radar if they have not seen this object before (culling)
         }
 
         public void HandleAgentRequestSit(IClientAPI remoteClient, UUID agentID, UUID targetID, Vector3 offset)
@@ -4565,7 +4565,7 @@ namespace OpenSim.Region.Framework.Scenes
                     continue;
 
                 //Send an immediate update
-                presence.SceneView.SendGroupUpdate(gobj);
+                presence.SceneView.SendGroupUpdate(gobj, PrimUpdateFlags.ForcedFullUpdate);
             }
         }
 

--- a/OpenSim/Region/Framework/Scenes/SceneTransactionManager.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneTransactionManager.cs
@@ -28,6 +28,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using OpenSim.Framework;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -234,7 +235,7 @@ namespace OpenSim.Region.Framework.Scenes
             if (part != null)
             {
                 part.IsInTransaction = false;
-                if (!part.ParentGroup.IsDeleted && postUpdates) part.ScheduleFullUpdate();
+                if (!part.ParentGroup.IsDeleted && postUpdates) part.ScheduleFullUpdate(PrimUpdateFlags.ForcedFullUpdate);
             }
         }
 

--- a/OpenSim/Region/Framework/Scenes/UndoState.cs
+++ b/OpenSim/Region/Framework/Scenes/UndoState.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using OpenMetaverse;
 using log4net;
 using System.Reflection;
+using OpenSim.Framework;
 
 namespace OpenSim.Region.Framework.Scenes
 {
@@ -128,7 +129,7 @@ namespace OpenSim.Region.Framework.Scenes
                     }
                 }
                 part.Undoing = false;
-                part.ScheduleFullUpdate();
+                part.ScheduleFullUpdate(PrimUpdateFlags.FindBest);
             }
         }
 
@@ -173,7 +174,7 @@ namespace OpenSim.Region.Framework.Scenes
                     }
                 }
                 part.Undoing = false;
-                part.ScheduleFullUpdate();
+                part.ScheduleFullUpdate(PrimUpdateFlags.FindBest);
             }
         }
     }

--- a/OpenSim/Region/OptionalModules/World/TreePopulator/TreePopulatorModule.cs
+++ b/OpenSim/Region/OptionalModules/World/TreePopulator/TreePopulatorModule.cs
@@ -176,7 +176,7 @@ namespace OpenSim.Region.OptionalModules.World.TreePopulator
 
                     // 100 seconds to grow 1m
                     s_tree.Scale += new Vector3(0.1f, 0.1f, 0.1f);
-                    s_tree.ScheduleFullUpdate();
+                    s_tree.ScheduleFullUpdate(PrimUpdateFlags.FindBest);
                     //s_tree.ScheduleTerseUpdate();
                 }
                 else
@@ -304,7 +304,7 @@ namespace OpenSim.Region.OptionalModules.World.TreePopulator
                     uuid, UUID.Zero, new Vector3(0.1f, 0.1f, 0.1f), Quaternion.Identity, position, Tree.Cypress1, false);
             
             m_trees.Add(tree.UUID);
-            tree.ScheduleGroupForFullUpdate();
+            tree.ScheduleGroupForFullUpdate(PrimUpdateFlags.ForcedFullUpdate);
         }
 
         private void CalculateTrees_Elapsed(object sender, ElapsedEventArgs e)


### PR DESCRIPTION
Address an issue with duplicating calling cards each time the user logs in with some v3 viewers. This commit modifies the handling of the "CreateInventoryItem" packet to check whether the new item is a calling card, whether it is in the "Calling Cards"/Friends/All folder, and that another calling card for the user does not already exist in this folder. If a duplicate item exists, the create inventory item action does not take place and is ignored. To make sure that this does not hit the inventory database too much, only one thread is allowed to populate the calling card cache and the others will wait until it completes or 10 seconds have passed. I'm not sure of a better way to do this, but I don't believe it is a problem; as far as I know, UDP packets are processed on a single thread, so the thread handling code *should* never come into effect.

See https://bitbucket.org/cinderblocks/inworldz/commits/e4698bebe1e6e86cfd77dc296b476f1c28e8799c for the reason the viewer is creating these duplicate calling cards.

One issue that this commit does not address is the requirement to only do this check in the first 10 minutes of the user's login. I was unable to find a property that stored when the user logged in and as we will only ever populate this if they create a calling card, I did not feel that the cache would cause too much of a performance hit.

One change that might need to be made to this commit is disabling the warning message I added to show when blocking of these items occurs. I found this helpful for debugging and it may end up being useful for a short period of time for verification on the main grid itself - but it should be disabled in the long term most likely.

This does not address a separate issue that I ran into where a user can modify the description field of a calling card and change it from the UUID of the person on the calling card to something else, causing the viewer to regenerate the calling card upon logging in. This could also be addressed in this new method by adding a check to make sure the UUID is valid and update the inventory item if it is not.