### PR TITLE
Lsl http request headers

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -13104,7 +13104,8 @@ namespace InWorldz.Phlox.Engine
             httpHeaders["X-SecondLife-Owner-Key"] = m_host.ObjectOwner.ToString();
             string userAgent = config.Configs["Network"].GetString("user_agent", null);
             if (userAgent == null)
-                userAgent = "InWorldz LSL/"+ VersionInfo.Version+ " (http://inworldz.com)";
+                userAgent = "InWorldz LSL/"+ VersionInfo.Version+ " (Mozilla Compatible)";
+
             httpHeaders["User-Agent"] = userAgent;
 
             UUID reqId = httpScriptMod.StartHttpRequest(m_host.ParentGroup.UUID, m_localID, m_itemID, url, param, httpHeaders, body);

--- a/OpenSim/Region/CoreModules/Scripting/HttpRequest/ScriptsHttpRequests.cs
+++ b/OpenSim/Region/CoreModules/Scripting/HttpRequest/ScriptsHttpRequests.cs
@@ -258,8 +258,8 @@ namespace OpenSim.Region.CoreModules.Scripting.HttpRequest
                 return false;
 
             // These are reserved for internal use only.
-            if (targetKey == "user-agent")
-                return false;
+            // if (targetKey == "user-agent")   // SL allows appending multi-line text on the end of the URL to achieve this.
+            //    return false;                 // instead we'll just allow it normally.
             if (targetKey.StartsWith("x-secondlife"))
                 return false;
 


### PR DESCRIPTION
- Restored previous (Mozilla compatible) suffix on User-Agent" headers. The previous User-Agent change fixed some HTTP requests to Shoutcast servers, but broke others. The best combination seems to be the SL-like prefix, with "(Mozilla Compatible)" suffix.  (We probably need that for other server types anyway.)
- Disabled the blocking of User-Agent headers. i.e. allow them to be specified in custom headers, since we don't support the SL kludge of appending them to the end of the URL in a multi-line hack (and won't be, since that seems like it would be a security risk anyway).