### PR TITLE
Implemented the RezRestoreToWorld (Restore To Last Position) packet.

### DIFF
--- a/InWorldz/InWorldz.Testing/MockClientAPI.cs
+++ b/InWorldz/InWorldz.Testing/MockClientAPI.cs
@@ -134,6 +134,7 @@ namespace InWorldz.Testing
         public event TextureRequest OnRequestTexture;
 
         public event RezObject OnRezObject;
+        public event RestoreObject OnRestoreObject;
 
         public event ModifyTerrain OnModifyTerrain;
 

--- a/OpenSim/Framework/IClientAPI.cs
+++ b/OpenSim/Framework/IClientAPI.cs
@@ -71,6 +71,8 @@ namespace OpenSim.Framework
                                    UUID RayTargetID, byte BypassRayCast, bool RayEndIsIntersection,
                                    bool RezSelected, bool RemoveItem, UUID fromTaskID);
 
+    public delegate void RestoreObject(IClientAPI remoteClient, UUID groupID, UUID itemID);
+
     public delegate UUID RezSingleAttachmentFromInv(IClientAPI remoteClient, UUID itemID, uint AttachmentPt, bool append);
 
     public delegate void RezMultipleAttachmentsFromInv(IClientAPI remoteClient, RezMultipleAttachmentsFromInvPacket.HeaderDataBlock header,
@@ -660,6 +662,7 @@ namespace OpenSim.Framework
         event TextureRequest OnRequestTexture;
         // [Obsolete("LLClientView Specific - Remove bitbuckets. Adam, can you be more specific here..  as I don't see any bit buckets.")]
         event RezObject OnRezObject;
+        event RestoreObject OnRestoreObject;
         // [Obsolete("LLClientView Specific - Replace with more suitable arguments.")]
         event ModifyTerrain OnModifyTerrain;
         event BakeTerrain OnBakeTerrain;

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
@@ -464,6 +464,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
         public event TextureRequest OnRequestTexture;
 
         public event RezObject OnRezObject;
+        public event RestoreObject OnRestoreObject;
 
         public event ModifyTerrain OnModifyTerrain;
 

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -3171,6 +3171,7 @@ namespace OpenSim.Region.Framework.Scenes
             client.OnSpinUpdate += m_sceneGraph.SpinObject;
             client.OnDeRezObjects += DeRezObjects;
             client.OnRezObject += RezObject;
+            client.OnRestoreObject += RestoreObject;
             client.OnRezSingleAttachmentFromInv += RezSingleAttachment;
             client.OnRezMultipleAttachmentsFromInv += RezMultipleAttachments;
             client.OnDetachAttachmentIntoInv += DetachSingleAttachmentToInv;


### PR DESCRIPTION
This adds support for single-object and coalesced object Restore To Last
Position viewer commands. It differs from SL by blocking the operation
when the last position was as an attachment, and informs the user that
it was an attachment and they should use Wear or Add. (SL rezzes the
object instead, near 0,0,0 in the region.)