### PR TITLE
Fixed a regression that caused bot profiles to not be found.

### DIFF
--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -235,6 +235,10 @@ namespace OpenSim.Framework.Communications
 
             UserProfileData profile;
 
+            // Temp profiles do not exist in permanent storage, cannot force refresh.
+            if (m_tempDataByUUID.TryGetValue(uuid, out profile))
+                return profile;
+
             if (!forceRefresh)
             {
                 lock (m_userDataLock)

--- a/OpenSim/Region/Framework/Scenes/GroupPartsCollection.cs
+++ b/OpenSim/Region/Framework/Scenes/GroupPartsCollection.cs
@@ -196,14 +196,19 @@ namespace OpenSim.Region.Framework.Scenes
         /// <param name="value">The new localid</param>
         public void PartLocalIdUpdated(SceneObjectPart part, uint oldLocalId, uint value)
         {
-            //add the new local ID then remove the old
+            if (value == oldLocalId) return; // nothing to do
+
+            // different local IDs
             lock (m_mutationLock)
             {
-                m_partsByLocalId = m_partsByLocalId.Add(value, part.UUID);
-
-                if (oldLocalId != 0 && oldLocalId != value)
+                //add the new local ID then remove the old
+                if (oldLocalId != 0)
                 {
                     m_partsByLocalId = m_partsByLocalId.Remove(oldLocalId);
+                }
+                if (value != 0)
+                {
+                    m_partsByLocalId = m_partsByLocalId.Add(value, part.UUID);
                 }
             }
         }

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -2422,8 +2422,9 @@ namespace OpenSim.Region.Framework.Scenes
 
             foreach (SceneObjectPart part in partsList)
             {
+                m_children.RemovePart(part); // the old IDs are changing
                 part.ResetIDs(part.LinkNum); // Don't change link nums
-                m_children.AddPart(part);
+                m_children.AddPart(part); // update the part lists with new IDs
             }
         }
 


### PR DESCRIPTION
The fixes for user profile caching missed a special exception case for
temp profiles which left them unable to be returned from a UUID search.
Special check restored in this commit.  Fixes missing bot names,
profiles, and ability to create a second bot with the same name, etc.