### PR TITLE
IW_OBJECT_SCRIPT_MEMORY_USED

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -5086,10 +5086,8 @@ namespace InWorldz.Phlox.Engine
                             case ScriptBaseClass.OBJECT_SCRIPT_MEMORY:  // total mem possible (128K)
                                 total += engine.GetMaxMemory();
                                 break;
-                            case ScriptBaseClass.OBJECT_SCRIPT_MEMORY_USED:
+                            case ScriptBaseClass.IW_OBJECT_SCRIPT_MEMORY_USED:
                                 total += m_ScriptEngine.GetUsedMemory(inv.Value.ItemID);
-                                //total += m_ScriptEngine.GetUsedMemory(ScriptByName(inv.Value.Name));
-                                //total += m_ScriptEngine.GetUsedMemory(inv.Key);
                                 break;
                         }
                     }
@@ -5158,7 +5156,7 @@ namespace InWorldz.Phlox.Engine
                     case ScriptBaseClass.OBJECT_RUNNING_SCRIPT_COUNT:
                     case ScriptBaseClass.OBJECT_TOTAL_SCRIPT_COUNT:
                     case ScriptBaseClass.OBJECT_SCRIPT_MEMORY:
-                    case ScriptBaseClass.OBJECT_SCRIPT_MEMORY_USED:
+                    case ScriptBaseClass.IW_OBJECT_SCRIPT_MEMORY_USED:
                         total += GetObjectScriptTotal(group, which);
                         break;
                 }
@@ -13371,7 +13369,7 @@ namespace InWorldz.Phlox.Engine
                     case ScriptBaseClass.OBJECT_RUNNING_SCRIPT_COUNT:
                     case ScriptBaseClass.OBJECT_TOTAL_SCRIPT_COUNT:
                     case ScriptBaseClass.OBJECT_SCRIPT_MEMORY:
-                    case ScriptBaseClass.OBJECT_SCRIPT_MEMORY_USED:
+                    case ScriptBaseClass.IW_OBJECT_SCRIPT_MEMORY_USED:
                         ret.Add(GetAgentTotals(av, param));
                         break;
                     case ScriptBaseClass.OBJECT_SCRIPT_TIME:
@@ -13505,7 +13503,7 @@ namespace InWorldz.Phlox.Engine
                             case ScriptBaseClass.OBJECT_RUNNING_SCRIPT_COUNT:
                             case ScriptBaseClass.OBJECT_TOTAL_SCRIPT_COUNT:
                             case ScriptBaseClass.OBJECT_SCRIPT_MEMORY:
-                            case ScriptBaseClass.OBJECT_SCRIPT_MEMORY_USED:
+                            case ScriptBaseClass.IW_OBJECT_SCRIPT_MEMORY_USED:
                                 ret.Add(GetObjectScriptTotal(part.ParentGroup, param));
                                 break;
                             case ScriptBaseClass.OBJECT_SCRIPT_TIME:

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -5083,8 +5083,13 @@ namespace InWorldz.Phlox.Engine
                                 if (engine.GetScriptState(inv.Value.ItemID))
                                     total++;
                                 break;
-                            case ScriptBaseClass.OBJECT_SCRIPT_MEMORY:  // total mem possible (64K)
+                            case ScriptBaseClass.OBJECT_SCRIPT_MEMORY:  // total mem possible (128K)
                                 total += engine.GetMaxMemory();
+                                break;
+                            case ScriptBaseClass.OBJECT_SCRIPT_MEMORY_USED:
+                                total += m_ScriptEngine.GetUsedMemory(inv.Value.ItemID);
+                                //total += m_ScriptEngine.GetUsedMemory(ScriptByName(inv.Value.Name));
+                                //total += m_ScriptEngine.GetUsedMemory(inv.Key);
                                 break;
                         }
                     }
@@ -13498,6 +13503,7 @@ namespace InWorldz.Phlox.Engine
                             case ScriptBaseClass.OBJECT_RUNNING_SCRIPT_COUNT:
                             case ScriptBaseClass.OBJECT_TOTAL_SCRIPT_COUNT:
                             case ScriptBaseClass.OBJECT_SCRIPT_MEMORY:
+                            case ScriptBaseClass.OBJECT_SCRIPT_MEMORY_USED:
                                 ret.Add(GetObjectScriptTotal(part.ParentGroup, param));
                                 break;
                             case ScriptBaseClass.OBJECT_SCRIPT_TIME:

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -5158,6 +5158,7 @@ namespace InWorldz.Phlox.Engine
                     case ScriptBaseClass.OBJECT_RUNNING_SCRIPT_COUNT:
                     case ScriptBaseClass.OBJECT_TOTAL_SCRIPT_COUNT:
                     case ScriptBaseClass.OBJECT_SCRIPT_MEMORY:
+                    case ScriptBaseClass.OBJECT_SCRIPT_MEMORY_USED:
                         total += GetObjectScriptTotal(group, which);
                         break;
                 }
@@ -13370,6 +13371,7 @@ namespace InWorldz.Phlox.Engine
                     case ScriptBaseClass.OBJECT_RUNNING_SCRIPT_COUNT:
                     case ScriptBaseClass.OBJECT_TOTAL_SCRIPT_COUNT:
                     case ScriptBaseClass.OBJECT_SCRIPT_MEMORY:
+                    case ScriptBaseClass.OBJECT_SCRIPT_MEMORY_USED:
                         ret.Add(GetAgentTotals(av, param));
                         break;
                     case ScriptBaseClass.OBJECT_SCRIPT_TIME:

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
@@ -544,7 +544,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
         public const int OBJECT_BODY_SHAPE_TYPE = 26;
         public const int OBJECT_LAST_OWNER_ID = 27;
         public const int OBJECT_CLICK_ACTION = 28;
-        public const int OBJECT_SCRIPT_MEMORY_USED = 1001;
+        public const int IW_OBJECT_SCRIPT_MEMORY_USED = 10001;
 
         // Values for llGetObjectDetails(OBJECT_PATHFINDING_TYPE) above
         public const int OPT_OTHER = -1;            // Attachments, Linden trees & grass

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
@@ -544,6 +544,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
         public const int OBJECT_BODY_SHAPE_TYPE = 26;
         public const int OBJECT_LAST_OWNER_ID = 27;
         public const int OBJECT_CLICK_ACTION = 28;
+        public const int OBJECT_SCRIPT_MEMORY_USED = 1001;
 
         // Values for llGetObjectDetails(OBJECT_PATHFINDING_TYPE) above
         public const int OPT_OTHER = -1;            // Attachments, Linden trees & grass


### PR DESCRIPTION
This branch (which is misnamed) adds a new inworldz-specific constant for llGetObjectDetails and llGetAgentDetails, IW_OBJECT_SCRIPT_MEMORY_USED.  It functions like the OBJECT_SCRIPT_MEMORY constant, but instead of assuming each script is using the maximum amount of memory, it instead reports the actual memory usage of the scripts.

I could have simply changed the behavior of OBJECT_SCRIPT_MEMORY, but it occurred to me that scripts imported from Second Life may break if they're coded to assume SL behavior.