### PR TITLE
Options for "forcegc" command to allow max generation and forced mode.

### DIFF
--- a/OpenSim/Framework/Servers/BaseOpenSimServer.cs
+++ b/OpenSim/Framework/Servers/BaseOpenSimServer.cs
@@ -174,7 +174,7 @@ namespace OpenSim.Framework.Servers
                         "Quit the application", HandleQuit);
 
                 m_console.Commands.AddCommand("base", false, "forcegc",
-                        "forcegc",
+                        "forcegc [ 0|1|2|*|now ]",
                         "Forces an immediate full garbage collection (testing/dev only)", HandleForceGC);
 
                 m_console.Commands.AddCommand("base", false, "set log level",
@@ -326,7 +326,32 @@ namespace OpenSim.Framework.Servers
 
         private void HandleForceGC(string module, string[] args)
         {
-            GC.Collect();
+            // Default is an full (gen2) but NON-forced GC.
+            int gen = 2;
+            GCCollectionMode mode = GCCollectionMode.Optimized;
+
+            if (args.Length > 1)
+            {
+                // Any argument implies forced GC.
+                mode = GCCollectionMode.Forced;
+                switch (args[1].ToLower())
+                {
+                    case "now":
+                    case "*":
+                        gen = GC.MaxGeneration;
+                        break;
+                    case "0":
+                    case "1":
+                    case "2":
+                        gen = Convert.ToInt32(args[1]);
+                        break;
+                    default:
+                        m_log.Warn("Usage: forcegc [ 0|1|2|*|now ]");
+                        return;
+                }
+            }
+
+            GC.Collect(gen, mode, true);
         }
 
         private void HandleLogLevel(string module, string[] cmd)


### PR DESCRIPTION
The forcegc command actually doesn't force it (uses GCCollectionMode.Default --> GCCollectionMode.Optimized) and this doesn't change that but allows an optional maximum generation number and if used, forces a blocking GC.