### PR TITLE
Fixed null reference exception in llGetLandOwnerAt, others.

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/EngineInterface.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/EngineInterface.cs
@@ -242,14 +242,15 @@ namespace InWorldz.Phlox.Engine
         public bool ScriptsCanRun(ILandObject parcel, SceneObjectPart hostPart)
         {
             if (hostPart.ParentGroup.IsAttachment)
-            {
                 return true;
-            }
 
-            bool parcelAllowsOtherScripts = parcel != null && (parcel.landData.Flags & (uint)ParcelFlags.AllowOtherScripts) != 0;
-            bool parcelAllowsGroupScripts = parcel != null && (parcel.landData.Flags & (uint)ParcelFlags.AllowGroupScripts) != 0;
-            bool parcelMatchesObjectGroup = parcel != null && parcel.landData.GroupID == hostPart.GroupID;
-            bool ownerOwnsParcel = parcel != null && parcel.landData.OwnerID == hostPart.OwnerID;
+            if (parcel == null)
+                return false;
+
+            bool parcelAllowsOtherScripts = (parcel.landData.Flags & (uint)ParcelFlags.AllowOtherScripts) != 0;
+            bool parcelAllowsGroupScripts = (parcel.landData.Flags & (uint)ParcelFlags.AllowGroupScripts) != 0;
+            bool parcelMatchesObjectGroup = parcel.landData.GroupID == hostPart.GroupID;
+            bool ownerOwnsParcel = parcel.landData.OwnerID == hostPart.OwnerID;
 
             if (ownerOwnsParcel ||
                 parcelAllowsOtherScripts ||

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -7692,7 +7692,7 @@ namespace InWorldz.Phlox.Engine
 
         public int llOverMyLand(string id)
         {
-            
+            ILandObject parcel = null;
             UUID key = new UUID();
             if (UUID.TryParse(id, out key))
             {
@@ -7701,8 +7701,7 @@ namespace InWorldz.Phlox.Engine
                 if (presence != null) // object is an avatar
                 {
                     pos = presence.AbsolutePosition;
-                    if (m_host.OwnerID == World.LandChannel.GetLandObject(pos.X, pos.Y).landData.OwnerID)
-                        return 1;
+                    parcel = World.LandChannel.GetLandObject(pos.X, pos.Y);
                 }
                 else // object is not an avatar
                 {
@@ -7710,19 +7709,21 @@ namespace InWorldz.Phlox.Engine
                     if (obj != null)
                     {
                         pos = obj.AbsolutePosition;
-                        if (m_host.OwnerID == World.LandChannel.GetLandObject(pos.X, pos.Y).landData.OwnerID)
-                            return 1;
+                        parcel = World.LandChannel.GetLandObject(pos.X, pos.Y);
                     }
                 }
             }
 
-            return 0;
+            return (parcel != null) && (m_host.OwnerID == parcel.landData.OwnerID) ? 1 : 0;
         }
 
         public string llGetLandOwnerAt(LSL_Vector pos)
         {
-            
-            return World.LandChannel.GetLandObject((float)pos.X, (float)pos.Y).landData.OwnerID.ToString();
+            UUID owner = UUID.Zero;
+            ILandObject parcel = World.LandChannel.GetLandObject((float)pos.X, (float)pos.Y);
+            if (parcel != null)
+                owner = parcel.landData.OwnerID;
+            return owner.ToString();
         }
 
         /// <summary>
@@ -10151,6 +10152,8 @@ namespace InWorldz.Phlox.Engine
         public string llGetParcelMusicURL()
         {
             ILandObject land = World.LandChannel.GetLandObject(m_host.AbsolutePosition.X, m_host.AbsolutePosition.Y);
+            if (land == null)
+                return String.Empty;
 
             return land.GetMusicUrl();
         }
@@ -12731,7 +12734,7 @@ namespace InWorldz.Phlox.Engine
             
             UUID key;
             LandData land = World.LandChannel.GetLandObject(m_host.AbsolutePosition.X, m_host.AbsolutePosition.Y).landData;
-            if (land.OwnerID == m_host.OwnerID)
+            if ((land != null) && (land.OwnerID == m_host.OwnerID))
             {
                 ParcelManager.ParcelAccessEntry entry = new ParcelManager.ParcelAccessEntry();
                 if (UUID.TryParse(avatar, out key))
@@ -12751,7 +12754,7 @@ namespace InWorldz.Phlox.Engine
             
             UUID key;
             LandData land = World.LandChannel.GetLandObject(m_host.AbsolutePosition.X, m_host.AbsolutePosition.Y).landData;
-            if (land.OwnerID == m_host.OwnerID)
+            if ((land != null) && (land.OwnerID == m_host.OwnerID))
             {
                 if (UUID.TryParse(avatar, out key))
                 {
@@ -12774,7 +12777,7 @@ namespace InWorldz.Phlox.Engine
             
             UUID key;
             LandData land = World.LandChannel.GetLandObject(m_host.AbsolutePosition.X, m_host.AbsolutePosition.Y).landData;
-            if (land.OwnerID == m_host.OwnerID)
+            if ((land != null) && (land.OwnerID == m_host.OwnerID))
             {
                 if (UUID.TryParse(avatar, out key))
                 {
@@ -13141,7 +13144,7 @@ namespace InWorldz.Phlox.Engine
         {
             
             LandData land = World.LandChannel.GetLandObject(m_host.AbsolutePosition.X, m_host.AbsolutePosition.Y).landData;
-            if (land.OwnerID == m_host.OwnerID)
+            if ((land != null) && (land.OwnerID == m_host.OwnerID))
             {
                 foreach (ParcelManager.ParcelAccessEntry entry in land.ParcelAccessList)
                 {
@@ -13159,7 +13162,7 @@ namespace InWorldz.Phlox.Engine
         {
             
             LandData land = World.LandChannel.GetLandObject(m_host.AbsolutePosition.X, m_host.AbsolutePosition.Y).landData;
-            if (land.OwnerID == m_host.OwnerID)
+            if ((land != null) && (land.OwnerID == m_host.OwnerID))
             {
                 foreach (ParcelManager.ParcelAccessEntry entry in land.ParcelAccessList)
                 {

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
@@ -133,6 +133,12 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
                 }
 
                 ILandObject parcel = m_scene.LandChannel.GetLandObject(startPos.X, startPos.Y);
+                if (parcel == null)
+                {
+                    reason = "Land parcel could not be found at "+ ((int)startPos.X).ToString() + "," + ((int)startPos.Y).ToString();
+                    return UUID.Zero;
+                }
+
                 ParcelPropertiesStatus status;
                 if (parcel.DenyParcelAccess(owner, out status))
                 {
@@ -566,12 +572,14 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
                     }
                 }
 
-                ILandObject parcel = m_scene.LandChannel.GetLandObject(sp.AbsolutePosition.X, sp.AbsolutePosition.Y);
+                Vector3 pos = sp.AbsolutePosition;
+                ILandObject parcel = m_scene.LandChannel.GetLandObject(pos.X, pos.Y);
                 if (parcel == null)
                 {
-                    reason = "Land parcel could not be found.";
+                    reason = "Land parcel could not be found at " + ((int)pos.X).ToString() + "," + ((int)pos.Y).ToString();
                     return false;
                 }
+
                 if (!CheckAttachmentCount(appearance, parcel, appearance.Owner, out reason))
                 {
                     //Too many objects already on this parcel/region

--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -402,7 +402,7 @@ namespace OpenSim.Region.CoreModules.World.Land
             }
 
             ILandObject parcel = landChannel.GetLandObject(pos.X, pos.Y);
-            if (parcel.DenyParcelAccess(avatar.UUID, out reason2))
+            if ((parcel != null) && parcel.DenyParcelAccess(avatar.UUID, out reason2))
             {
                 float minZ = LandChannel.BAN_LINE_SAFETY_HEIGHT + AVATAR_BOUNCE;
                 if (pos.Z < minZ)
@@ -1758,7 +1758,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                     if (regionID == m_scene.RegionInfo.RegionID)
                     {
                         ILandObject parcel = this.GetLandObject(localLandID);
-                        if (parcel.landData != null)
+                        if ((parcel != null) && (parcel.landData != null))
                             landData = parcel.landData;
                         regionHandle = m_scene.RegionInfo.RegionHandle;
                     }

--- a/OpenSim/Region/CoreModules/World/Land/LandObject.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandObject.cs
@@ -567,7 +567,7 @@ namespace OpenSim.Region.CoreModules.World.Land
             }
 
             ILandObject parcel = m_scene.LandChannel.GetLandObject(pos.X, pos.Y);
-            if (parcel.DenyParcelAccess(sp.UUID, out reason2))
+            if ((parcel != null) && parcel.DenyParcelAccess(sp.UUID, out reason2))
             {
                 float minZ = LandChannel.BAN_LINE_SAFETY_HEIGHT + AVATAR_BOUNCE;
                 if (pos.Z < minZ)

--- a/OpenSim/Region/CoreModules/World/Permissions/PermissionsModule.cs
+++ b/OpenSim/Region/CoreModules/World/Permissions/PermissionsModule.cs
@@ -998,6 +998,9 @@ namespace OpenSim.Region.CoreModules.World.Permissions
     
         protected bool GenericParcelOwnerPermission(UUID user, ILandObject parcel, ulong groupPowers)
         {
+            if (parcel == null)
+                return false;
+
             // First the simple check, calling context matches the land owner.
             // This also includes group-deeded objects on group-deeded land.
             if (parcel.landData.OwnerID == user)

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2335,7 +2335,7 @@ namespace OpenSim.Region.Framework.Scenes
             // Pass 0 for landImpact here so that it can be tested separately.
             if (Permissions.CanRezObject(0, ownerID, UUID.Zero, pos, false))
             {
-                reason = ". Cannot determine land parcel.";
+                reason = ". Cannot determine land parcel at "+(int)pos.X+","+(int)pos.Y;
                 ILandObject parcel = LandChannel.GetLandObject(pos.X, pos.Y);
                 if (parcel != null)
                 {


### PR DESCRIPTION
Fixed null reference exception in **llGetLandOwnerAt** when parcel coordinates are outside region. See [forum discussion](http://inworldz.com/forums/viewtopic.php?f=12&t=22214) for more.

It was a pattern so _several_ places updated. Also improved some of the error message cases to indicate the location (coordinates) in question. 

See also [Mantis #3170](http://bugs.inworldz.com/mantis/view.php?id=3170)