### PR TITLE
Fixed a regression that caused bot profiles to not be found.

### DIFF
--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -235,6 +235,10 @@ namespace OpenSim.Framework.Communications
 
             UserProfileData profile;
 
+            // Temp profiles do not exist in permanent storage, cannot force refresh.
+            if (m_tempDataByUUID.TryGetValue(uuid, out profile))
+                return profile;
+
             if (!forceRefresh)
             {
                 lock (m_userDataLock)


### PR DESCRIPTION
The fixes for user profile caching missed a special exception case for
temp profiles which left them unable to be returned from a UUID search.
Special check restored in this commit.  Fixes missing bot names,
profiles, and ability to create a second bot with the same name, etc.