### PR TITLE
Fixes to Export Permission based on IW3 tests

### DIFF
--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.Inventory.cs
@@ -289,6 +289,7 @@ namespace OpenSim.Region.Framework.Scenes
             return -1;
         }
 
+        private const uint PERM_MCT = (uint)PermissionMask.Copy | (uint)PermissionMask.Modify | (uint)PermissionMask.Transfer;
         public uint GetEffectivePermissions(bool includeContents)
         {
             uint perms = (uint)(PermissionMask.All | PermissionMask.Export);
@@ -337,6 +338,9 @@ namespace OpenSim.Region.Framework.Scenes
                 perms &= ~(uint)PermissionMask.Copy;
             if ((nextOwnerMask & (uint)PermissionMask.Transfer) == 0)
                 perms &= ~(uint)PermissionMask.Transfer;
+
+            if ((perms & PERM_MCT) != PERM_MCT)
+                perms &= ~(uint)PermissionMask.Export;
 
             return perms;
         }

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
@@ -1057,6 +1057,7 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
+        private const uint PERM_MCT = (uint)PermissionMask.Copy | (uint)PermissionMask.Modify | (uint)PermissionMask.Transfer;
         public uint MaskEffectivePermissions()
         {
             uint mask = ScenePermBits.BASEMASK;
@@ -1073,6 +1074,8 @@ namespace OpenSim.Region.Framework.Scenes
                         mask &= ~(uint)PermissionMask.Modify;
                 }
             }
+            if ((mask & PERM_MCT) != PERM_MCT)
+                mask &= ~(uint)PermissionMask.Export;
             return mask;
         }
         public uint MaskEffectiveNextPermissions()
@@ -1091,6 +1094,8 @@ namespace OpenSim.Region.Framework.Scenes
                         mask &= ~(uint)PermissionMask.Modify;
                 }
             }
+            if ((mask & PERM_MCT) != PERM_MCT)
+                mask &= ~(uint)PermissionMask.Export;
             return mask;
         }
 


### PR DESCRIPTION
Fixed non-FP objects and parts to clear the Export flag in effective
permissions.