### PR TITLE
Fixed IMs not being able to follow users as they moved to new regions.

### DIFF
--- a/OpenSim/Region/CoreModules/Avatar/InstantMessage/MessageTransferModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/InstantMessage/MessageTransferModule.cs
@@ -533,7 +533,7 @@ namespace OpenSim.Region.CoreModules.Avatar.InstantMessage
             if (lookupAgent)
             {
                 // Non-cached user agent lookup.
-                upd = m_Scenes[0].CommsManager.UserService.GetUserAgent(toAgentID);
+                upd = m_Scenes[0].CommsManager.UserService.GetUserAgent(toAgentID,true);
 
                 if (upd != null)
                 {


### PR DESCRIPTION
On error delivering to the previous known location, force a refresh of
UserAgentData with the region handle.