### PR TITLE
Object part flags

### DIFF
--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1707,12 +1707,15 @@ namespace OpenSim.Region.Framework.Scenes
 
         public void aggregateScriptEvents()
         {
+            uint objectflagupdate = (uint)RootPart.GetEffectiveObjectFlags();
+
             ScriptEvents aggregateScriptEvents = 0;
 
             m_children.ForEachPart((SceneObjectPart part) => {
                 if (part == null)
                     return;
-                part.ObjectFlags = (uint)part.GetEffectiveObjectFlags();
+                if (part != RootPart)
+                    part.ObjectFlags = objectflagupdate;
                 aggregateScriptEvents |= part.AggregateScriptEvents;
             });
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1707,15 +1707,12 @@ namespace OpenSim.Region.Framework.Scenes
 
         public void aggregateScriptEvents()
         {
-            uint objectflagupdate = (uint)RootPart.GetEffectiveObjectFlags();
-
             ScriptEvents aggregateScriptEvents = 0;
 
             m_children.ForEachPart((SceneObjectPart part) => {
                 if (part == null)
                     return;
-                if (part != RootPart)
-                    part.ObjectFlags = objectflagupdate;
+                part.ObjectFlags = (uint)part.GetEffectiveObjectFlags();
                 aggregateScriptEvents |= part.AggregateScriptEvents;
             });
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1715,7 +1715,16 @@ namespace OpenSim.Region.Framework.Scenes
                 if (part == null)
                     return;
                 if (part != RootPart)
-                    part.ObjectFlags = objectflagupdate;
+                {
+                    // Preserve the Scripted flag status for each part.
+                    bool isScripted = (part.Flags & PrimFlags.Scripted) != 0;
+                    part.ObjectFlags = objectflagupdate;    // update
+                    // Now restore the per-part Scripted flag.
+                    if (isScripted)
+                        part.ObjectFlags |= (uint)PrimFlags.Scripted;
+                    else
+                        part.ObjectFlags &= ~(uint)PrimFlags.Scripted;
+                }
                 aggregateScriptEvents |= part.AggregateScriptEvents;
             });
 


### PR DESCRIPTION
The fixes that were in #152 were undone by this polluting of the Scripted flag from the root prim. This PR just preserves the Scripted flag so as to provide the fix from #152, while *not* applying it to all other flags, as they may have different semantics.