### PR TITLE
Address an issue with duplicating calling cards ...

### DIFF
--- a/OpenSim/Framework/Communications/Cache/CachedUserInfo.cs
+++ b/OpenSim/Framework/Communications/Cache/CachedUserInfo.cs
@@ -75,6 +75,15 @@ namespace OpenSim.Framework.Communications.Cache
         public bool HasReceivedInventory { get { return true; } }
 
         /// <summary>
+        /// This is a list of all of the inventory items that are of type "CallingCard" in the
+        ///   "Calling Card"/Friends/All folder to work around a bug with the viewer creating
+        ///   multiple copies of the same calling card
+        /// </summary>
+        private List<string> _namesOfCallingCardsInCallingCardsFriendsAllFolder = null;
+        private object _namesOfCallingCardsInCallingCardsFriendsAllFolderLock = new object();
+        private System.Threading.AutoResetEvent _namesOfCallingCardsInCallingCardsFriendsAllFolderWaitLock = null;
+
+        /// <summary>
         /// Holds the most appropriate folders for the given type.
         /// Note:  Thus far in the code, this folder doesn't have to be kept up to date as it will 
         /// only be used to retrieve an ID.  If this ever changes, this collection will have to be kept up to date
@@ -168,6 +177,116 @@ namespace OpenSim.Framework.Communications.Cache
             lock (_permissionsGivenByFriends)
             {
                 _permissionsGivenByFriends[friendId] = newPermissions;
+            }
+        }
+
+        /// <summary>
+        /// Check if a calling card already exists in the given folder with the name given
+        /// </summary>
+        /// <param name="folderId">Folder to check for calling cards in</param>
+        /// <param name="name">Name of user whose name may be on one of the calling cards</param>
+        /// <returns></returns>
+        public bool CheckIfCallingCardAlreadyExistsForUser(UUID folderId, string name)
+        {
+            //On 2015-12-15, a problem with calling cards occurred such that all calling cards
+            // would be duplicated by the viewer when logging in, which caused users to not
+            // display themselves and in extreme cases, would block them from doing anything
+            // along with generating 65000 calling cards for one user
+            //To address this issue, we make sure that the viewer cannot add calling cards
+            // that already exist for that user in the "Calling Cards"/Friends/All folder. 
+            // We will ignore the requests.
+            PopulateCallingCardCache(folderId);
+            lock (_namesOfCallingCardsInCallingCardsFriendsAllFolderLock)
+            {
+                if (_namesOfCallingCardsInCallingCardsFriendsAllFolder != null)
+                {
+                    return _namesOfCallingCardsInCallingCardsFriendsAllFolder.Contains(name);
+                }
+                //Something went wrong and we weren't able to populate the calling card cache
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Populates the calling card cache for the user for the given folder
+        /// </summary>
+        /// <param name="folderId"></param>
+        private void PopulateCallingCardCache(UUID folderId)
+        {
+            bool mustWait = true;
+            //Make sure that multiple threads are not trying to populate the cache at the same time
+            // as the inventory operations are heavy
+            lock (_namesOfCallingCardsInCallingCardsFriendsAllFolderLock)
+            {
+                if (_namesOfCallingCardsInCallingCardsFriendsAllFolder != null)
+                {
+                    //The cache exists, we don't need to populate it
+                    return;
+                }
+
+                if (_namesOfCallingCardsInCallingCardsFriendsAllFolderWaitLock == null)
+                {
+                    //We were the first one here, we get to create the lock and have the other threads wait
+                    // as we don't want all threads that might come in here requesting all of the folder contents multiple times
+                    mustWait = false;
+                    _namesOfCallingCardsInCallingCardsFriendsAllFolderWaitLock = new System.Threading.AutoResetEvent(false);
+                }
+            }
+
+            if (mustWait)
+            {
+                //Wait for another thread to finish populating the cache, but dDo not block indefinitely - wait a max of 10 seconds
+                // before proceeding on even though the other thread hasn't finished... this might allow some duplicate calling
+                // cards, but if something is going so wrong that after 10 seconds it hasn't gotten the folders, we should just
+                // give up and try to move on
+                _namesOfCallingCardsInCallingCardsFriendsAllFolderWaitLock.WaitOne(10000);
+                return;
+            }
+
+            List<string> callingCardItemNames = null;
+            try
+            {
+                InventoryFolderBase potentialCallingCardsFolder = FindTopLevelFolderFor(folderId);
+                if (potentialCallingCardsFolder == null || //This can happen if MySQL is used for inventory
+                    potentialCallingCardsFolder.Type == (short)InventoryType.CallingCard)
+                {
+                    InventoryFolderBase newCallingCardFolder = GetFolder(folderId);
+                    //We only check in the All folder as the bug with calling card duplication
+                    // only occurs in "Calling Cards"/Friends/All - not other folders
+                    if (newCallingCardFolder.Name == "All")
+                    {
+                        callingCardItemNames = new List<string>();
+                        foreach (InventoryItemBase itm in newCallingCardFolder.Items)
+                        {
+                            if (itm.AssetType == (int)AssetType.CallingCard)
+                            {
+                                //Add the item name to the list - as the user cannot edit this in the viewer
+                                // as it is disabled, it is safe to check just based on the name
+                                callingCardItemNames.Add(itm.Name);
+                            }
+                        }
+
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                m_log.ErrorFormat("[INVENTORY] An exception occurred finding calling cards in folderID {0}: {1}", folderId, e);
+            }
+            finally
+            {
+                //Now under the lock, set the list of calling cards and then pulse the wait lock to inform other threads
+                // that they can run now too
+                lock (_namesOfCallingCardsInCallingCardsFriendsAllFolderLock)
+                {
+                    _namesOfCallingCardsInCallingCardsFriendsAllFolder = callingCardItemNames;
+                    _namesOfCallingCardsInCallingCardsFriendsAllFolderWaitLock.Set();
+                    if (callingCardItemNames == null)
+                    {
+                        //It failed, so clear the wait lock and let someone else try later
+                        _namesOfCallingCardsInCallingCardsFriendsAllFolderWaitLock = null;
+                    }
+                }
             }
         }
 

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -1157,6 +1157,26 @@ namespace OpenSim.Region.Framework.Scenes
 
             if (userInfo != null)
             {
+                if(assetType == AssetType.CallingCard && invType == (int)OpenMetaverse.InventoryType.CallingCard)
+                {
+                    //On 2015-12-15, a problem with calling cards occurred such that all calling cards
+                    // would be duplicated by the viewer when logging in, which caused users to not
+                    // display themselves and in extreme cases, would block them from doing anything
+                    // along with generating 65000 calling cards for one user
+                    //To address this issue, we make sure that the viewer cannot add calling cards
+                    // that already exist for that user in the "Calling Cards"/Friends/All folder. 
+                    // We will ignore the requests.
+                    //We will cache the calling card folder in the CachedUserInfo as we don't want to 
+                    // call the inventory database repeatedly to get the data.
+                    if (userInfo.CheckIfCallingCardAlreadyExistsForUser(folderID, name))
+                    {
+                        m_log.WarnFormat(
+                            "[AGENT INVENTORY]: User requested to generate duplicate calling card for client {0} uuid {1} in CreateNewInventoryItem!",
+                                remoteClient.Name, remoteClient.AgentId);
+                        return;
+                    }
+                }
+
                 InventoryItemBase item = new InventoryItemBase();
                 item.Owner = remoteClient.AgentId;
                 item.CreatorId = creatorID;


### PR DESCRIPTION
each time the user logs in with some v3 viewers. This commit modifies the handling of the "CreateInventoryItem" packet to check whether the new item is a calling card, whether it is in the "Calling Cards"/Friends/All folder, and that another calling card for the user does not already exist in this folder. If a duplicate item exists, the create inventory item action does not take place and is ignored. To make sure that this does not hit the inventory database too much, only one thread is allowed to populate the calling card cache and the others will wait until it completes or 10 seconds have passed. I'm not sure of a better way to do this, but I don't believe it is a problem; as far as I know, UDP packets are processed on a single thread, so the thread handling code *should* never come into effect.

See https://bitbucket.org/cinderblocks/inworldz/commits/e4698bebe1e6e86cfd77dc296b476f1c28e8799c for the reason the viewer is creating these duplicate calling cards.

One issue that this commit does not address is the requirement to only do this check in the first 10 minutes of the user's login. I was unable to find a property that stored when the user logged in and as we will only ever populate this if they create a calling card, I did not feel that the cache would cause too much of a performance hit.

One change that might need to be made to this commit is disabling the warning message I added to show when blocking of these items occurs. I found this helpful for debugging and it may end up being useful for a short period of time for verification on the main grid itself - but it should be disabled in the long term most likely.

This does not address a separate issue that I ran into where a user can modify the description field of a calling card and change it from the UUID of the person on the calling card to something else, causing the viewer to regenerate the calling card upon logging in. This could also be addressed in this new method by adding a check to make sure the UUID is valid and update the inventory item if it is not.