### PR TITLE
Overlapping profile fetch locking

### DIFF
--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -711,7 +711,8 @@ namespace OpenSim.Framework.Communications
                 }
             }
 
-            UserProfileData profile = m_storage.GetUserProfileData(uuid);
+            // Need to update UserAgentData. Also check if UserProfile needs an update.
+            UserProfileData profile = GetUserProfile(uuid, false);
             if (profile == null)
             {
                 FlushCachedInfo(uuid);

--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -284,7 +284,9 @@ namespace OpenSim.Framework.Communications
                     {
                         if (uuidLock == myLock)
                         {
+                            attempts = 0; // We're in, no more retries.
                             profile = m_storage.GetUserProfileData(uuid);
+                            // m_log.WarnFormat("Fetching profile for [{0}]: {1}", uuid, profile == null ? "null" : profile.Name);
                             if (profile != null)
                             {
                                 profile.CurrentAgent = GetUserAgent(uuid, forceRefresh);

--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -269,14 +269,10 @@ namespace OpenSim.Framework.Communications
                     // now see if we're the first ones in on this uuid
                     lock (m_fetchLocks)
                     {
-                        if (m_fetchLocks.ContainsKey(uuid))
+                        // check if someone else is working on this uuid, use their lock object
+                        if (!m_fetchLocks.TryGetValue(uuid, out uuidLock))
                         {
-                            // someone else is working on this uuid, use their lock object
-                            uuidLock = m_fetchLocks[uuid];
-                        }
-                        else
-                        {
-                            // we're first ones in, ours will be the lock object
+                            // nope, this is the first one in, myLock will be the lock object
                             m_fetchLocks[uuid] = myLock;
                             uuidLock = myLock;
                         }
@@ -298,7 +294,10 @@ namespace OpenSim.Framework.Communications
                                 RemoveUserData(uuid);
 
                             // no longer outstanding
-                            m_fetchLocks.Remove(uuid);
+                            lock (m_fetchLocks)
+                            {
+                                m_fetchLocks.Remove(uuid);
+                            }
                         }
                         else
                         {

--- a/OpenSim/Framework/IScene.cs
+++ b/OpenSim/Framework/IScene.cs
@@ -68,7 +68,7 @@ namespace OpenSim.Framework
 
         event restart OnRestart;
 
-        void AddNewClient(IClientAPI client);
+        void AddNewClient(IClientAPI client, bool isBot);
         void RemoveClient(UUID agentID);
 
         void Restart(int seconds);

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -1029,7 +1029,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 RefreshGroupMembership();   // Do this before AddNewClient since it will send the data down
             }
 
-            m_scene.AddNewClient(this);
+            m_scene.AddNewClient(this, false);
 
             // check if we've already received the CompleteAgentMovement packet for this client
             if (_receivedCompleteAgentMovement)

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
@@ -232,7 +232,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
                 };
 
                 m_scene.ConnectionManager.NewConnection(data, Region.Framework.Connection.EstablishedBy.Login);
-                m_scene.AddNewClient(client);
+                m_scene.AddNewClient(client, true);
                 m_scene.ConnectionManager.TryAttachUdpCircuit(client);
 
                 ScenePresence sp;

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -3108,7 +3108,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         #region Add/Remove Avatar Methods
 
-        public override void AddNewClient(IClientAPI client)
+        public override void AddNewClient(IClientAPI client, bool isBot)
         {
             SubscribeToClientEvents(client);
             ScenePresence presence;
@@ -3143,7 +3143,8 @@ namespace OpenSim.Region.Framework.Scenes
                     "[SCENE]: Adding new child agent for {0} in {1}",
                     client.Name, RegionInfo.RegionName);
 
-                CommsManager.UserService.CacheUser(client.AgentId);
+                if (!isBot)
+                    CommsManager.UserService.CacheUser(client.AgentId);
 
                 CreateAndAddScenePresence(client);
             }

--- a/OpenSim/Region/Framework/Scenes/SceneBase.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneBase.cs
@@ -170,7 +170,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// will promote it to a root agent during login.
         /// </summary>
         /// <param name="client"></param
-        public abstract void AddNewClient(IClientAPI client);
+        public abstract void AddNewClient(IClientAPI client, bool isBot);
 
         /// <summary>
         /// Remove a client from the scene


### PR DESCRIPTION
- Fixed the locking in profile fetches
- Fixed unwanted looping fetching profiles after lock conflict
- Fixed XMLRPC User service lookups for bots.  Because botCreateBot **doesn't need** to check with the User server if that UUID already exists, given it just made one up.  (Call to UserService.CacheUser is now conditional on NOT being a bot.)  Also fixed UserProfileManager.GetUserInfo to fetch the profile indirectly through GetUserProfile to support local profiles (presences) and temp profiles (bots).