### PR TITLE
Fixed a KeyNotFoundException when materials ID not found

### DIFF
--- a/OpenSim/Framework/RenderMaterials.cs
+++ b/OpenSim/Framework/RenderMaterials.cs
@@ -431,8 +431,13 @@ namespace OpenSim.Framework
         {
             lock (Materials)
             {
-                return Materials[id.Guid];
+                if (Materials.ContainsKey(id.Guid))
+                    return Materials[id.Guid];
             }
+
+            // If we get here, there is no material by that ID.
+            // It's a struct (can't return a null), we must return *some* material.
+            return (RenderMaterial)RenderMaterial.DefaultMaterial.Clone();
         }
 
         public List<RenderMaterial> GetMaterials()


### PR DESCRIPTION
This is probably a symptom of a larger problem, but for now I will patch
it to avoid the exception and use default materials when the ID is not
in the materials dictionary.