### PR TITLE
Commit region XML (and others) out-of-place

### DIFF
--- a/OpenSim/Framework/Configuration/XML/XmlConfiguration.cs
+++ b/OpenSim/Framework/Configuration/XML/XmlConfiguration.cs
@@ -140,7 +140,17 @@ namespace OpenSim.Framework.Configuration.XML
             {
                 Directory.CreateDirectory(Util.configDir());
             }
-            doc.Save(fileName);
+
+            // Perform commit out of place in case of insufficient disk space.
+            String oldFile = fileName + ".old";
+            String newFile = fileName + ".new";
+            if (File.Exists(newFile))
+                File.Delete(newFile);
+            doc.Save(newFile);
+            if (File.Exists(oldFile))
+                File.Delete(oldFile);
+            File.Move(fileName, oldFile);
+            File.Move(newFile, fileName);
             needsCommit = false;
         }
 

--- a/OpenSim/Framework/Configuration/XML/XmlConfiguration.cs
+++ b/OpenSim/Framework/Configuration/XML/XmlConfiguration.cs
@@ -151,6 +151,8 @@ namespace OpenSim.Framework.Configuration.XML
                 File.Delete(oldFile);
             File.Move(fileName, oldFile);
             File.Move(newFile, fileName);
+            if (File.Exists(fileName) && File.Exists(oldFile))
+                File.Delete(oldFile);
             needsCommit = false;
         }
 

--- a/OpenSim/Framework/ConfigurationMember.cs
+++ b/OpenSim/Framework/ConfigurationMember.cs
@@ -516,10 +516,19 @@ namespace OpenSim.Framework
             return plug;
         }
 
-        public void forceSetConfigurationOption(string configuration_key, string configuration_value)
+        public void forceUpdateConfigurationOneOption(string configuration_key, string configuration_value)
         {
             configurationPlugin.LoadData();
             configurationPlugin.SetAttribute(configuration_key, configuration_value);
+            configurationPlugin.Commit();
+            configurationPlugin.Close();
+        }
+
+        public void forceUpdateConfigurationOptions(Dictionary<string,string>options)
+        {
+            configurationPlugin.LoadData();
+            foreach (KeyValuePair<string,string>option in options)
+                configurationPlugin.SetAttribute(option.Key, option.Value);
             configurationPlugin.Commit();
             configurationPlugin.Close();
         }

--- a/OpenSim/Framework/RegionInfo.cs
+++ b/OpenSim/Framework/RegionInfo.cs
@@ -26,6 +26,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Xml;
@@ -1005,8 +1006,11 @@ namespace OpenSim.Framework
             lastMapUUID = mapUUID;
             lastMapRefresh = Util.UnixTimeSinceEpoch().ToString();
 
-            configMember.forceSetConfigurationOption("lastmap_uuid", mapUUID.ToString());
-            configMember.forceSetConfigurationOption("lastmap_refresh", lastMapRefresh);
+            Dictionary<string, string> options = new Dictionary<string, string>();
+            options.Add("lastmap_uuid", mapUUID.ToString());
+            options.Add("lastmap_refresh", lastMapRefresh);
+
+            configMember.forceUpdateConfigurationOptions(options);
         }
 
         public OSDMap PackRegionInfoData()


### PR DESCRIPTION
- Commit region XML (and others) out-of-place. Avoids creating 0-length region.xml files when the VM is out of disk space.
- Changed SaveLastMapUUID to not rewrite the whole XML file twice. forceSetConfigurationOption reloaded the whole XML then updated one option and committed the whole XML again (and do the rename dance), then for a second option it would reload the whole XML again, update another option, and commit that.
- If the XML rename dance is successful, delete .old file.