### PR TITLE
Fixed botGetPos to not require ownership.

### DIFF
--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
@@ -740,7 +740,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
 
         public Vector3 GetBotPosition(UUID botID, UUID attemptingUser)
         {
-            if (GetBotWithPermission(botID, attemptingUser) == null)
+            if (GetBot(botID) == null)
                 return Vector3.Zero;
 
             ScenePresence sp = m_scene.GetScenePresence(botID);


### PR DESCRIPTION
Made botGetPos consistent with botGetName, etc. in that any script can
get the position of a bot in the region. It is not only available to the
owner, and is not priviledged info. I think this was an unintended
copy/paste problem from botSetPos or other similar functions that do
require ownership. See
http://inworldz.com/forums/viewtopic.php?f=17&t=21338&p=194059#p194059