### PR TITLE
Fixed UserAgentData objects not being cached by regions.

### DIFF
--- a/OpenSim/Framework/Communications/UserProfileManagerData.cs
+++ b/OpenSim/Framework/Communications/UserProfileManagerData.cs
@@ -126,7 +126,11 @@ namespace OpenSim.Framework.Communications
             {
                 UserAgentData agent = plugin.GetAgentByUUID(uuid);
                 if (agent != null)
+                {
+                    // Whatever plugin returns an agent data structure, ensure the UUID is filled in.
+                    agent.ProfileID = uuid;
                     return agent;
+                }
             }
 
             return null;


### PR DESCRIPTION
"get_agent_by_uuid" XMLRPC calls to the User server return a
UserAgentData with .ProfileID==UUID.Zero so when the UserAgentData is
cached, it's cached with the wrong dictionary key.  (In fact, only
session ID, region handle and online status boolean are initialized in a
UserAgentData on regions due to that XMLRPC call.)