### PR TITLE
Workaround for Issue 113

### DIFF
--- a/OpenSim/Region/CoreModules/Avatar/AvatarFactory/AvatarFactoryModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/AvatarFactory/AvatarFactoryModule.cs
@@ -112,11 +112,13 @@ namespace OpenSim.Region.CoreModules.Avatar.AvatarFactory
 
             private static InventoryFolderBase GetCurrentOutfitFolder(CachedUserInfo userInfo)
             {
-                InventoryFolderBase CurrentOutfitFolder = null;
+                // Duplicate method exists at Scene.Inventory.cs::Scene::GetCurrentOutfitFolder
+
+                InventoryFolderBase currentOutfitFolder = null;
 
                 try
                 {
-                    CurrentOutfitFolder = userInfo.FindFolderForType((int)AssetType.CurrentOutfitFolder);
+                    currentOutfitFolder = userInfo.FindFolderForType((int)AssetType.CurrentOutfitFolder);
                 }
                 catch (InventoryStorageException)
                 {
@@ -133,17 +135,17 @@ namespace OpenSim.Region.CoreModules.Avatar.AvatarFactory
                     }
                     if (foundFolder != null)
                     {
-                        CurrentOutfitFolder = userInfo.GetFolder(foundFolder.ID);
-                        if (CurrentOutfitFolder != null)
+                        currentOutfitFolder = userInfo.GetFolder(foundFolder.ID);
+                        if (currentOutfitFolder != null)
                         {
-                            CurrentOutfitFolder.Level = InventoryFolderBase.FolderLevel.TopLevel;
-                            userInfo.UpdateFolder(CurrentOutfitFolder);
+                            currentOutfitFolder.Level = InventoryFolderBase.FolderLevel.TopLevel;
+                            userInfo.UpdateFolder(currentOutfitFolder);
                         }
                     }
                 }
-                if(CurrentOutfitFolder != null)
-                    CurrentOutfitFolder = userInfo.GetFolder(CurrentOutfitFolder.ID);
-                return CurrentOutfitFolder;
+                if(currentOutfitFolder != null)
+                    currentOutfitFolder = userInfo.GetFolder(currentOutfitFolder.ID);
+                return currentOutfitFolder;
             }
 
             public void COFHasBeenSet()

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -1185,14 +1185,20 @@ namespace OpenSim.Region.Framework.Scenes
                     InventoryFolderBase currentOutfitFolder = GetCurrentOutfitFolder(userInfo);
                     if (currentOutfitFolder != null && currentOutfitFolder.ID == folderID)
                     {
+                        uint count = 0;
+
                         // Get rid of all folder links in the COF: there should only ever be one, and that's the one we are about to create.
                         foreach (InventoryItemBase cofItem in currentOutfitFolder.Items)
                         {
                             if (cofItem.AssetType == (int)AssetType.LinkFolder)
                             {
                                 userInfo.DeleteItem(cofItem);
+                                ++count;
                             }
                         }
+
+                        if (count > 1) // Only report if more than one was removed.
+                            m_log.InfoFormat("[AGENT INVENTORY] Removed {0} out of date folder links from the COF for avatar {1}.", count, userInfo.UserProfile.ID);
 
                         userInfo.UpdateFolder(currentOutfitFolder);
                     }

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -1185,26 +1185,13 @@ namespace OpenSim.Region.Framework.Scenes
                     InventoryFolderBase currentOutfitFolder = GetCurrentOutfitFolder(userInfo);
                     if (currentOutfitFolder != null)
                     {
-                        List<InventoryItemBase> linksToRemove = null;
-
-                        // Mark all folder links in the COF for removal: there should only ever be one, and that's the one we are about to create.
-                        lock (currentOutfitFolder.Items)
+                        // Get rid of all folder links in the COF: there should only ever be one, and that's the one we are about to create.
+                        foreach (InventoryItemBase cofItem in currentOutfitFolder.Items)
                         {
-                            linksToRemove = new List<InventoryItemBase>(currentOutfitFolder.Items.Count); // This is the maximum number of entries that we can possibly ever remove, and therefore means only ONE alloc of this list per call to this method.
-
-                            foreach (InventoryItemBase cofItem in currentOutfitFolder.Items)
+                            if (cofItem.AssetType == (int)AssetType.LinkFolder)
                             {
-                                if (cofItem.AssetType == (int)AssetType.LinkFolder)
-                                {
-                                    linksToRemove.Add(cofItem);
-                                }
+                                userInfo.DeleteItem(cofItem);
                             }
-                        }
-
-                        // Get rid of 'em!  Don't care if there were failures: if this doesn't kill them now, it will on the next outfit change!
-                        foreach (InventoryItemBase itemToBeDeleted in linksToRemove)
-                        {
-                            userInfo.DeleteItem(itemToBeDeleted);
                         }
 
                         userInfo.UpdateFolder(currentOutfitFolder);

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -1181,9 +1181,9 @@ namespace OpenSim.Region.Framework.Scenes
                 // However there may be more than one if this is is an old DB, so make sure all are gone.
                 if (assetType == AssetType.LinkFolder)
                 {
-                    //verify this user actually owns the item
+                    // Verify this user actually owns the item, AND that the current operation is in the COF - otherwise there's no reason to clean the COF!
                     InventoryFolderBase currentOutfitFolder = GetCurrentOutfitFolder(userInfo);
-                    if (currentOutfitFolder != null)
+                    if (currentOutfitFolder != null && currentOutfitFolder.ID == folderID)
                     {
                         // Get rid of all folder links in the COF: there should only ever be one, and that's the one we are about to create.
                         foreach (InventoryItemBase cofItem in currentOutfitFolder.Items)


### PR DESCRIPTION
Christmas gift for Vin, and by extension the rest of the Halcyon universe, a cleaner database.

This does NOT solve the underlying issue to #113, it only cleans up and makes sure that the mess making doesn't go anywhere. I do not know why FS is/was not detecting the current outfit on a fresh login and sometimes forgetting which one it's wearing mid login, but this patch solves that by making sure the duplicate records go away.

Please review with a fine-tooth comb and a sense of distrust: this does some pretty heavy-handed activity.