### PR TITLE
Bug fix for release and master.  RenderMaterials on a Legacy prim fails.

### DIFF
--- a/InWorldz/InWorldz.Region.Data.Thoosa/Serialization/PrimShapeSnapshot.cs
+++ b/InWorldz/InWorldz.Region.Data.Thoosa/Serialization/PrimShapeSnapshot.cs
@@ -345,7 +345,7 @@ namespace InWorldz.Region.Data.Thoosa.Serialization
                 MidLODBytes = this.MidLODBytes,
                 LowLODBytes = this.LowLODBytes,
                 LowestLODBytes = this.LowestLODBytes,
-                RenderMaterials = this.RenderMaterials
+                RenderMaterials = this.RenderMaterials != null ? this.RenderMaterials : new RenderMaterials()
             };
         }
     }


### PR DESCRIPTION
Handle a case where a legacy prim is restored from inventory with no RenderMaterials entry in PrimitiveBaseShape.