### PR TITLE
Fixes to outgoing HTTP request headers from LSL scripts

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -13104,8 +13104,7 @@ namespace InWorldz.Phlox.Engine
             httpHeaders["X-SecondLife-Owner-Key"] = m_host.ObjectOwner.ToString();
             string userAgent = config.Configs["Network"].GetString("user_agent", null);
             if (userAgent == null)
-                userAgent = "LSL Script (Mozilla Compatible)";
-
+                userAgent = "InWorldz LSL/"+ VersionInfo.Version+ " (http://inworldz.com)";
             httpHeaders["User-Agent"] = userAgent;
 
             UUID reqId = httpScriptMod.StartHttpRequest(m_host.ParentGroup.UUID, m_localID, m_itemID, url, param, httpHeaders, body);

--- a/OpenSim/Region/CoreModules/Scripting/HttpRequest/ScriptsHttpRequests.cs
+++ b/OpenSim/Region/CoreModules/Scripting/HttpRequest/ScriptsHttpRequests.cs
@@ -296,10 +296,15 @@ namespace OpenSim.Region.CoreModules.Scripting.HttpRequest
                         case (int)HttpRequestConstants.HTTP_CUSTOM_HEADER:
                             string key = parms[i++];
                             string value = parms[i++];
-                            // Don't overwrite values.  Keeps us from clobbering
-                            // The standard X-Secondlife params with user ones.
-                            if (headers.ContainsKey(key) == false)
-                                headers.Add(key, value);
+                            if (key.ToLower().StartsWith("x-secondlife"))
+                            {
+                                // Don't overwrite values.  Keeps us from clobbering
+                                // The standard X-Secondlife params with user ones.
+                                if (headers.ContainsKey(key) == false)
+                                    headers.Add(key, value);
+                            }
+                            else
+                                headers[key] = value;
                             break;
 
                         case (int)HttpRequestConstants.HTTP_PRAGMA_NO_CACHE:


### PR DESCRIPTION
- Fixed the format of the default User-Agent header for LSL scripts calling llHTTPRequest, which was not accepted at some servers, notably Shoutcast servers. They would reject calls (with a 403) from InWorldz scripts that would work unchanged in SL. Fixes Mantis 3194.
- Fixed the llHTTPRequest to allow User-Agent overrides, i.e. HTTP_CUSTOM_HEADER, "User-Agent" is now supported. (Actually it now allows any non- X-secondlife header to be overridden, although there's only one at the point this is called, unless the caller specifies the same header more than once, now the last one wins.)
- Added support for more LSL HTTP request headers: "accept", "content-length", "content-type",
"expect", "host", "date", "if-modified-since", "range", "transfer-encoding" (auto-enabling chunked sends), and "connection" (including recognizing keep-alive).
