### PR TITLE
Final fixes after testing immutable parts list management

### DIFF
--- a/OpenSim/Region/Framework/Scenes/GroupPartsCollection.cs
+++ b/OpenSim/Region/Framework/Scenes/GroupPartsCollection.cs
@@ -196,14 +196,19 @@ namespace OpenSim.Region.Framework.Scenes
         /// <param name="value">The new localid</param>
         public void PartLocalIdUpdated(SceneObjectPart part, uint oldLocalId, uint value)
         {
-            //add the new local ID then remove the old
+            if (value == oldLocalId) return; // nothing to do
+
+            // different local IDs
             lock (m_mutationLock)
             {
-                m_partsByLocalId = m_partsByLocalId.Add(value, part.UUID);
-
-                if (oldLocalId != 0 && oldLocalId != value)
+                //add the new local ID then remove the old
+                if (oldLocalId != 0)
                 {
                     m_partsByLocalId = m_partsByLocalId.Remove(oldLocalId);
+                }
+                if (value != 0)
+                {
+                    m_partsByLocalId = m_partsByLocalId.Add(value, part.UUID);
                 }
             }
         }

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -2422,8 +2422,9 @@ namespace OpenSim.Region.Framework.Scenes
 
             foreach (SceneObjectPart part in partsList)
             {
+                m_children.RemovePart(part); // the old IDs are changing
                 part.ResetIDs(part.LinkNum); // Don't change link nums
-                m_children.AddPart(part);
+                m_children.AddPart(part); // update the part lists with new IDs
             }
         }
 


### PR DESCRIPTION
- SOG.ResetIDs needs to remove the part first (since IDs are being
updated) otherwise AddPart duplicates it in the list.
- Fix to avoid PartLocalIdUpdated adding localId 0 and never removing it
(also some other lesser changes such as doing the Remove first to void
having a time when a part was in the list twice, other small changes).