### PR TITLE
Ll remote load script pin error tweak

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -8702,6 +8702,11 @@ namespace InWorldz.Phlox.Engine
 
         public void llRemoteLoadScriptPin(string target, string name, int pin, int running, int start_param)
         {
+			if (pin == 0) {
+				ScriptShoutError ("llRemoteLoadScriptPin: PIN cannot be zero.");
+				ScriptSleep(3000);
+				return;
+			}
             
             bool found = false;
             UUID destId = UUID.Zero;

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -8760,8 +8760,10 @@ namespace InWorldz.Phlox.Engine
             if (!String.IsNullOrEmpty(result))
             {
                 // validation error updating script
-                if (result == "PIN")    // special case for public error (let's not match the silly SL "illegal" text)
-                    ShoutError("llRemoteLoadScriptPin: Script update denied - PIN mismatch.");
+				if (result == "PIN")    // special case for public error (let's not match the silly SL "illegal" text)
+                    ShoutError ("llRemoteLoadScriptPin: Script update denied - PIN mismatch.");
+				else if (result == "NO PIN")
+					ShoutError ("llRemoteLoadScriptPin: Script update denied - PIN not set.");
                 else
                     ScriptShoutError("llRemoteLoadScriptPin: " + result);
             }

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -2216,6 +2216,9 @@ namespace OpenSim.Region.Framework.Scenes
                         "[PRIM INVENTORY]: " +
                         "Script in object {0} : {1}, attempted to load script {2} : {3} into object {4} : {5} with invalid pin {6}",
                         srcPart.Name, srcId, srcTaskItem.Name, srcTaskItem.ItemID, destPart.Name, destId, pin);
+				if (destPart.ScriptAccessPin == 0) {
+					return "NO PIN";
+				}
                 return "PIN";   // signal a different response to the caller
             }
 


### PR DESCRIPTION
This Pull Request contains two changes two llRemoteLoadScriptPin:


1) If llRemoteLoadScriptPin's PIN argument is zero, then instead of trying to use that PIN as though it were valid, it will instead throw an error saying _"llRemoteLoadScriptPin: PIN cannot be zero"_ and then do an early return (with a 3000ms sleep, as it would normally do with or without a valid PIN)

2) If the target prim's PIN mismatches the one passed to llRemoteLoadScriptPin, then instead of simply giving an error stating _"PIN mismatch"_, it will alternatively say _"PIN not set"_ if the target prim's PIN is zero.  


Combined, these changes should give scripters a bit more useful information when debugging scripts that are calling llRemoteLoadScriptPin and llSetRemoteScriptAccessPin