### PR TITLE
Get rid of insane overloads on SimChat #145

### DIFF
--- a/InWorldz/InWorldz.ApplicationPlugins/AvatarRemoteCommandModule/AvatarRemoteCommandModule.cs
+++ b/InWorldz/InWorldz.ApplicationPlugins/AvatarRemoteCommandModule/AvatarRemoteCommandModule.cs
@@ -325,7 +325,6 @@ namespace InWorldz.ApplicationPlugins.AvatarRemoteCommandModule
                 Message = message,
                 Position = presence.AbsolutePosition,
                 Scene = presence.Scene,
-                Sender = presence.ControllingClient,
                 SenderUUID = presence.UUID,
                 Type = ChatTypeEnum.Say
             });

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -1002,8 +1002,7 @@ namespace InWorldz.Phlox.Engine
             if (text.Length > 1023)
                 text = text.Substring(0, 1023);
 
-            world.SimChat(Utils.StringToBytes(text),
-                          type, channelID, part.AbsolutePosition, part.Name, part.UUID, false, destID, part.OwnerID);
+            world.SimChat(text, type, channelID, part, destID);
 
             IWorldComm wComm = world.RequestModuleInterface<IWorldComm>();
             wComm.DeliverMessage(type, channelID, part.Name, part.UUID, text, destID);
@@ -11971,9 +11970,7 @@ namespace InWorldz.Phlox.Engine
 
         public void llOwnerSay(string msg)
         {
-            World.SimChatBroadcast(Utils.StringToBytes(msg), ChatTypeEnum.Owner, 0,
-                                   m_host.AbsolutePosition, m_host.Name, m_host.UUID, false,
-                                   m_host.OwnerID);
+            World.SimChat(msg, ChatTypeEnum.Owner, 0, m_host, UUID.Zero, true);
 
             ScriptSleep(15);
         }

--- a/OpenSim/Framework/OSChatMessage.cs
+++ b/OpenSim/Framework/OSChatMessage.cs
@@ -33,7 +33,6 @@ namespace OpenSim.Framework
     public interface IEventArgs
     {
         IScene Scene { get; set; }
-        IClientAPI Sender { get; set; }
     }
 
     /// <summary>
@@ -109,18 +108,6 @@ namespace OpenSim.Framework
         }
 
         #region IEventArgs Members
-
-        /// TODO: Sender and SenderObject should just be Sender and of
-        /// type IChatSender
-
-        /// <summary>
-        /// The client responsible for sending the message, or null.
-        /// </summary>
-        public IClientAPI Sender
-        {
-            get { return m_sender; }
-            set { m_sender = value; }
-        }
         
         public UUID SenderUUID
         {

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -7564,7 +7564,6 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 args.Position = fromPos;
 
                 args.Scene = Scene;
-                args.Sender = this;
                 args.SenderUUID = this.AgentId;
                 args.DestinationUUID = UUID.Zero;
 
@@ -7646,7 +7645,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 args.Type = ChatTypeEnum.Say;
                 args.Position = pos;
                 args.Scene = Scene;
-                args.Sender = this;
+                args.SenderUUID = this.AgentId;
                 args.DestinationUUID = UUID.Zero;
 
                 ChatMessage handlerChatFromClient2 = OnChatFromClient;

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
@@ -253,7 +253,6 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
             chatFromClient.Message = message;
             chatFromClient.Position = StartPos;
             chatFromClient.Scene = m_scene;
-            chatFromClient.Sender = this;
             chatFromClient.SenderUUID = AgentId;
             chatFromClient.Type = sourceType;
 

--- a/OpenSim/Region/CoreModules/Avatar/Chat/ChatModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Chat/ChatModule.cs
@@ -122,7 +122,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
 
             ScenePresence avatar;
             Scene scene = (Scene)c.Scene;
-            if ((avatar = scene.GetScenePresence(c.Sender.AgentId)) != null)
+            if (scene.TryGetAvatar(c.SenderUUID, out avatar))
                 c.Position = avatar.AbsolutePosition;
 
             return c;
@@ -167,7 +167,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
             if (c.Channel != 0 && c.Channel != DEBUG_CHANNEL) return;
 
             // sanity check:
-            if (c.Sender == null)
+            if (c.SenderUUID == UUID.Zero)
             {
                 m_log.ErrorFormat("[CHAT] OnChatFromClient from {0} has empty Sender field!", sender);
                 return;
@@ -204,16 +204,25 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
                     if (!(scene is Scene))
                     {
                         m_log.WarnFormat("[CHAT]: scene {0} is not a Scene object, cannot obtain scene presence for {1}",
-                            scene.RegionInfo.RegionName, c.Sender.AgentId);
+                            scene.RegionInfo.RegionName, c.SenderUUID);
                         return;
                     }
-                    ScenePresence avatar = (scene as Scene).GetScenePresence(c.Sender.AgentId);
-                    fromPos = avatar.AbsolutePosition;
-                    fromName = avatar.Name;
-                    fromID = c.Sender.AgentId;
-                    ownerID = c.Sender.AgentId;
+                    ScenePresence avatar;
+                    if((scene as Scene).TryGetAvatar(c.SenderUUID, out avatar))
+                    {
+                        fromPos = avatar.AbsolutePosition;
+                        fromName = avatar.Name;
+                        fromID = c.SenderUUID;
+                        ownerID = c.SenderUUID;
+                    }
+                    else
+                    {
+                        m_log.WarnFormat("[CHAT]: cannot obtain scene presence for {0}",
+                            c.SenderUUID);
+                        return;
+                    }
 
-                break;
+                    break;
 
                 case ChatSourceType.Object:
                     fromID = c.SenderUUID;
@@ -264,12 +273,12 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
             UUID fromID = UUID.Zero;
             UUID ownerID = c.GeneratingAvatarID;
             ChatSourceType sourceType = ChatSourceType.Object;
-            if (null != c.Sender)
+            ScenePresence avatar;
+            if ((c.Scene as Scene).TryGetAvatar(c.SenderUUID, out avatar))
             {
-                ScenePresence avatar = (c.Scene as Scene).GetScenePresence(c.Sender.AgentId);
-                fromID = c.Sender.AgentId;
+                fromID = c.SenderUUID;
                 fromName = avatar.Name;
-                ownerID = c.Sender.AgentId;
+                ownerID = c.SenderUUID;
                 sourceType = ChatSourceType.Agent;
             } 
             else if (c.SenderUUID != UUID.Zero)
@@ -672,7 +681,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
                     break;
 
                 default:
-                    c.Sender.SendAlertMessage("Region chat command was not recognized.");
+                    client.SendAlertMessage("Region chat command was not recognized.");
                     break;
             }
         }

--- a/OpenSim/Region/CoreModules/Scripting/DynamicTexture/DynamicTextureModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/DynamicTexture/DynamicTextureModule.cs
@@ -253,9 +253,7 @@ namespace OpenSim.Region.CoreModules.Scripting.DynamicTexture
                 {
                     string msg = 
                         String.Format("DynamicTextureModule: Error preparing image using URL {0}", Url);
-                    scene.SimChat(Utils.StringToBytes(msg), ChatTypeEnum.Say,
-                                  0, part.ParentGroup.RootPart.AbsolutePosition, part.Name, part.UUID, false,
-                                  part.OwnerID);
+                    scene.SimChat(msg, ChatTypeEnum.Say, 0, part);
                     return;
                 }
 

--- a/OpenSim/Region/CoreModules/Scripting/WorldComm/WorldCommModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/WorldComm/WorldCommModule.cs
@@ -391,8 +391,9 @@ namespace OpenSim.Region.CoreModules.Scripting.WorldComm
 
         private void DeliverClientMessage(Object sender, OSChatMessage e)
         {
-            if (null != e.Sender)
-                DeliverMessage(e.Type, e.Channel, e.Sender.Name, e.Sender.AgentId, e.Message, e.Position, UUID.Zero);
+            ScenePresence sp;
+            if (m_scene.TryGetAvatar(e.SenderUUID, out sp))
+                DeliverMessage(e.Type, e.Channel, sp.Name, e.SenderUUID, e.Message, e.Position, UUID.Zero);
             else
                 DeliverMessage(e.Type, e.Channel, e.From, UUID.Zero, e.Message, e.Position, UUID.Zero);
         }

--- a/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
@@ -37,78 +37,93 @@ namespace OpenSim.Region.Framework.Scenes
 {
     public partial class Scene
     {
-        protected void SimChat(byte[] message, ChatTypeEnum type, int channel, Vector3 fromPos, string fromName,
-                               UUID fromID, bool fromAgent, bool broadcast, UUID destID, UUID generatingAvatarID)
+        /// <summary>
+        /// Sends a chat message to clients in the region
+        /// </summary>
+        /// <param name="message">The message to send to users</param>
+        /// <param name="type">The type of message (say, shout, whisper, owner say, etc)</param>
+        /// <param name="channel">The channel to speak the message on</param>
+        /// <param name="part">The SceneObjectPart that is sending this chat message</param>
+        public void SimChat(string message, ChatTypeEnum type, int channel, SceneObjectPart part)
         {
-            OSChatMessage args = new OSChatMessage();
+            SimChat(message, type, channel, part.AbsolutePosition, part.Name, part.UUID, UUID.Zero, part.OwnerID, false);
+        }
 
-            args.Message = Utils.BytesToString(message);
-            args.Channel = channel;
-            args.Type = type;
-            args.Position = fromPos;
-            args.SenderUUID = fromID;
-            args.DestinationUUID = destID;
-            args.Scene = this;
+        /// <summary>
+        /// Sends a chat message to clients in the region
+        /// </summary>
+        /// <param name="message">The message to send to users</param>
+        /// <param name="type">The type of message (say, shout, whisper, owner say, etc)</param>
+        /// <param name="channel">The channel to speak the message on</param>
+        /// <param name="part">The SceneObjectPart that is sending this chat message</param>
+        /// <param name="destID">The user or object that is being spoken to (UUID.Zero specifies all users will get the message)</param>
+        /// <param name="broadcast">Whether the message will be sent regardless of distance from the sender</param>
+        public void SimChat(string message, ChatTypeEnum type, int channel, SceneObjectPart part,
+            UUID destID, bool broadcast = false)
+        {
+            SimChat(message, type, channel, part.AbsolutePosition, part.Name, part.UUID, destID, part.OwnerID, broadcast);
+        }
 
-            if (fromAgent)
+        /// <summary>
+        /// Sends a chat message to clients in the region
+        /// </summary>
+        /// <param name="message">The message to send to users</param>
+        /// <param name="type">The type of message (say, shout, whisper, owner say, etc)</param>
+        /// <param name="channel">The channel to speak the message on</param>
+        /// <param name="presence">The ScenePresence that is sending this chat message</param>
+        public void SimChat(string message, ChatTypeEnum type, int channel, ScenePresence presence)
+        {
+            SimChat(message, type, channel, presence.AbsolutePosition, presence.Name, presence.UUID, UUID.Zero, presence.UUID, false);
+        }
+
+        /// <summary>
+        /// Sends a chat message to clients in the region
+        /// </summary>
+        /// <param name="message">The message to send to users</param>
+        /// <param name="type">The type of message (say, shout, whisper, owner say, etc)</param>
+        /// <param name="channel">The channel to speak the message on</param>
+        /// <param name="presence">The ScenePresence that is sending this chat message</param>
+        /// <param name="destID">The user or object that is being spoken to (UUID.Zero specifies all users will get the message)</param>
+        /// <param name="broadcast">Whether the message will be sent regardless of distance from the sender</param>
+        public void SimChat(string message, ChatTypeEnum type, int channel, ScenePresence presence,
+            UUID destID, bool broadcast = false)
+        {
+            SimChat(message, type, channel, presence.AbsolutePosition, presence.Name, presence.UUID, destID, presence.UUID, broadcast);
+        }
+
+        /// <summary>
+        /// Sends a chat message to clients in the region
+        /// </summary>
+        /// <param name="message">The message to send to users</param>
+        /// <param name="type">The type of message (say, shout, whisper, owner say, etc)</param>
+        /// <param name="channel">The channel to speak the message on</param>
+        /// <param name="fromPos">The position of the speaker (the SceneObjectPart or ScenePresence)</param>
+        /// <param name="fromName">The name of the speaker (the SceneObjectPart or ScenePresence)</param>
+        /// <param name="fromID">The UUID of the speaker (the SceneObjectPart or ScenePresence)</param>
+        /// <param name="destID">The user or object that is being spoken to (UUID.Zero specifies all users will get the message)</param>
+        /// <param name="generatingAvatarID">The avatar ID that has generated this message regardless of
+        /// if it is a script owned by this avatar, or the avatar itself</param>
+        /// <param name="broadcast">Whether the message will be sent regardless of distance from the sender</param>
+        public void SimChat(string message, ChatTypeEnum type, int channel, Vector3 fromPos,
+            string fromName, UUID fromID, UUID destID, UUID generatingAvatarID, bool broadcast)
+        {
+            OSChatMessage args = new OSChatMessage()
             {
-                ScenePresence user = GetScenePresence(fromID);
-                if (user != null)
-                    args.Sender = user.ControllingClient;
-            }
-
-            args.From = fromName;
-            args.GeneratingAvatarID = generatingAvatarID;
+                Channel = channel,
+                DestinationUUID = destID,
+                From = fromName,
+                GeneratingAvatarID = generatingAvatarID,
+                Message = message,
+                Position = fromPos,
+                Scene = this,
+                SenderUUID = fromID,
+                Type = type
+            };
 
             if (broadcast)
                 EventManager.TriggerOnChatBroadcast(this, args);
             else
                 EventManager.TriggerOnChatFromWorld(this, args);
-        }
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="type"></param>
-        /// <param name="fromPos"></param>
-        /// <param name="fromName"></param>
-        /// <param name="fromAgentID"></param>
-        public void SimChat(byte[] message, ChatTypeEnum type, int channel, Vector3 fromPos, string fromName,
-                            UUID fromID, bool fromAgent, UUID destID, UUID generatingAvatarID)
-        {
-            SimChat(message, type, channel, fromPos, fromName, fromID, fromAgent, false, destID, generatingAvatarID);
-        }
-
-        public void SimChat(byte[] message, ChatTypeEnum type, int channel, Vector3 fromPos, string fromName,
-                            UUID fromID, bool fromAgent, UUID generatingAvatarID)
-        {
-            SimChat(message, type, channel, fromPos, fromName, fromID, fromAgent, false, UUID.Zero, generatingAvatarID);
-        }
-
-        public void SimChat(string message, ChatTypeEnum type, Vector3 fromPos, string fromName, UUID fromID, 
-            bool fromAgent, UUID generatingAvatarID)
-        {
-            SimChat(Utils.StringToBytes(message), type, 0, fromPos, fromName, fromID, fromAgent, generatingAvatarID);
-        }
-
-        public void SimChat(string message, string fromName, UUID generatingAvatarID)
-        {
-            SimChat(message, ChatTypeEnum.Broadcast, Vector3.Zero, fromName, UUID.Zero, false, generatingAvatarID);
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="type"></param>
-        /// <param name="fromPos"></param>
-        /// <param name="fromName"></param>
-        /// <param name="fromAgentID"></param>
-        public void SimChatBroadcast(byte[] message, ChatTypeEnum type, int channel, Vector3 fromPos, string fromName,
-                                     UUID fromID, bool fromAgent, UUID generatingAvatarID)
-        {
-            SimChat(message, type, channel, fromPos, fromName, fromID, fromAgent, true, UUID.Zero, generatingAvatarID);
         }
 
         /// <summary>

--- a/OpenSim/Region/OptionalModules/Avatar/Concierge/ConciergeModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Concierge/ConciergeModule.cs
@@ -573,7 +573,6 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
             c.Channel = 0;
             c.Position = PosOfGod;
             c.From = m_whoami;
-            c.Sender = null;
             c.SenderUUID = UUID.Zero;
             c.Scene = scene;
 
@@ -589,7 +588,6 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
             c.Channel = 0;
             c.Position = PosOfGod;
             c.From = m_whoami;
-            c.Sender = null;
             c.SenderUUID = UUID.Zero;
             c.Scene = agent.Scene;
 

--- a/OpenSim/Region/OptionalModules/Scripting/RegionReady/RegionReady.cs
+++ b/OpenSim/Region/OptionalModules/Scripting/RegionReady/RegionReady.cs
@@ -126,7 +126,6 @@ namespace OpenSim.Region.CoreModules.Scripting.RegionReady
                 c.Message += numScriptsFailed.ToString() + "," + message;
                 c.Type = ChatTypeEnum.Region;
                 c.Position = new Vector3(128, 128, 30);
-                c.Sender = null;
                 c.SenderUUID = UUID.Zero;
 
                 m_log.InfoFormat("[RegionReady]: Region \"{0}\" is ready: \"{1}\" on channel {2}",


### PR DESCRIPTION
Clean up SimChat method and make much simpler methods for it that have proper documentation as to what each argument does. Get rid of "Sender" property in OSChatMessage as OSChatMessage does not need to have an IClientAPI reference at all times.