### PR TITLE
Make sure that bots do not ever get information put into SceneView as…

### DIFF
--- a/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
+++ b/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
@@ -177,6 +177,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
             if (UseCulling == false)
                 return;
 
+            //Bots don't get to check for updates
+            if (m_presence.IsBot)
+                return;
+
             //With 25K objects, this method takes around 10ms if the client has seen none of the objects in the sim
             if (m_presence.DrawDistance <= 0)
                 return;
@@ -337,6 +341,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// </summary>
         public void SendInitialFullUpdateToAllClients()
         {
+            //Bots don't get to check for updates
+            if (m_presence.IsBot)
+                return;
+
             m_perfMonMS = Environment.TickCount;
 
             List<ScenePresence> avatars = m_presence.Scene.GetScenePresences();
@@ -400,6 +408,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// </summary>
         public void SendFullUpdateToAllClients()
         {
+            //Bots don't get to check for updates
+            if (m_presence.IsBot)
+                return;
+
             m_perfMonMS = Environment.TickCount;
 
             // only send update from root agents to other clients; children are only "listening posts"
@@ -702,6 +714,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
                 return;
             }
 
+            //Bots don't get to check for updates
+            if (m_presence.IsBot)
+                return;
+
             if (m_presence.IsInTransit)
                 return; // disable prim updates during a crossing, but leave them queued for after transition
             if (!m_presence.IsChildAgent && !m_presence.IsFullyInRegion) 
@@ -881,6 +897,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
 
         public void SendGroupUpdate(SceneObjectGroup sceneObjectGroup, PrimUpdateFlags updateFlags)
         {
+            //Bots don't get to send updates
+            if (m_presence.IsBot)
+                return;
+
             SendPartUpdate(sceneObjectGroup.RootPart, updateFlags);
             foreach (SceneObjectPart part in sceneObjectGroup.GetParts())
             {
@@ -984,7 +1004,7 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// 
         /// SHOULD ONLY BE CALLED FROM CHILDREN OF THE SCENE LOOP!!
         /// </summary>
-        private void ClearAllTracking()
+        public void ClearAllTracking()
         {
             if (m_partsUpdateQueue.Count > 0)
                 m_partsUpdateQueue.Clear();
@@ -1005,6 +1025,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// <param name="localIds"></param>
         public void SendKillObjects(SceneObjectGroup grp, List<uint> localIds)
         {
+            //Bots don't get to check for updates
+            if (m_presence.IsBot)
+                return;
+
             //Only send the kill object packet if we have seen this object
             lock (m_updateTimes)
             {
@@ -1025,6 +1049,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// <param name="y"></param>
         public void TerrainPatchUpdated(float[] serialized, int x, int y)
         {
+            //Bots don't get to check for updates
+            if (m_presence.IsBot)
+                return;
+
             //Check to make sure that we only send it if we can see it or culling is disabled
             if ((UseCulling == false) || ShowTerrainPatchToClient(x, y))
                 m_presence.ControllingClient.SendLayerData(x, y, serialized);

--- a/OpenSim/Region/Framework/Interfaces/ISceneView.cs
+++ b/OpenSim/Region/Framework/Interfaces/ISceneView.cs
@@ -159,6 +159,11 @@ namespace OpenSim.Region.Framework.Interfaces
         void ClearScene();
 
         /// <summary>
+        /// Clears all presence and tracking information for this scene view
+        /// </summary>
+        void ClearAllTracking();
+
+        /// <summary>
         /// Send a terse update for an avatar if they are within draw distance
         /// </summary>
         /// <param name="scenePresence"></param>

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -4408,6 +4408,7 @@ namespace OpenSim.Region.Framework.Scenes
             m_closed = true;
 
             ClearSceneView();
+            SceneView.ClearAllTracking();
         }
 
         /// <summary>


### PR DESCRIPTION
… they can't use it. Also make sure to fully clear out SceneView in case it isn't disposed properly by the GC later.