### PR TITLE
Fixes to position on dialog replies (button presses).

### DIFF
--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -7587,6 +7587,11 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 args.SenderUUID = this.AgentId;
                 args.DestinationUUID = UUID.Zero;
 
+                // Force avatar position to be server-known avatar position. (Former contents of FixPositionOfChatMessage.)
+                ScenePresence avatar;
+                if (((Scene)Scene).TryGetAvatar(args.SenderUUID, out avatar))
+                    args.Position = avatar.AbsolutePosition;
+
                 ChatMessage handlerChatFromClient = OnChatFromClient;
                 if (handlerChatFromClient != null)
                     handlerChatFromClient(this, args);

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
@@ -265,6 +265,11 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
             chatFromClient.SenderUUID = AgentId;
             chatFromClient.Type = sourceType;
 
+            // Force avatar position to be server-known avatar position. (Former contents of FixPositionOfChatMessage.)
+            ScenePresence avatar;
+            if (m_scene.TryGetAvatar(m_UUID, out avatar))
+                chatFromClient.Position = avatar.AbsolutePosition;
+
             OnChatFromClient(this, chatFromClient);
         }
 

--- a/OpenSim/Region/CoreModules/Avatar/Chat/ChatModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Chat/ChatModule.cs
@@ -112,22 +112,6 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
             client.OnChatFromClient += OnChatFromClient;
         }
 
-        protected OSChatMessage FixPositionOfChatMessage(OSChatMessage c)
-        {
-            if (c.SenderUUID == UUID.Zero)
-            {
-                //this is from a dialog, dont adjust the pos
-                return c;
-            }
-
-            ScenePresence avatar;
-            Scene scene = (Scene)c.Scene;
-            if (scene.TryGetAvatar(c.SenderUUID, out avatar))
-                c.Position = avatar.AbsolutePosition;
-
-            return c;
-        }
-
         private bool PrefilterChat(Object sender, OSChatMessage c)
         {
             if (c.Type != ChatTypeEnum.Say)
@@ -154,8 +138,6 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat
 
         public virtual void OnChatFromClient(Object sender, OSChatMessage c)
         {
-            c = FixPositionOfChatMessage(c);
-
             if (PrefilterChat(sender, c))
                 return;
 

--- a/OpenSim/Region/OptionalModules/Avatar/Concierge/ConciergeModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Concierge/ConciergeModule.cs
@@ -215,13 +215,17 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
             {
                 // replacing ChatModule: need to redistribute
                 // ChatFromClient to interested subscribers
-                c = FixPositionOfChatMessage(c);
 
                 Scene scene = (Scene)c.Scene;
                 scene.EventManager.TriggerOnChatFromClient(sender, c);
 
                 if (m_conciergedScenes.Contains(c.Scene))
                 {
+                    // Force avatar position to be server-known avatar position. (Former contents of FixPositionOfChatMessage.)
+                    ScenePresence avatar;
+                    if (scene.TryGetAvatar(c.SenderUUID, out avatar))
+                        c.Position = avatar.AbsolutePosition;
+
                     // when we are replacing ChatModule, we treat
                     // OnChatFromClient like OnChatBroadcast for
                     // concierged regions, effectively extending the


### PR DESCRIPTION
_ChatModule_'s function _FixPositionOfChatMessage_ was mostly hidden to the callers who specified a location for the chat to come from.  It was a dangerous override of the position being passed in and caused this regression. I have removed it, and callers are now responsible for passing in the desired chat source position, since this code doesn't know if it's from an avatar or a prim, and viewers send 0,0,0 for avatar chat source position.  Fixes Mantis 3206.