### PR TITLE
Fixed a mesh upload regression with the order of parts.

### DIFF
--- a/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
@@ -802,26 +802,28 @@ namespace OpenSim.Region.CoreModules.Capabilities
                 }
 
                 Vector3 rootPos = positions[0];
-                SceneObjectPart[] parts = grp.GetParts().ToArray();
-
                 // Fix first link number
-                if (parts.Length > 1)
+                if (mesh_list.Count > 1)
                 {
-                    grp.RootPart.LinkNum++;
-
                     Quaternion rootRotConj = Quaternion.Conjugate(rotations[0]);
                     Quaternion tmprot;
                     Vector3 offset;
 
                     // Fix child rotations and positions
-                    for (int i = 1; i < rotations.Count; i++)
+                    foreach (SceneObjectPart part in grp.GetParts())
                     {
+                        // The part values are likely to come out of order from the collection,
+                        // but the positions and rotations arrays are ordered by link number.
+                        int i = part.LinkNum;
+                        if (i > 0) i--; // need to convert to 0-based except for single-prim
+                        if (i == 0)
+                            continue;   // the root prim does not need an adjustment
                         tmprot = rotations[i];
                         tmprot = rootRotConj * tmprot;
-                        parts[i].RotationOffset = tmprot;
+                        part.RotationOffset = tmprot;
                         offset = positions[i] - rootPos;
                         offset *= rootRotConj;
-                        parts[i].OffsetPosition = offset;
+                        part.OffsetPosition = offset;
                     }
 
                     grp.AbsolutePosition = rootPos;


### PR DESCRIPTION
Mesh uploader had a SOG root prim correction that are no longer needed
in the new implementation and in fact causes a problem now. Also removed
the assumption of the order of prims returned from GetParts since it
depends on dictionary implementations.