### PR TITLE
Add an XML serializable RenderMaterialsBytes

### DIFF
--- a/OpenSim/Framework/PrimitiveBaseShape.cs
+++ b/OpenSim/Framework/PrimitiveBaseShape.cs
@@ -115,7 +115,7 @@ namespace OpenSim.Framework
         private PhysicsShapeType _preferredPhysicsShape;
 
         // Materials
-        [XmlIgnore][NonSerialized] private RenderMaterials _renderMaterials;
+        private RenderMaterials _renderMaterials;
 
         // Sculpted
         [XmlIgnore] private UUID _sculptTexture = UUID.Zero;
@@ -1041,6 +1041,19 @@ namespace OpenSim.Framework
             set
             {
                 _renderMaterials = value;
+            }
+        }
+
+        // Used for XML Serialization
+        public byte[] RenderMaterialsBytes
+        {
+            get
+            {
+                return _renderMaterials.ToBytes();
+            }
+            set
+            {
+                _renderMaterials = RenderMaterials.FromBytes(value, 0);
             }
         }
 

--- a/OpenSim/Region/FrameworkTests/SceneUtil.cs
+++ b/OpenSim/Region/FrameworkTests/SceneUtil.cs
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2015, InWorldz Halcyon Developers
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ * 
+ *   * Neither the name of halcyon nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using OpenMetaverse;
+using OpenSim.Region.Framework.Scenes;
+
+namespace OpenSim.Region.FrameworkTests
+{
+    internal class SceneUtil
+    {
+        private readonly static Random rand = new Random();
+
+        public static Vector3 RandomVector()
+        {
+            return new Vector3((float)rand.NextDouble(), (float)rand.NextDouble(), (float)rand.NextDouble());
+        }
+
+        public static Quaternion RandomQuat()
+        {
+            return new Quaternion((float)rand.NextDouble(), (float)rand.NextDouble(), (float)rand.NextDouble(), (float)rand.NextDouble());
+        }
+
+        internal static byte RandomByte()
+        {
+            return (byte)rand.Next(byte.MaxValue);
+        }
+
+        public static SceneObjectPart RandomSOP(string name, uint localId)
+        {
+            var shape = new OpenSim.Framework.PrimitiveBaseShape();
+            shape.ExtraParams = new byte[] { 0xA, 0x9, 0x8, 0x7, 0x6, 0x5 };
+            shape.FlexiDrag = 0.3f;
+            shape.FlexiEntry = true;
+            shape.FlexiForceX = 1.0f;
+            shape.FlexiForceY = 2.0f;
+            shape.FlexiForceZ = 3.0f;
+            shape.FlexiGravity = 10.0f;
+            shape.FlexiSoftness = 1;
+            shape.FlexiTension = 999.4f;
+            shape.FlexiWind = 9292.33f;
+            shape.HollowShape = OpenSim.Framework.HollowShape.Square;
+            shape.LightColorA = 0.3f;
+            shape.LightColorB = 0.22f;
+            shape.LightColorG = 0.44f;
+            shape.LightColorR = 0.77f;
+            shape.LightCutoff = 0.4f;
+            shape.LightEntry = true;
+            shape.LightFalloff = 7474;
+            shape.LightIntensity = 0.0f;
+            shape.LightRadius = 10.0f;
+            shape.Media = new OpenSim.Framework.PrimitiveBaseShape.PrimMedia();
+            shape.Media.New(2);
+            shape.Media[0] = new MediaEntry
+            {
+                AutoLoop = true,
+                AutoPlay = true,
+                AutoScale = true,
+                AutoZoom = true,
+                ControlPermissions = MediaPermission.All,
+                Controls = MediaControls.Standard,
+                CurrentURL = "bam.com",
+                EnableAlterntiveImage = true,
+                EnableWhiteList = false,
+                Height = 1,
+                HomeURL = "anotherbam.com",
+                InteractOnFirstClick = true,
+                InteractPermissions = MediaPermission.Group,
+                WhiteList = new string[] { "yo mamma" },
+                Width = 5
+            };
+            shape.Media[1] = new MediaEntry
+            {
+                AutoLoop = true,
+                AutoPlay = true,
+                AutoScale = true,
+                AutoZoom = true,
+                ControlPermissions = MediaPermission.All,
+                Controls = MediaControls.Standard,
+                CurrentURL = "kabam.com",
+                EnableAlterntiveImage = true,
+                EnableWhiteList = true,
+                Height = 1,
+                HomeURL = "anotherbam.com",
+                InteractOnFirstClick = true,
+                InteractPermissions = MediaPermission.Group,
+                WhiteList = new string[] { "ur mamma" },
+                Width = 5
+            };
+
+            shape.PathBegin = 3;
+            shape.PathCurve = 127;
+            shape.PathEnd = 10;
+            shape.PathRadiusOffset = 127;
+            shape.PathRevolutions = 2;
+            shape.PathScaleX = 50;
+            shape.PathScaleY = 100;
+            shape.PathShearX = 33;
+            shape.PathShearY = 44;
+            shape.PathSkew = 126;
+            shape.PathTaperX = 110;
+            shape.PathTaperY = 66;
+            shape.PathTwist = 99;
+            shape.PathTwistBegin = 3;
+            shape.PCode = 3;
+            shape.PreferredPhysicsShape = PhysicsShapeType.Prim;
+            shape.ProfileBegin = 77;
+            shape.ProfileCurve = 5;
+            shape.ProfileEnd = 7;
+            shape.ProfileHollow = 9;
+            shape.ProfileShape = OpenSim.Framework.ProfileShape.IsometricTriangle;
+            shape.ProjectionAmbiance = 0.1f;
+            shape.ProjectionEntry = true;
+            shape.ProjectionFocus = 3.4f;
+            shape.ProjectionFOV = 4.0f;
+            shape.ProjectionTextureUUID = UUID.Random();
+            shape.Scale = SceneUtil.RandomVector();
+            shape.SculptEntry = true;
+            shape.SculptTexture = UUID.Random();
+            shape.SculptType = 40;
+            shape.VertexCount = 1;
+            shape.HighLODBytes = 2;
+            shape.MidLODBytes = 3;
+            shape.LowLODBytes = 4;
+            shape.LowestLODBytes = 5;
+
+            SceneObjectPart part = new SceneObjectPart(UUID.Zero, shape, new Vector3(1, 2, 3), new Quaternion(4, 5, 6, 7), Vector3.Zero, false);
+            part.Name = name;
+            part.Description = "Desc";
+            part.AngularVelocity = SceneUtil.RandomVector();
+            part.BaseMask = 0x0876;
+            part.Category = 10;
+            part.ClickAction = 5;
+            part.CollisionSound = UUID.Random();
+            part.CollisionSoundVolume = 1.1f;
+            part.CreationDate = OpenSim.Framework.Util.UnixTimeSinceEpoch();
+            part.CreatorID = UUID.Random();
+            part.EveryoneMask = 0x0543;
+            part.Flags = PrimFlags.CameraSource | PrimFlags.DieAtEdge;
+            part.GroupID = UUID.Random();
+            part.GroupMask = 0x0210;
+            part.LastOwnerID = UUID.Random();
+            part.LinkNum = 4;
+            part.LocalId = localId;
+            part.Material = 0x1;
+            part.MediaUrl = "http://bam";
+            part.NextOwnerMask = 0x0234;
+            part.CreatorID = UUID.Random();
+            part.ObjectFlags = 10101;
+            part.OwnerID = UUID.Random();
+            part.OwnerMask = 0x0567;
+            part.OwnershipCost = 5;
+            part.ParentID = 0202;
+            part.ParticleSystem = new byte[] { 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, };
+            part.PassTouches = true;
+            part.PhysicalAngularVelocity = SceneUtil.RandomVector();
+            part.RegionHandle = 1234567;
+            part.RegionID = UUID.Random();
+            part.RotationOffset = SceneUtil.RandomQuat();
+            part.SalePrice = 42;
+            part.SavedAttachmentPoint = 6;
+            part.SavedAttachmentPos = SceneUtil.RandomVector();
+            part.SavedAttachmentRot = SceneUtil.RandomQuat();
+            part.ScriptAccessPin = 87654;
+            part.SerializedPhysicsData = new byte[] { 0xA, 0xB, 0xC, 0xD, 0xE, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, };
+            part.ServerWeight = 3.0f;
+            part.StreamingCost = 2.0f;
+            part.SitName = "Sitting";
+            part.SitTargetOrientation = SceneUtil.RandomQuat();
+            part.SitTargetPosition = SceneUtil.RandomVector();
+            part.Sound = UUID.Random();
+            part.SoundGain = 3.4f;
+            part.SoundOptions = 9;
+            part.SoundRadius = 10.3f;
+            part.Text = "Test";
+            part.TextColor = System.Drawing.Color.FromArgb(1, 2, 3, 4);
+            part.TextureAnimation = new byte[] { 0xA, 0xB, 0xC, 0xD, 0xE, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD };
+            part.TouchName = "DoIt";
+            part.UUID = UUID.Random();
+            part.Velocity = SceneUtil.RandomVector();
+            part.FromItemID = UUID.Random();
+
+            return part;
+        }
+    }
+}

--- a/OpenSim/Region/FrameworkTests/Serialization.cs
+++ b/OpenSim/Region/FrameworkTests/Serialization.cs
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2015, InWorldz Halcyon Developers
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ * 
+ *   * Neither the name of halcyon nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using OpenSim.Region.Framework.Scenes;
+using OpenSim.Region.Framework.Scenes.Serialization;
+using OpenMetaverse;
+using KellermanSoftware.CompareNetObjects;
+using OpenSim.Framework;
+
+namespace OpenSim.Region.FrameworkTests
+{
+    [TestFixture]
+    public class XMLSerializerTests
+    {
+        private readonly List<string> PrimCompareIgnoreList = new List<string> { "ParentGroup", "FullUpdateCounter", "TerseUpdateCounter", 
+                "TimeStamp", "SerializedVelocity", "InventorySerial", "Rezzed", "Shape" };
+
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+        }
+
+        [Test]
+        public void TestGroupSerializationDeserialization()
+        {
+            var sop1 = SceneUtil.RandomSOP("Root", 1);
+            var sop2 = SceneUtil.RandomSOP("Child1", 2);
+            var sop3 = SceneUtil.RandomSOP("Child2", 3);
+
+            SceneObjectGroup group = new SceneObjectGroup(sop1);
+            group.AddPart(sop2);
+            group.AddPart(sop3);
+
+            SceneObjectGroup deserGroup = null;
+            string grpBytes = null;
+
+            Assert.DoesNotThrow(() =>
+            {
+                grpBytes = SceneObjectSerializer.ToXml2Format(group, true);
+                Assert.NotNull(grpBytes);
+            });
+
+            Assert.DoesNotThrow(() =>
+            {
+                deserGroup = SceneObjectSerializer.FromXml2Format(grpBytes);
+            });
+
+            CompareObjects comp = new CompareObjects();
+            comp.CompareStaticFields = false;
+            comp.CompareStaticProperties = false;
+            comp.ElementsToIgnore = PrimCompareIgnoreList;
+
+            Assert.IsTrue(comp.Compare(group, deserGroup), comp.DifferencesString);
+        }
+
+        [Test]
+        public void TestNullMediaListIsNotAnError()
+        {
+            var sop1 = SceneUtil.RandomSOP("Root", 1);
+            var sop2 = SceneUtil.RandomSOP("Child1", 2);
+            var sop3 = SceneUtil.RandomSOP("Child2", 3);
+
+            SceneObjectGroup group = new SceneObjectGroup(sop1);
+            group.AddPart(sop2);
+            group.AddPart(sop3);
+
+            sop1.Shape.Media = null;
+
+            Assert.DoesNotThrow(() =>
+            {
+
+                var grpBytes = SceneObjectSerializer.ToXml2Format(group, true);
+                Assert.NotNull(grpBytes);
+
+                var deserGroup = SceneObjectSerializer.FromXml2Format(grpBytes);
+            });
+        }
+
+        [Test]
+        public void TestNullMediaEntryIsNotAnError()
+        {
+            var sop1 = SceneUtil.RandomSOP("Root", 1);
+            var sop2 = SceneUtil.RandomSOP("Child1", 2);
+            var sop3 = SceneUtil.RandomSOP("Child2", 3);
+
+            sop1.Shape.Media = new PrimitiveBaseShape.PrimMedia(3);
+            sop1.Shape.Media[0] = null;
+            sop1.Shape.Media[1] = new MediaEntry();
+            sop1.Shape.Media[2] = null;
+
+            SceneObjectGroup group = new SceneObjectGroup(sop1);
+            group.AddPart(sop2);
+            group.AddPart(sop3);
+
+            Assert.DoesNotThrow(() =>
+            {
+
+                var grpBytes = SceneObjectSerializer.ToXml2Format(group, true);
+                Assert.NotNull(grpBytes);
+
+                var deserGroup = SceneObjectSerializer.FromXml2Format(grpBytes);
+            });
+        }
+
+        [Test]
+        public void TestRenderMaterialsSerialization()
+        {
+            var sop1 = SceneUtil.RandomSOP("Root", 1);
+            var sop2 = SceneUtil.RandomSOP("Child1", 2);
+            var sop3 = SceneUtil.RandomSOP("Child2", 3);
+
+            var mat1 = new RenderMaterial(UUID.Random(), UUID.Random());
+            var mat2 = new RenderMaterial(UUID.Random(), UUID.Random());
+
+            sop1.Shape.RenderMaterials.AddMaterial(mat1);
+            sop2.Shape.RenderMaterials.AddMaterial(mat2);
+
+            SceneObjectGroup group = new SceneObjectGroup(sop1);
+            group.AddPart(sop2);
+            group.AddPart(sop3);
+
+            SceneObjectGroup deserObj = null;
+
+            Assert.DoesNotThrow(() =>
+            {
+                var grpBytes = SceneObjectSerializer.ToXml2Format(group, true);
+                Assert.NotNull(grpBytes);
+                deserObj = SceneObjectSerializer.FromXml2Format(grpBytes);
+            });
+
+            var newsop1 = deserObj.GetChildPart(1);
+            var newsop2 = deserObj.GetChildPart(2);
+            var newsop3 = deserObj.GetChildPart(3);
+
+            Assert.That(sop1.Shape.RenderMaterials, Is.EqualTo(newsop1.Shape.RenderMaterials));
+            Assert.That(sop2.Shape.RenderMaterials, Is.EqualTo(newsop2.Shape.RenderMaterials));
+            Assert.That(sop3.Shape.RenderMaterials, Is.EqualTo(newsop3.Shape.RenderMaterials));
+        }
+
+    }
+}

--- a/OpenSim/Region/FrameworkTests/Serialization.cs
+++ b/OpenSim/Region/FrameworkTests/Serialization.cs
@@ -43,7 +43,7 @@ namespace OpenSim.Region.FrameworkTests
     public class XMLSerializerTests
     {
         private readonly List<string> PrimCompareIgnoreList = new List<string> { "ParentGroup", "FullUpdateCounter", "TerseUpdateCounter", 
-                "TimeStamp", "SerializedVelocity", "InventorySerial", "Rezzed", "Shape" };
+                "TimeStamp", "SerializedVelocity", "InventorySerial", "Rezzed" };
 
         [TestFixtureSetUp]
         public void Setup()
@@ -67,8 +67,9 @@ namespace OpenSim.Region.FrameworkTests
             Assert.DoesNotThrow(() =>
             {
                 grpBytes = SceneObjectSerializer.ToXml2Format(group, true);
-                Assert.NotNull(grpBytes);
             });
+
+            Assert.NotNull(grpBytes);
 
             Assert.DoesNotThrow(() =>
             {
@@ -96,13 +97,20 @@ namespace OpenSim.Region.FrameworkTests
 
             sop1.Shape.Media = null;
 
+            SceneObjectGroup deserGroup = null;
+            string grpBytes = null;
+
             Assert.DoesNotThrow(() =>
             {
+                grpBytes = SceneObjectSerializer.ToXml2Format(group, true);
 
-                var grpBytes = SceneObjectSerializer.ToXml2Format(group, true);
-                Assert.NotNull(grpBytes);
+            });
 
-                var deserGroup = SceneObjectSerializer.FromXml2Format(grpBytes);
+            Assert.NotNull(grpBytes);
+
+            Assert.DoesNotThrow(() =>
+            {
+                deserGroup = SceneObjectSerializer.FromXml2Format(grpBytes);
             });
         }
 
@@ -122,13 +130,19 @@ namespace OpenSim.Region.FrameworkTests
             group.AddPart(sop2);
             group.AddPart(sop3);
 
+            SceneObjectGroup deserGroup = null;
+            string grpBytes = null;
+
             Assert.DoesNotThrow(() =>
             {
+                grpBytes = SceneObjectSerializer.ToXml2Format(group, true);
+            });
 
-                var grpBytes = SceneObjectSerializer.ToXml2Format(group, true);
-                Assert.NotNull(grpBytes);
+            Assert.NotNull(grpBytes);
 
-                var deserGroup = SceneObjectSerializer.FromXml2Format(grpBytes);
+            Assert.DoesNotThrow(() =>
+            {
+                deserGroup = SceneObjectSerializer.FromXml2Format(grpBytes);
             });
         }
 
@@ -149,18 +163,24 @@ namespace OpenSim.Region.FrameworkTests
             group.AddPart(sop2);
             group.AddPart(sop3);
 
-            SceneObjectGroup deserObj = null;
+            SceneObjectGroup deserGroup = null;
+            string grpBytes = null;
 
             Assert.DoesNotThrow(() =>
             {
-                var grpBytes = SceneObjectSerializer.ToXml2Format(group, true);
-                Assert.NotNull(grpBytes);
-                deserObj = SceneObjectSerializer.FromXml2Format(grpBytes);
+                grpBytes = SceneObjectSerializer.ToXml2Format(group, true);
             });
 
-            var newsop1 = deserObj.GetChildPart(1);
-            var newsop2 = deserObj.GetChildPart(2);
-            var newsop3 = deserObj.GetChildPart(3);
+            Assert.NotNull(grpBytes);
+
+            Assert.DoesNotThrow(() =>
+            {
+                deserGroup = SceneObjectSerializer.FromXml2Format(grpBytes);
+            });
+
+            var newsop1 = deserGroup.GetChildPart(1);
+            var newsop2 = deserGroup.GetChildPart(2);
+            var newsop3 = deserGroup.GetChildPart(3);
 
             Assert.That(sop1.Shape.RenderMaterials, Is.EqualTo(newsop1.Shape.RenderMaterials));
             Assert.That(sop2.Shape.RenderMaterials, Is.EqualTo(newsop2.Shape.RenderMaterials));


### PR DESCRIPTION
Add an XML serializable RenderMaterialsBytes so we can save/restore OARS with materials set on them.  RenderMaterials is still set to XmlIgnore.  It contains a dictionary which the XML serializer chokes on.