### PR TITLE
Fixed bot attachment itemID and (non-)save logic

### DIFF
--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -3084,27 +3084,37 @@ namespace OpenSim.Region.Framework.Scenes
 
         private Dictionary<UUID, KnownAssetUpdateRequest> _pendingAssetUpdates = new Dictionary<UUID, KnownAssetUpdateRequest>();
 
+        public void DeleteAttachment(SceneObjectGroup grp)
+        {
+            if (grp != null)
+            {
+                grp.DetachToInventoryPrep();
+                DeleteSceneObject(grp, false);
+                return;
+            }
+        }
+
         public void SaveAndDeleteAttachment(IClientAPI remoteClient, SceneObjectGroup grp, UUID assetID, UUID agentID)
         {
             if (grp != null)
             {
                 m_log.DebugFormat("[DETACH]: Saving attachpoint {0}: [{1}] {2}", grp.GetCurrentAttachmentPoint(), grp.UUID, grp.Name);
 
-                grp.DetachToInventoryPrep();
-
                 if (!grp.HasGroupChanged && grp.GroupScriptEvents == 0)
                 {
                     m_log.InfoFormat("[ATTACHMENT]: Save request for {0} which is unchanged", grp.UUID);
-                    DeleteSceneObject(grp, false);
+                    DeleteAttachment(grp);
                     return;
                 }
 
                 if (grp.IsTempAttachment)
                 {
                     m_log.InfoFormat("[ATTACHMENT]: Ignored save request for {0} which is temporary", grp.UUID);
-                    DeleteSceneObject(grp, false);
+                    DeleteAttachment(grp);
                     return;
                 }
+
+                grp.DetachToInventoryPrep();
 
                 KnownAssetUpdateRequest updateReq = new KnownAssetUpdateRequest
                 {
@@ -4496,16 +4506,26 @@ namespace OpenSim.Region.Framework.Scenes
         {
             UUID groupId = UUID.Zero;
             ScenePresence presence;
+            bool isBot = false;
+
             if (TryGetAvatar(remoteClient.AgentId, out presence))
             {
+                isBot = presence.IsBot;
+                if (isBot)
+                    itemID ^= presence.UUID;    // use original itemID from owner's inventory
                 groupId = presence.Appearance.DetachAttachment(itemID);
                 IAvatarFactory ava = RequestModuleInterface<IAvatarFactory>();
                 if (ava != null)
-                    ava.UpdateDatabase(remoteClient.AgentId, presence.Appearance, null, null);
-
+                {
+                    if (!isBot)
+                        ava.UpdateDatabase(remoteClient.AgentId, presence.Appearance, null, null);
+                }
             }
 
-            m_sceneGraph.DetachSingleAttachmentToInv(itemID, groupId, remoteClient);
+            if (isBot)
+                m_sceneGraph.DetachSingleBotAttachment(itemID, groupId, remoteClient);
+            else
+                m_sceneGraph.DetachSingleAttachmentToInv(itemID, groupId, remoteClient);
         }
 
         public void GetScriptRunning(IClientAPI controllingClient, UUID objectID, UUID itemID)

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -738,9 +738,8 @@ namespace OpenSim.Region.Framework.Scenes
             return objatt;
         }
 
-        // What makes this method odd and unique is it tries to detach using an UUID....     Yay for standards.
-        // To LocalId or UUID, *THAT* is the question. How now Brown UUID??
-        public void DetachSingleAttachmentToInv(UUID itemID, UUID groupId, IClientAPI remoteClient)
+        // This method uses an *inventory* UUID (because it is coming from the source (in this case an LSL script?) as an inventory ID).
+        private void DetachSingleAttachmentFromItemID(UUID itemID, UUID groupId, IClientAPI remoteClient, bool isBot)
         {
             if (itemID == UUID.Zero) // If this happened, someone made a mistake....
                 return;
@@ -758,7 +757,10 @@ namespace OpenSim.Region.Framework.Scenes
                     SceneObjectGroup group = part.ParentGroup;
                     if (group.OwnerID == remoteClient.AgentId)
                     {
-                        m_parentScene.SaveAndDeleteAttachment(remoteClient, group,
+                        if (isBot)
+                            m_parentScene.DeleteAttachment(group);
+                        else
+                            m_parentScene.SaveAndDeleteAttachment(remoteClient, group,
                                 group.GetFromItemID(), group.OwnerID);
                     }
                 }
@@ -780,7 +782,10 @@ namespace OpenSim.Region.Framework.Scenes
                         {
                             if (group.OwnerID == remoteClient.AgentId)
                             {
-                                m_parentScene.SaveAndDeleteAttachment(remoteClient, group,
+                                if (isBot)
+                                    m_parentScene.DeleteAttachment(group);
+                                else
+                                    m_parentScene.SaveAndDeleteAttachment(remoteClient, group,
                                         group.GetFromItemID(), group.OwnerID);
                                 return;
                             }
@@ -788,6 +793,18 @@ namespace OpenSim.Region.Framework.Scenes
                     }
                 }
             }
+        }
+
+        // This method uses an *inventory* UUID (because it is coming from the source (in this case an LSL script?) as an inventory ID).
+        public void DetachSingleBotAttachment(UUID itemID, UUID groupId, IClientAPI remoteClient)
+        {
+            DetachSingleAttachmentFromItemID(itemID, groupId, remoteClient, true);
+        }
+
+        // This method uses an *inventory* UUID (because it is coming from the source (in this case an LSL script?) as an inventory ID).
+        public void DetachSingleAttachmentToInv(UUID itemID, UUID groupId, IClientAPI remoteClient)
+        {
+            DetachSingleAttachmentFromItemID(itemID, groupId, remoteClient, false);
         }
 
         // This one tries to detach using an attachment point.


### PR DESCRIPTION
- Fixed bot attachments detaches to use the correct itemID so that it
can actually find the group to detach (llDetachFromAvatar and other
callers to DetachSingleAttachmentToInv)
- Now that it's passing the correct user inventory item ID, insurance
code to ensure changes to bot attachmetns are not accidentally saved to
the original copy (which the avatar might have been wearing and saved
different changes for).