### PR TITLE
Added an easy optimization to avoid a potentially expensive call.

### DIFF
--- a/OpenSim/Region/CoreModules/World/Permissions/PermissionsModule.cs
+++ b/OpenSim/Region/CoreModules/World/Permissions/PermissionsModule.cs
@@ -522,6 +522,10 @@ namespace OpenSim.Region.CoreModules.World.Permissions
 
         public bool FriendHasEditPermission(UUID owner, UUID friend)
         {
+            // There's one easy optimization we should ensure isn't the case before proceeding further.
+            if (friend == owner)
+                return true;
+
             //the friend in this case will always be the active user in the scene
             CachedUserInfo user = m_scene.CommsManager.UserService.GetUserDetails(friend);
             if (user != null)


### PR DESCRIPTION
FriendHasEditPermission didn't check if the friend was the same/owner
ID.