### PR TITLE
Fixed crossing inefficiencies when seated avatars

### DIFF
--- a/OpenSim/Framework/Communications/IUserService.cs
+++ b/OpenSim/Framework/Communications/IUserService.cs
@@ -123,6 +123,16 @@ namespace OpenSim.Framework.Communications
         void UpdateUserFriendPerms(UUID friendlistowner, UUID friend, uint perms);
 
         /// <summary>
+        /// Check if this user can access another's items.
+        /// </summary>
+        /// <param name="friendlistowner">This user (to check).</param>
+        /// <param name="friendId">The ID of the other user (friend owner of the items).</param>
+        /// <param name="permissionMask">Desired permission.</param>
+        /// <param name="noFetch">If true, don't make any net/storage calls. Memory only.</param>
+        /// <returns>true if permission is available</returns>
+        bool UserHasFriendPerms(UUID friendlistowner, UUID friendId, uint permissionMask, bool noFetch);
+
+        /// <summary>
         /// Logs off a user on the user server
         /// </summary>
         /// <param name="userid">UUID of the user</param>

--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -783,6 +783,36 @@ namespace OpenSim.Framework.Communications
         }
 
         /// <summary>
+        /// Check if this user can access another's items.
+        /// </summary>
+        /// <param name="friendlistowner">This user (to check).</param>
+        /// <param name="friendId">The ID of the other user (friend owner of the items).</param>
+        /// <param name="permissionMask">Desired permission.</param>
+        /// <param name="noFetch">If true, don't make any net/storage calls. Memory only.</param>
+        /// <returns>true if permission is available</returns>
+        public bool UserHasFriendPerms(UUID friendlistowner, UUID friendId, uint permissionMask, bool noFetch)
+        {
+            CachedUserInfo userInfo = null;
+
+            if (noFetch)
+            {
+                // Can be called this way on crossings to prevent lookups.
+                TimestampedItem<CachedUserInfo> item;
+                lock (m_userInfoLock)
+                {
+                    // Ignore timeouts etc if this is a noFetch/fastCheck call.
+                    if (!m_userInfoByUUID.TryGetValue(friendlistowner, out item))
+                        return false;   // user will need to repeat the operation not in a crossing.
+                }
+                userInfo = item.Item;
+            } else {
+                userInfo = GetUserInfo(friendlistowner);
+            }
+
+            return userInfo.HasPermissionFromFriend(friendId, permissionMask);
+        }
+
+        /// <summary>
         /// Resets the currentAgent in the user profile
         /// </summary>
         /// <param name="agentID">The agent's ID</param>

--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -809,6 +809,9 @@ namespace OpenSim.Framework.Communications
                 userInfo = GetUserInfo(friendlistowner);
             }
 
+            if (userInfo == null)
+                return false;
+
             return userInfo.HasPermissionFromFriend(friendId, permissionMask);
         }
 

--- a/OpenSim/Region/Framework/Scenes/Scene.Permissions.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Permissions.cs
@@ -35,7 +35,7 @@ using OpenSim.Region.Framework.Interfaces;
 namespace OpenSim.Region.Framework.Scenes
 {
     #region Delegates
-    public delegate uint GenerateClientFlagsHandler(UUID userID, UUID objectIDID);
+    public delegate uint GenerateClientFlagsHandler(UUID userID, UUID objectIDID, bool fastCheck);
     public delegate void SetBypassPermissionsHandler(bool value);
     public delegate bool BypassPermissionsHandler();
     public delegate bool PropagatePermissionsHandler();
@@ -148,7 +148,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         #region Object Permission Checks
 
-        public uint GenerateClientFlags(UUID userID, UUID objectID)
+        public uint GenerateClientFlags(UUID userID, UUID objectID, bool fastCheck)
         {
             SceneObjectPart part=m_scene.GetSceneObjectPart(objectID);
 
@@ -177,7 +177,7 @@ namespace OpenSim.Region.Framework.Scenes
                 Delegate[] list = handlerGenerateClientFlags.GetInvocationList();
                 foreach (GenerateClientFlagsHandler check in list)
                 {
-                    perms &= check(userID, objectID);
+                    perms &= check(userID, objectID, fastCheck);
                 }
             }
             return perms;

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2930,7 +2930,12 @@ namespace OpenSim.Region.Framework.Scenes
                 newObject.RootPart.ParentGroup.CreateScriptInstances(null, ScriptStartFlags.FromCrossing, DefaultScriptEngine, (int)ScriptStateSource.PrimData, null);
 
                 //there are avatars coming over, they need an immediate update
-                newObject.SendFullUpdateToAllClientsImmediate(true);
+                foreach (var userId in avatars)
+                {
+                    ScenePresence sp = GetScenePresence(userId);
+                    if (sp != null)
+                        newObject.SendFullUpdateToClientImmediate(sp.ControllingClient, true);
+                }
             }
             else
             {

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2930,7 +2930,7 @@ namespace OpenSim.Region.Framework.Scenes
                 newObject.RootPart.ParentGroup.CreateScriptInstances(null, ScriptStartFlags.FromCrossing, DefaultScriptEngine, (int)ScriptStateSource.PrimData, null);
 
                 //there are avatars coming over, they need an immediate update
-                newObject.SendFullUpdateToAllClientsImmediate();
+                newObject.SendFullUpdateToAllClientsImmediate(true);
             }
             else
             {

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -910,7 +910,7 @@ namespace OpenSim.Region.Framework.Scenes
             //fact that a bunch of methods are called when the attachment rezzes
             group.HasGroupChanged = isTainted;
             if (!silent)
-                group.SendFullUpdateToAllClientsImmediate();
+                group.SendFullUpdateToAllClientsImmediate(false);
 
             if ((flags & AttachFlags.DontFireOnAttach) == 0)
             {

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1925,33 +1925,33 @@ namespace OpenSim.Region.Framework.Scenes
 
         public void SendFullUpdateToClient(IClientAPI remoteClient, PrimUpdateFlags updateFlags)
         {
-            SendPartFullUpdate(remoteClient, RootPart, m_scene.Permissions.GenerateClientFlags(remoteClient.AgentId, RootPart.UUID), updateFlags);
+            SendPartFullUpdate(remoteClient, RootPart, m_scene.Permissions.GenerateClientFlags(remoteClient.AgentId, RootPart.UUID, false), updateFlags);
 
             m_children.ForEachPart((SceneObjectPart part) => {
                 if (part != RootPart)
-                    SendPartFullUpdate(remoteClient, part, m_scene.Permissions.GenerateClientFlags(remoteClient.AgentId, part.UUID), updateFlags);
+                    SendPartFullUpdate(remoteClient, part, m_scene.Permissions.GenerateClientFlags(remoteClient.AgentId, part.UUID, false), updateFlags);
             });
         }
 
-        public void SendFullUpdateToAllClientsImmediate()
+        public void SendFullUpdateToAllClientsImmediate(bool fastCheck)
         {
             IEnumerable<ScenePresence> avatars = Scene.GetScenePresences();
             foreach (var sp in avatars)
             {
-                this.SendFullUpdateToClientImmediate(sp.ControllingClient);
+                this.SendFullUpdateToClientImmediate(sp.ControllingClient, fastCheck);
             }
         }
 
-        public void SendFullUpdateToClientImmediate(IClientAPI remoteClient)
+        public void SendFullUpdateToClientImmediate(IClientAPI remoteClient, bool fastCheck)
         {
             //Since this is immediate, the update flags are ignored, but for clarity, we'll use ForcedFullUpdate
-            SendPartFullUpdate(remoteClient, RootPart, m_scene.Permissions.GenerateClientFlags(remoteClient.AgentId, RootPart.UUID),
+            SendPartFullUpdate(remoteClient, RootPart, m_scene.Permissions.GenerateClientFlags(remoteClient.AgentId, RootPart.UUID, fastCheck),
                 true, PrimUpdateFlags.ForcedFullUpdate);
             
             m_children.ForEachPart((SceneObjectPart part) => {
                 if (part != RootPart)
                     SendPartFullUpdate(remoteClient, part,
-                        m_scene.Permissions.GenerateClientFlags(remoteClient.AgentId, part.UUID), true, PrimUpdateFlags.ForcedFullUpdate);
+                        m_scene.Permissions.GenerateClientFlags(remoteClient.AgentId, part.UUID, fastCheck), true, PrimUpdateFlags.ForcedFullUpdate);
             });
         }
 

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1048,7 +1048,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         public uint GenerateClientFlags(UUID ObjectID)
         {
-            return m_scene.Permissions.GenerateClientFlags(m_uuid, ObjectID);
+            return m_scene.Permissions.GenerateClientFlags(m_uuid, ObjectID, false);
         }
 
 #region Status Methods


### PR DESCRIPTION
Removed unnecessary profile/friends fetches during crossings. Fixed major (multi-second) dropouts inside the object2 handler on crossings that could cause failure to enter regions and user presence
viewer/server region confusion. Main change is in PermissionsModule.cs (avoids calling GetUserDetails on user crossings) by:
- Added UserHasFriendPerms to UserProfileManager to directly check
friend perms without a profile fetch.
- Added fastCheck/noFetch parameter to several function interfaces so as
to be able to tell it to avoid profile/friends fetches during crossings.
- Also updated it to only send the immediate update to the passengers on a crossing of an imcoming object with seated avatars, rather than all avatars.