### PR TITLE
Fixed a dictionary add exception that would happen on any localID update

### DIFF
--- a/OpenSim/Region/Framework/Scenes/GroupPartsCollection.cs
+++ b/OpenSim/Region/Framework/Scenes/GroupPartsCollection.cs
@@ -196,15 +196,10 @@ namespace OpenSim.Region.Framework.Scenes
         /// <param name="value">The new localid</param>
         public void PartLocalIdUpdated(SceneObjectPart part, uint oldLocalId, uint value)
         {
-            //add the new local ID then remove the old
+            // replace the old local ID with the new one
             lock (m_mutationLock)
             {
-                m_partsByLocalId = m_partsByLocalId.Add(value, part.UUID);
-
-                if (oldLocalId != 0 && oldLocalId != value)
-                {
-                    m_partsByLocalId = m_partsByLocalId.Remove(oldLocalId);
-                }
+                m_partsByLocalId = m_partsByLocalId.SetItem(value, part.UUID);
             }
         }
     }


### PR DESCRIPTION
There's a SetItem that can be used like a Replace anyway, instead of
calling Add/Remove, since calling them in either order leaves a time
when the dictionaries aren't consistent.  Single update to handle the
remove/add as a replace.

This is a merge into the release branch. Separate PR #117 for master.