### PR TITLE
More complete NRE fixes for PrimMedia null cases

### DIFF
--- a/OpenSim/Framework/PrimitiveBaseShape.cs
+++ b/OpenSim/Framework/PrimitiveBaseShape.cs
@@ -1299,7 +1299,17 @@ namespace OpenSim.Framework
             }
             public PrimMedia(PrimMedia other) : base()
             {
-                m_MediaFaces = (other == null) ? null : other.CopyArray();
+                if ((other == null) || (other.m_MediaFaces == null))
+                {
+                    New(0);
+                }
+                else
+                {
+                    lock (this)
+                    {
+                        m_MediaFaces = other.CopyArray();
+                    }
+                }
             }
 
             public int Count
@@ -1360,6 +1370,9 @@ namespace OpenSim.Framework
             {
                 lock (this)
                 {
+                    if (m_MediaFaces == null)
+                        return null;
+
                     int len = m_MediaFaces.Length;
                     MediaEntry[] copyFaces = new MediaEntry[len];
                     for (int x=0; x<len; x++)
@@ -1406,10 +1419,13 @@ namespace OpenSim.Framework
                             OSDArray meArray = new OSDArray();
                             lock (this)
                             {
-                                foreach (MediaEntry me in m_MediaFaces)
+                                if (m_MediaFaces != null)
                                 {
-                                    OSD osd = (null == me ? new OSD() : me.GetOSD());
-                                    meArray.Add(osd);
+                                    foreach (MediaEntry me in m_MediaFaces)
+                                    {
+                                        OSD osd = (null == me ? new OSD() : me.GetOSD());
+                                        meArray.Add(osd);
+                                    }
                                 }
                             }
 

--- a/OpenSim/Region/CoreModules/World/Media/Moap/MoapModule.cs
+++ b/OpenSim/Region/CoreModules/World/Media/Moap/MoapModule.cs
@@ -328,15 +328,18 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
                 return String.Empty;
             }
 
-            if (null == part.Shape.Media)
-                return String.Empty;
-
             ObjectMediaResponse resp = new ObjectMediaResponse();
-
             resp.PrimID = primId;
 
             lock (part.Shape.Media)
+            {
+                if (null == part.Shape.Media)
+                    return String.Empty;
+
                 resp.FaceMedia = part.Shape.Media.CopyArray();
+                if (null == resp.FaceMedia)
+                    return String.Empty;
+            }
 
             resp.Version = part.MediaUrl;
 


### PR DESCRIPTION
- PrimMedia constructor handles other.media== null now, and does consistent locking on the array copy.
- CopyArray now handles a null array.
- MoapModule's null check and CopyArray call is now thread-safe and handles the null case better.