### PR TITLE
SP&Bot SceneView fixes

### DIFF
--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
@@ -58,6 +58,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
         private Dictionary<string, UUID> m_defaultAnimations = new Dictionary<string, UUID>();
         private bool m_frozenUser = false;
         private bool m_closing = false;
+        private static int m_depth = 0;
 
         #endregion
 
@@ -78,6 +79,13 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
             TimeCreated = DateTime.Now;
 
             InitDefaultAnimations();
+
+            m_log.Warn("[BOTCLIENT]: Constructor, clients now: " + (++m_depth).ToString());
+        }
+
+        ~BotClient()
+        {
+            m_log.Warn("[BOTCLIENT]: Destructor, clients now: " + (--m_depth).ToString());
         }
 
         #endregion

--- a/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
+++ b/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
@@ -412,10 +412,6 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// </summary>
         public void SendFullUpdateToAllClients()
         {
-            //Bots don't get to check for updates
-            if (m_presence.IsBot)
-                return;
-
             m_perfMonMS = Environment.TickCount;
 
             // only send update from root agents to other clients; children are only "listening posts"

--- a/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
+++ b/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
@@ -335,6 +335,8 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
             // 2 stage check is needed.
             if (otherClient == null)
                 return;
+            if (otherClient.IsBot)
+                return;
             if (otherClient.ControllingClient == null)
                 return;
             if (m_presence.Appearance.Texture == null)

--- a/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
+++ b/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
@@ -153,6 +153,7 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         #endregion
 
         #region Constructor
+        private static int m_depth = 0;
 
         public SceneView(ScenePresence presence, bool useCulling)
         {
@@ -163,8 +164,15 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
 
             //Update every 1/4th a draw distance
             DistanceBeforeCullingRequired = _MINIMUM_DRAW_DISTANCE / 8;
+
+            m_log.Warn("[SCENEVIEW]: Constructor, depth now: " + (++m_depth).ToString());
         }
 
+        ~SceneView()
+        {
+            //m_updateTimes
+            m_log.Warn("[SCENEVIEW]: Destructor, depth now: " + (--m_depth).ToString());
+        }
         #endregion
 
         #region Culler Methods

--- a/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
+++ b/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
@@ -185,6 +185,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
             if (UseCulling == false)
                 return;
 
+            //Bots don't get to check for updates
+            if (m_presence.IsBot)
+                return;
+
             //With 25K objects, this method takes around 10ms if the client has seen none of the objects in the sim
             if (m_presence.DrawDistance <= 0)
                 return;
@@ -345,6 +349,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// </summary>
         public void SendInitialFullUpdateToAllClients()
         {
+            //Bots don't get to check for updates
+            if (m_presence.IsBot)
+                return;
+
             m_perfMonMS = Environment.TickCount;
 
             List<ScenePresence> avatars = m_presence.Scene.GetScenePresences();
@@ -408,6 +416,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// </summary>
         public void SendFullUpdateToAllClients()
         {
+            //Bots don't get to check for updates
+            if (m_presence.IsBot)
+                return;
+
             m_perfMonMS = Environment.TickCount;
 
             // only send update from root agents to other clients; children are only "listening posts"
@@ -710,6 +722,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
                 return;
             }
 
+            //Bots don't get to check for updates
+            if (m_presence.IsBot)
+                return;
+
             if (m_presence.IsInTransit)
                 return; // disable prim updates during a crossing, but leave them queued for after transition
             if (!m_presence.IsChildAgent && !m_presence.IsFullyInRegion) 
@@ -889,6 +905,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
 
         public void SendGroupUpdate(SceneObjectGroup sceneObjectGroup, PrimUpdateFlags updateFlags)
         {
+            //Bots don't get to send updates
+            if (m_presence.IsBot)
+                return;
+
             SendPartUpdate(sceneObjectGroup.RootPart, updateFlags);
             foreach (SceneObjectPart part in sceneObjectGroup.GetParts())
             {
@@ -992,7 +1012,7 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// 
         /// SHOULD ONLY BE CALLED FROM CHILDREN OF THE SCENE LOOP!!
         /// </summary>
-        private void ClearAllTracking()
+        public void ClearAllTracking()
         {
             if (m_partsUpdateQueue.Count > 0)
                 m_partsUpdateQueue.Clear();
@@ -1013,6 +1033,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// <param name="localIds"></param>
         public void SendKillObjects(SceneObjectGroup grp, List<uint> localIds)
         {
+            //Bots don't get to check for updates
+            if (m_presence.IsBot)
+                return;
+
             //Only send the kill object packet if we have seen this object
             lock (m_updateTimes)
             {
@@ -1033,6 +1057,10 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// <param name="y"></param>
         public void TerrainPatchUpdated(float[] serialized, int x, int y)
         {
+            //Bots don't get to check for updates
+            if (m_presence.IsBot)
+                return;
+
             //Check to make sure that we only send it if we can see it or culling is disabled
             if ((UseCulling == false) || ShowTerrainPatchToClient(x, y))
                 m_presence.ControllingClient.SendLayerData(x, y, serialized);

--- a/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
+++ b/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
@@ -349,10 +349,6 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// </summary>
         public void SendInitialFullUpdateToAllClients()
         {
-            //Bots don't get to check for updates
-            if (m_presence.IsBot)
-                return;
-
             m_perfMonMS = Environment.TickCount;
 
             List<ScenePresence> avatars = m_presence.Scene.GetScenePresences();

--- a/OpenSim/Region/Framework/Interfaces/ISceneView.cs
+++ b/OpenSim/Region/Framework/Interfaces/ISceneView.cs
@@ -159,6 +159,11 @@ namespace OpenSim.Region.Framework.Interfaces
         void ClearScene();
 
         /// <summary>
+        /// Clears all presence and tracking information for this scene view
+        /// </summary>
+        void ClearAllTracking();
+
+        /// <summary>
         /// Send a terse update for an avatar if they are within draw distance
         /// </summary>
         /// <param name="scenePresence"></param>

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1488,7 +1488,8 @@ namespace OpenSim.Region.Framework.Scenes
             // the inventory arrives
             // m_scene.GetAvatarAppearance(m_controllingClient, out m_appearance);
 
-            SendAvatarData(ControllingClient, true);
+            if (!IsBot)
+                SendAvatarData(ControllingClient, true);
             SceneView.SendInitialFullUpdateToAllClients();
             SendAnimPack();
         }
@@ -3448,7 +3449,8 @@ namespace OpenSim.Region.Framework.Scenes
                 }
             }
 
-            SendAvatarData(m_controllingClient, false);
+            if (!IsBot)
+                SendAvatarData(m_controllingClient, false);
         }
 
         /// <summary>
@@ -3524,7 +3526,7 @@ namespace OpenSim.Region.Framework.Scenes
                 m_scene.EventManager.TriggerSignificantClientMovement(m_controllingClient);
             }
 
-            if (m_sceneView != null && m_sceneView.UseCulling)
+            if (m_sceneView != null && m_sceneView.UseCulling && !IsBot)
             {
                 //Check to see if the agent has moved enough to warrent another culling check
                 if (Util.GetDistanceTo(pos, posLastCullCheck) > m_sceneView.DistanceBeforeCullingRequired)

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -4416,6 +4416,7 @@ namespace OpenSim.Region.Framework.Scenes
             m_closed = true;
 
             ClearSceneView();
+            SceneView.ClearAllTracking();
         }
 
         /// <summary>

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -879,10 +879,11 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
-#endregion
+        #endregion
 
-#region Constructor(s)
+        #region Constructor(s)
 
+        private static int m_depth = 0;
         private ScenePresence(IClientAPI client, Scene world, RegionInfo reginfo)
         {
             m_regionHandle = reginfo.RegionHandle;
@@ -903,6 +904,8 @@ namespace OpenSim.Region.Framework.Scenes
                 m_grouptitle = gm.GetGroupTitle(m_uuid);
 
             m_scriptEngines = m_scene.RequestModuleInterfaces<IScriptModule>();
+
+            m_log.Warn("[PRESENCE]: Constructor, clients now: " + (++m_depth).ToString());
 
             ISceneViewModule sceneViewModule = m_scene.RequestModuleInterface<ISceneViewModule>();
             if (sceneViewModule != null)
@@ -931,6 +934,11 @@ namespace OpenSim.Region.Framework.Scenes
             : this(client, world, reginfo)
         {
             m_appearance = appearance;
+        }
+
+        ~ScenePresence()
+        {
+            m_log.Warn("[PRESENCE]: Destructor, clients now: " + (--m_depth).ToString());
         }
 
         public void RegisterToEvents()


### PR DESCRIPTION
- Matt's fixes to avoid sending updates to bots, and queuing those updates (using memory)
- Fixed two places that shouldn't have changed.
- Added a few more places to avoid calling stubbed bot avatar update functions.
