### PR TITLE
Added the ability to handle ISEs from the Cassandra datastorage layer.

### DIFF
--- a/OpenSim/Framework/Communications/Cache/CachedUserInfo.cs
+++ b/OpenSim/Framework/Communications/Cache/CachedUserInfo.cs
@@ -548,7 +548,7 @@ namespace OpenSim.Framework.Communications.Cache
         /// If the inventory service has not yet delievered the inventory
         /// for this user then the request will be queued.
         /// </summary>
-        /// <param name="itemID"></param>
+        /// <param name="item"></param>
         /// <returns>
         /// true on a successful delete or a if the request is queued.
         /// Returns false on an immediate failure

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -1187,14 +1187,21 @@ namespace OpenSim.Region.Framework.Scenes
                     {
                         uint count = 0;
 
-                        // Get rid of all folder links in the COF: there should only ever be one, and that's the one we are about to create.
-                        foreach (InventoryItemBase cofItem in currentOutfitFolder.Items)
+                        try
                         {
-                            if (cofItem.AssetType == (int)AssetType.LinkFolder)
+                            // Get rid of all folder links in the COF: there should only ever be one, and that's the one we are about to create.
+                            foreach (InventoryItemBase cofItem in currentOutfitFolder.Items)
                             {
-                                userInfo.DeleteItem(cofItem);
-                                ++count;
+                                if (cofItem.AssetType == (int)AssetType.LinkFolder)
+                                {
+                                    userInfo.DeleteItem(cofItem);
+                                    ++count;
+                                }
                             }
+                        }
+                        catch (InventoryStorageException ise)
+                        {
+                            m_log.WarnFormat("[AGENT INVENTORY] Had InventoryStorageException while removing out of date folder links from the COF for avatar {0}: {1}", userInfo.UserProfile.ID, ise);
                         }
 
                         if (count > 1) // Only report if more than one was removed.


### PR DESCRIPTION
If a link couldn't be deleted for some Cassandra-related reason the Cassandra PurgeItem implementation would throw an InventoryStorageException.
Catching it here allows us to keep moving without taking out the server as nothing upstream of this method would catch it.