### PR TITLE
Fixes to outgoing HTTP request headers from LSL scripts

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -13104,8 +13104,7 @@ namespace InWorldz.Phlox.Engine
             httpHeaders["X-SecondLife-Owner-Key"] = m_host.ObjectOwner.ToString();
             string userAgent = config.Configs["Network"].GetString("user_agent", null);
             if (userAgent == null)
-                userAgent = "LSL Script (Mozilla Compatible)";
-
+                userAgent = "InWorldz LSL/"+ VersionInfo.Version+ " (http://inworldz.com)";
             httpHeaders["User-Agent"] = userAgent;
 
             UUID reqId = httpScriptMod.StartHttpRequest(m_host.ParentGroup.UUID, m_localID, m_itemID, url, param, httpHeaders, body);

--- a/OpenSim/Region/CoreModules/Scripting/HttpRequest/ScriptsHttpRequests.cs
+++ b/OpenSim/Region/CoreModules/Scripting/HttpRequest/ScriptsHttpRequests.cs
@@ -296,10 +296,15 @@ namespace OpenSim.Region.CoreModules.Scripting.HttpRequest
                         case (int)HttpRequestConstants.HTTP_CUSTOM_HEADER:
                             string key = parms[i++];
                             string value = parms[i++];
-                            // Don't overwrite values.  Keeps us from clobbering
-                            // The standard X-Secondlife params with user ones.
-                            if (headers.ContainsKey(key) == false)
-                                headers.Add(key, value);
+                            if (key.ToLower().StartsWith("x-secondlife"))
+                            {
+                                // Don't overwrite values.  Keeps us from clobbering
+                                // The standard X-Secondlife params with user ones.
+                                if (headers.ContainsKey(key) == false)
+                                    headers.Add(key, value);
+                            }
+                            else
+                                headers[key] = value;
                             break;
 
                         case (int)HttpRequestConstants.HTTP_PRAGMA_NO_CACHE:

--- a/OpenSim/Region/CoreModules/Scripting/HttpRequest/ScriptsHttpRequests.cs
+++ b/OpenSim/Region/CoreModules/Scripting/HttpRequest/ScriptsHttpRequests.cs
@@ -248,6 +248,24 @@ namespace OpenSim.Region.CoreModules.Scripting.HttpRequest
             }
         }
 
+        // Called only from HTTP_CUSTOM_HEADER.
+        private bool ScriptCanChangeHeader(string key)
+        {
+            string targetKey = key.ToLower();
+
+            // Content-type must be set via HTTP_MIMETYPE
+            if (targetKey == "content-type")
+                return false;
+
+            // These are reserved for internal use only.
+            if (targetKey == "user-agent")
+                return false;
+            if (targetKey.StartsWith("x-secondlife"))
+                return false;
+
+            return true;
+        }
+
         public UUID StartHttpRequest(UUID sogId, uint localID, UUID itemID, string url, string[] parms, Dictionary<string, string> headers, string body)
         {
             //if there are already too many requests globally, reject this one
@@ -296,15 +314,19 @@ namespace OpenSim.Region.CoreModules.Scripting.HttpRequest
                         case (int)HttpRequestConstants.HTTP_CUSTOM_HEADER:
                             string key = parms[i++];
                             string value = parms[i++];
-                            if (key.ToLower().StartsWith("x-secondlife"))
+                            // The script is not allowed to override some of the headers.
+                            if (ScriptCanChangeHeader(key))
                             {
-                                // Don't overwrite values.  Keeps us from clobbering
-                                // The standard X-Secondlife params with user ones.
-                                if (headers.ContainsKey(key) == false)
+                                if (headers.ContainsKey(key))
+                                {
+                                    // In SL, duplicate headers add to the existing header after a comma+space
+                                    headers[key] += ", " + value;
+                                }
+                                else
+                                {
                                     headers.Add(key, value);
+                                }
                             }
-                            else
-                                headers[key] = value;
                             break;
 
                         case (int)HttpRequestConstants.HTTP_PRAGMA_NO_CACHE:


### PR DESCRIPTION
- Fixed the format of the User-Agent header for LSL scripts calling llHTTPRequest, which was not accepted at some servers, notably Shoutcast servers. They would reject calls (with a 403) from InWorldz scripts that would work unchanged in SL. Fixes Mantis 3194.
- Added support for more LSL HTTP request headers: "accept", "content-length", "content-type",
"expect", "host", "date", "if-modified-since", "range", "transfer-encoding" (auto-enabling chunked sends), and "connection" (including recognizing keep-alive).
- reserved headers (x-secondlife, user-agent) cannot be overridden (silently ignored)
- other headers append if already existing (custom: value1, value2)