### PR TITLE
Fixed GetUserProfile to never return with a null CurrentAgent.

### DIFF
--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -240,6 +240,12 @@ namespace OpenSim.Framework.Communications
                 profile = TryGetUserProfile(uuid, false);
                 if (profile != null)
                 {
+                    if (profile.CurrentAgent == null)
+                    {
+                        // Make sure we also have an AgentData for the profile.
+                        profile.CurrentAgent = GetUserAgent(uuid, true);
+                    }
+
                     // Check if we should force a refresh.
                     if (!forceRefresh)
                         return profile;


### PR DESCRIPTION
The (first,last) variant now calls this uuid-based variant which did not
ensure CurrentAgent was initialized like the name-based one did.