### PR TITLE
Enabled use of AgentLimit to control region entry.

### DIFF
--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -4164,6 +4164,18 @@ namespace OpenSim.Region.Framework.Scenes
                 return false;
             }
 
+            if (SceneGraph.GetRootAgentCount() + 1 > RegionInfo.RegionSettings.AgentLimit)
+            {
+                if (RegionInfo.EstateSettings.HasAccess(agentId) == false)
+                {
+                    m_log.WarnFormat(
+                        "[SCENE]: User {0} ({1}) was denied access to the region because agent limit was reached",
+                        agentId, userName);
+                    reason = "Region is full";
+                    return false;
+                }
+            }
+
             if (IsBlacklistedUser(agentId))
             {
                 m_log.WarnFormat("[SCENE]: Denied access to: {0} ({1}) at {2} because the user is blacklisted",


### PR DESCRIPTION
There are 2 settings for agents on a region.  MaxAgents comes from the region config and is a hard limit on the region. It will deny even estate managers.  Agent Limit is settable from the viewer and until now as ignored.  This adds a check for over the AgentLimit.  It will still allow Estate Managers and anyone on the region whitelist in.  This works for cases where a club or performance group may always want its club staff or performers to get in on a crash but otherwise apply an agent limit to the region as a whole.  This checks Agent limit on region entry as described above.

Note this needs careful review.  I don't have a way in dev to test this well and it can obviously affect region entry for agents.