### PR TITLE
Bug fix for shift copy of prims that have rendermaterials attached.

### DIFF
--- a/OpenSim/Framework/PrimitiveBaseShape.cs
+++ b/OpenSim/Framework/PrimitiveBaseShape.cs
@@ -462,10 +462,9 @@ namespace OpenSim.Framework
         {
             PrimitiveBaseShape shape = (PrimitiveBaseShape)MemberwiseClone();
             shape.TextureEntryBytes = (byte[])TextureEntryBytes.Clone();
-            if (shape.Media != null)
-            {
-                shape.Media = new PrimMedia(Media);
-            }
+            shape.Media = new PrimMedia(Media);
+            shape.RenderMaterials = RenderMaterials.Copy();
+
             return shape;
         }
 

--- a/OpenSim/Framework/RenderMaterials.cs
+++ b/OpenSim/Framework/RenderMaterials.cs
@@ -498,6 +498,11 @@ namespace OpenSim.Framework
             }
         }
 
+        public RenderMaterials Copy()
+        {
+            return RenderMaterials.FromBytes(this.ToBytes(), 0);
+        }
+
         public override bool Equals(object obj)
         {
             if (obj == null)
@@ -545,7 +550,7 @@ namespace OpenSim.Framework
                     builder.AppendFormat (" MaterialId : {0}, RenderMaterial : {{ {1} }} ", entry.Key.ToString(), entry.Value.ToString ());
                 builder.Append(" ]");
                 return builder.ToString();
-            };
+            }
         }
     }
 }

--- a/OpenSim/Framework/Tests/RenderMaterialsTests.cs
+++ b/OpenSim/Framework/Tests/RenderMaterialsTests.cs
@@ -221,5 +221,18 @@ namespace OpenSim.Framework.Tests
             UUID mat2ID = RenderMaterial.GenerateMaterialID(mat2);
             Assert.AreNotEqual(matID, mat2ID);
         }
+
+        [Test]
+        public void RenderMaterials_CopiedMaterialsGeneratesTheSameMaterialID()
+        {
+            RenderMaterial mat = new RenderMaterial();
+            RenderMaterials mats = new RenderMaterials();
+            UUID matID = mats.AddMaterial(mat);
+
+            RenderMaterials matsCopy = mats.Copy();
+
+            Assert.True(mats.ContainsMaterial(matID));
+            Assert.True(matsCopy.ContainsMaterial(matID));
+        }
     }
 }

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -2263,6 +2263,9 @@ namespace OpenSim.Region.Framework.Scenes
                     if (OnObjectDuplicate != null)
                         OnObjectDuplicate(original, copy);
 
+                    // Signal a new object in the scene 
+                    m_parentScene.EventManager.TriggerObjectAddedToScene(copy);
+
                     return copy;
                 }
             }


### PR DESCRIPTION
Do a deep copy of RenderMaterials on a Duplicate.  Add a test for the RenderMaterials copy function.  Signal a new object added to the scene on a duplicate. 