### PR TITLE
Fixed a bot UUID check that used null instead of UUID.Zero

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -16854,7 +16854,7 @@ namespace InWorldz.Phlox.Engine
                 UUID userID;
                 if (!UUID.TryParse(avatar, out userID))
                 {
-                    if (World.CommsManager.UserService.Name2Key(avatar) == null)
+                    if (World.CommsManager.UserService.Name2Key(avatar) == UUID.Zero)
                         return ScriptBaseClass.BOT_USER_NOT_FOUND;
                 }
 


### PR DESCRIPTION
Not sure how this even compiled before since UUID is a struct (cannot be
null or assigned a reference).