### PR TITLE
Bots profiles friends

### DIFF
--- a/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
@@ -1058,7 +1058,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                                 {
                                     m_log.ErrorFormat(
                                         "[CAPS/INVENTORY] Failed to resolve link to item {0} for {1}: {2}",
-                                        item.AssetID, m_Caps.AgentID, e);
+                                        item.AssetID, m_Caps.AgentID, e.Message);
                                 }
                             }
                         } 

--- a/OpenSim/Region/CoreModules/World/Permissions/PermissionsModule.cs
+++ b/OpenSim/Region/CoreModules/World/Permissions/PermissionsModule.cs
@@ -590,13 +590,15 @@ namespace OpenSim.Region.CoreModules.World.Permissions
             }
 
             ScenePresence sp = m_scene.GetScenePresence(user);
-
-            if (sp != null &&
-                (m_bypassPermissions     || // no perms checks
-                sp.GodLevel >= 200   || // Admin should be able to edit anything else in the sim (including admin objects)
-                FriendHasEditPermission(objectOwner, user, fastCheck))) // friend with permissions
+            // bots don't have friends let alone friend edit perms, skip the costly checks.
+            if (sp != null && !sp.IsBot)
             {
-                return RestrictClientFlags(task, objflags);    // minimal perms checks, act like owner
+                if (m_bypassPermissions || // no perms checks
+                    sp.GodLevel >= 200 || // Admin should be able to edit anything else in the sim (including admin objects)
+                    FriendHasEditPermission(objectOwner, user, fastCheck)) // friend with permissions
+                {
+                    return RestrictClientFlags(task, objflags);    // minimal perms checks, act like owner
+                }
             }
 
             /////////////////////////////////////////////////////////////

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -3546,8 +3546,9 @@ namespace OpenSim.Region.Framework.Scenes
             sLLVector3 tempCameraCenter = new sLLVector3(new Vector3(m_CameraCenter.X, m_CameraCenter.Y, m_CameraCenter.Z));
             cadu.cameraPosition = tempCameraCenter;
             cadu.drawdistance = m_DrawDistance;
-            if (m_scene.Permissions.IsGod(new UUID(cadu.AgentID)))
-                cadu.godlevel = m_godlevel;
+            if (!this.IsBot)    // bots don't need IsGod checks
+                if (m_scene.Permissions.IsGod(new UUID(cadu.AgentID)))
+                    cadu.godlevel = m_godlevel;
             cadu.GroupAccess = 0;
             cadu.Position = new sLLVector3(pos);
             cadu.regionHandle = m_scene.RegionInfo.RegionHandle;


### PR DESCRIPTION
- Don't RemoveUserData unless we've searched again, inside lock. There was a race condition with botCreateBot adding new bots and then profile lookups (for SceneView?) not finding the temp profile on first lock entry as attachments are added, then profile lookup grabbing the lock a second time and not checking again for changes between locks, then calling RemoveUserData if it wasn't in storage (killing bot profiles).
- Don't check friend edit perms for bots.
- Tame the many repeated inventory exception tracebacks. Report the "not found" but not a full traceback. That's a very costly operation for a very very common case and also pollutes the log preventing scanning for errors.
- Skip the IsGod check on bots when we can just check SP.IsBot
- Fixed bots prechecks.  Fixed a race condition allowing the same name, tightened the checks for null-named bots, etc.
- Key fix: Fixed incorrect removal of temp/bot profiles. RemoveUserData should not be used for bot (temp) profiles.  They are only in this region, should not be removed because storage couldn't find
them, and are explicitly removed.
- Closed a race condition where profile cache was checked outside the lock then assumed inside the lock.