### PR TITLE
Fixed missing permisisons pre-check on Contents item moves

### DIFF
--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -1683,6 +1683,16 @@ namespace OpenSim.Region.Framework.Scenes
             if (taskItem == null)
                 return null;
 
+            // Either the taskItem must be copyable (copy operation), or the enclosing object must be modifyable (move operation).
+            if ((taskItem.CurrentPermissions & (uint)PermissionMask.Copy) == 0) // rules out a copy
+            {
+                if ((part.OwnerMask & (uint)PermissionMask.Modify) == 0)        // rules out a move
+                {
+                    remoteClient.SendAlertMessage("Cannot remove a no-copy item from a no-modify object.");
+                    return null;
+                }
+            }
+
             if (remoteClient == null)
             {
                 UserProfileData profile = CommsManager.UserService.GetUserProfile(AgentId);


### PR DESCRIPTION
Either the task item must be copyable (for a copy operation), or the enclosing object must be modifyable (for a move operation).  If neither of those is true, the operation now fails with "Cannot remove a no-copy item from a no-modify object."  Fixes Mantis 3192.