### PR TITLE
Fixes to IsScripted initialization and maintenance

### DIFF
--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2122,7 +2122,7 @@ namespace OpenSim.Region.Framework.Scenes
 
                 AddRestoredSceneObject(group, true, true);
                 SceneObjectPart rootPart = group.GetChildPart(group.UUID);
-                rootPart.ObjectFlags &= ~(uint)PrimFlags.Scripted;
+                group.RecalcScriptedStatus();
                 rootPart.TrimPermissions();
 
                 // Check if it rezzed off-world...

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1534,7 +1534,7 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 RecalcPrimWeights();
             }
-            CheckIfScriptedStatusChanged();
+            RecalcScriptedStatus();
         }
 
         /// <summary>
@@ -1556,7 +1556,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             // Update the ServerWeight/LandImpact
             RecalcPrimWeights();
-            CheckIfScriptedStatusChanged();
+            RecalcScriptedStatus();
         }
 
         /// <summary>
@@ -2707,8 +2707,8 @@ namespace OpenSim.Region.Framework.Scenes
             // Update the ServerWeight/LandImpact And StreamingCost
             RecalcPrimWeights();
 
-            this.RootPart.ClearUndoState();
-            this.CheckIfScriptedStatusChanged();
+            RootPart.ClearUndoState();
+            RecalcScriptedStatus();
 
             HasGroupChanged = true;
             ScheduleGroupForFullUpdate(PrimUpdateFlags.ForcedFullUpdate);
@@ -2806,7 +2806,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             // Update the ServerWeight/LandImpact and StreamingCost
             RecalcPrimWeights();
-            CheckIfScriptedStatusChanged();
+            RecalcScriptedStatus();
 
             if (sendGroupUpdate)
             {
@@ -4589,36 +4589,20 @@ namespace OpenSim.Region.Framework.Scenes
         /// Checks if this group or any of its children are scripted and sets 
         /// a flag appropriately if so
         /// </summary>
-        /// <returns>True if the scripted status changed, false if not</returns>
-        public bool CheckIfScriptedStatusChanged()
+        public void RecalcScriptedStatus()
         {
-            bool oldIsScripted = IsScripted;
-            bool newIsScripted = false;
-
-            if ((RootPart.GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0)
-                newIsScripted = true;
-
-            if (!newIsScripted && this.PrimCount > 1)
+            bool scripted = false;
+            foreach (SceneObjectPart part in  m_children.GetAllParts())
             {
-                foreach(SceneObjectPart part in m_children.GetAllParts())
+                if (part == null)
+                    continue;
+                if ((part.GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0)
                 {
-                    if (part == null || part == RootPart)
-                        continue;
-                    if ((part.GetEffectiveObjectFlags() & PrimFlags.Scripted) != 0)
-                    {
-                        newIsScripted = true;
-                        break;
-                    }
+                    scripted = true;
+                    break;
                 }
             }
-
-            if(oldIsScripted != newIsScripted)
-            {
-                IsScripted = newIsScripted;
-                return true;
-            }
-
-            return false;
+            IsScripted = scripted;
         }
 
         

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -1764,8 +1764,9 @@ namespace OpenSim.Region.Framework.Scenes
 
                 if (flag == PrimFlags.TemporaryOnRez)
                     ResetExpire();
-                if((flag & PrimFlags.Scripted) != 0 && !ParentGroup.IsScripted)
-                    ParentGroup.CheckIfScriptedStatusChanged();
+                if (ParentGroup != null)    // null when called from the persistence backup
+                    if((flag & PrimFlags.Scripted) != 0 && !ParentGroup.IsScripted)
+                        ParentGroup.RecalcScriptedStatus();
             }
         }
 
@@ -2842,7 +2843,7 @@ namespace OpenSim.Region.Framework.Scenes
                 _flags &= ~flag;
                 if ((flag & PrimFlags.Scripted) != 0)
                     if(ParentGroup != null)
-                        ParentGroup.CheckIfScriptedStatusChanged();
+                        ParentGroup.RecalcScriptedStatus();
             }
             //m_log.Debug("prev: " + prevflag.ToString() + " curr: " + Flags.ToString());
             //ScheduleFullUpdate();
@@ -3087,8 +3088,10 @@ namespace OpenSim.Region.Framework.Scenes
                 return;
 
             clientFlags &= ~(uint) PrimFlags.CreateSelected;
-            if (ParentGroup.IsScripted && ParentGroup.RootPart == this)
+            if ((uint)(_flags & PrimFlags.Scripted) != 0)
                 clientFlags |= (uint)PrimFlags.Scripted;
+            else
+                clientFlags &= ~(uint)PrimFlags.Scripted;
 
             if (remoteClient.AgentId == _ownerID)
             {
@@ -3111,8 +3114,10 @@ namespace OpenSim.Region.Framework.Scenes
         public void SendFullUpdateToClientImmediate(IClientAPI remoteClient, Vector3 lPos, uint clientFlags)
         {
             clientFlags &= ~(uint)PrimFlags.CreateSelected;
-            if (ParentGroup.IsScripted && ParentGroup.RootPart == this)
+            if ((uint)(_flags & PrimFlags.Scripted) != 0)
                 clientFlags |= (uint)PrimFlags.Scripted;
+            else
+                clientFlags &= ~(uint)PrimFlags.Scripted;
 
             if (remoteClient.AgentId == _ownerID)
             {


### PR DESCRIPTION
- Resolves http://jira.phoenixviewer.com/browse/FIRE-17782
- Return value from CheckIfScriptedStatusChanged wasn't used, so removed
the return value and simplified the function considerably, including
removing the special casing for the root prim.  Renamed to
RecalcScriptedStatus.
- Removed the unconditional clearing of the root prims Scripted flag in
LoadPrimsFromStorage (o.O) after the whole group was initialized,
replaced with a call to RecalcScriptedStatus to initialize the object's
IsScripted status.
- Fixed a possible NRE in AddFlag if the ParentGroup was null (as it can
be now during scene persistence backup).
- Fixed prim full updates to send the prim scripted status rather than
the object scripted status. (This is the primary fix for the JIRA above,
although the rest is also required.)
- Moved the setting of the Scripted flag to inside the loop in
CreateScriptInstances where we initialize script instances rather than
inside CreateScriptInstance where it is conditional on region settings
etc. Must be set when there are scripts present, regardless of running
state.
- Updated HandleAddRunningScript to set or clear the Scripted flag
rather than just removing it (o.O) and renamed it to
HandleChangedScripts since it's not just for adding or running scripts.