### PR TITLE
Fixing the float to string conversions to match SL.

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -8581,9 +8581,9 @@ namespace InWorldz.Phlox.Engine
                 return String.Empty;
             }
             StringBuilder ret = new StringBuilder();
-            foreach (object o in src.Data)
+            for (int index = 0; index < src.Data.Length; ++index)
             {
-                ret.Append(o.ToString());
+                ret.Append(src.GetLSLStringItem(index));
                 ret.Append(seperator);
             }
             ret.Length -= seperator.Length;


### PR DESCRIPTION
With related change to Phlox, this corrects llDumpList2String but leaves llList2CSV using the short notation.

You can compare the differences between SL and Halcyon/Phlox using the following script - also attached.

``` LSL
test_str(string name, string expected, string value) {
    if (value == expected)
        llOwnerSay("PASSED - " + name);
    else
        llOwnerSay("FAIL - " + name + "\n  Expected '" + (string) expected + "' but got '" + (string) value + "'");
}

default {
    state_entry() {
        llOwnerSay("==== STARTING TESTS ===="); // Tests tuned to pass on Second Life Server 15.12.01.308474

        test_str("Zero integer cast to string", "0", (string)0);
        test_str("Integer cast to string", "1", (string)1);
        test_str("Negative integer cast to string", "-1", (string)-1);
        test_str("High value integer cast to string", "12345", (string)12345);
        test_str("Zero float cast to string", "0.000000", (string)0.0);
        test_str("Integral float cast to string", "1.000000", (string)1.0);
        test_str("Negative integral float cast to string", "-1.000000", (string)-1.0);
        test_str("High value integral float cast to string", "12345.000000", (string)12345.0);
        test_str("PI cast to string", "3.141593", (string)PI);
        {
            list lst = [0.0, 1.0, PI, -1.0];
            test_str("Four floats in a list cast to string", "0.0000001.0000003.141593-1.000000", (string)lst);
        }
        {
            list lst = [0.0, 1.0, PI, -1.0];
            test_str("Four floats in a list dumped to string", "0.000000|1.000000|3.141593|-1.000000", llDumpList2String(lst, "|"));
        }
        {
            list lst = [0.0, 1.0, PI, -1.0];
            test_str("Four floats in a list CSV'd to string", "0.000000, 1.000000, 3.141593, -1.000000", llList2CSV(lst));
        }
        test_str("Vector cast to string", "<0.00000, 1.00000, 3.14159>", (string)<0, 1, PI>);
        test_str("Rotation cast to string", "<0.00000, 1.00000, 3.14159, -1.00000>", (string)<0, 1, PI, -1>);
        {
            list lst = [<0, 1, PI>, <0, 1, PI, -1>];
            test_str("Vector and rotation in a list cast to string", "<0.000000, 1.000000, 3.141593><0.000000, 1.000000, 3.141593, -1.000000>", (string)lst);
        }
        {
            list lst = [<0, 1, PI>, <0, 1, PI, -1>];
            test_str("Vector and rotation in a list dumped to string", "<0.000000, 1.000000, 3.141593>|<0.000000, 1.000000, 3.141593, -1.000000>", llDumpList2String(lst, "|"));
        }
        {
            list lst = [<0, 1, PI>, <0, 1, PI, -1>];
            test_str("Vector and rotation in a list CSV'd to string", "<0.000000, 1.000000, 3.141593>, <0.000000, 1.000000, 3.141593, -1.000000>", llList2CSV(lst));
        }
    }
}
```

With the following commits and the corresponding changes  to Phlox, in Phlox [PR 9](https://github.com/InWorldz/phlox/pull/9), the output is as follows:

```
==== STARTING TESTS ====
[18:32] Primitive: PASSED - Zero integer cast to string
[18:32] Primitive: PASSED - Integer cast to string
[18:32] Primitive: PASSED - Negative integer cast to string
[18:32] Primitive: PASSED - High value integer cast to string
[18:32] Primitive: PASSED - Zero float cast to string
[18:32] Primitive: PASSED - Integral float cast to string
[18:32] Primitive: PASSED - Negative integral float cast to string
[18:32] Primitive: PASSED - High value integral float cast to string
[18:32] Primitive: PASSED - PI cast to string
[18:32] Primitive: PASSED - Four floats in a list cast to string
[18:32] Primitive: PASSED - Four floats in a list dumped to string
[18:32] Primitive: FAIL - Four floats in a list CSV'd to string
  Expected '0.000000, 1.000000, 3.141593, -1.000000' but got '0, 1, 3.141593, -1'
[18:32] Primitive: PASSED - Vector cast to string
[18:32] Primitive: PASSED - Rotation cast to string
[18:32] Primitive: PASSED - Vector and rotation in a list cast to string
[18:32] Primitive: PASSED - Vector and rotation in a list dumped to string
[18:32] Primitive: FAIL - Vector and rotation in a list CSV'd to string
  Expected '<0.000000, 1.000000, 3.141593>, <0.000000, 1.000000, 3.141593, -1.000000>' but got '<0, 1, 3.141593>, <0, 1, 3.141593, -1>'
```

IE: it is still failing on llList2CSV, but unless there's want to do so I'm of the opinion that CSV can stay in the short form.

With this PR is a request to update the included Phlox DLL so that everything lines up.
