### PR TITLE
Appearance/COF version, SP/SceneView/LLCV leaks, appearance debugging

### DIFF
--- a/OpenSim/Framework/AvatarAppearance.cs
+++ b/OpenSim/Framework/AvatarAppearance.cs
@@ -50,8 +50,12 @@ namespace OpenSim.Framework
         public readonly static int TEXTURE_COUNT = 21;
         public readonly static byte[] BAKE_INDICES = new byte[] { 8, 9, 10, 11, 19, 20 };
 
-        protected UUID m_owner; 
-        protected int m_serial = 0;
+        // The viewer defines the initial/default/unknown appearance serial number (version)
+        // in LLViewerInventoryCategory, as VERSION_INITIAL=-1 and VERSION_UNKNOWN=-1 (not zero).
+        public readonly static int VERSION_INITIAL = -1;
+
+        protected UUID m_owner;
+        protected int m_serial = VERSION_INITIAL;
         protected byte[] m_visualparams;
         protected Primitive.TextureEntry m_texture;
         protected Dictionary<int, AvatarWearable> m_wearables;
@@ -130,7 +134,7 @@ namespace OpenSim.Framework
         public AvatarAppearance(UUID owner)
         {
             m_owner = owner;
-            m_serial = 0;
+            m_serial = VERSION_INITIAL;
             m_attachments = new Dictionary<int, List<AvatarAttachment>>();
             m_wearables = new Dictionary<int, AvatarWearable>();
             
@@ -151,7 +155,7 @@ namespace OpenSim.Framework
 //            m_log.WarnFormat("[AVATAR APPEARANCE] create initialized appearance");
 
             m_owner = owner;
-            m_serial = 0;
+            m_serial = VERSION_INITIAL;
             m_attachments = new Dictionary<int, List<AvatarAttachment>>();
             m_wearables = new Dictionary<int, AvatarWearable>();
 
@@ -189,7 +193,7 @@ namespace OpenSim.Framework
 
             if (appearance == null)
             {
-                m_serial = 0;
+                m_serial = VERSION_INITIAL;
                 m_owner = UUID.Zero;
                 SetDefaultWearables();
                 SetDefaultTexture();
@@ -245,7 +249,7 @@ namespace OpenSim.Framework
         public virtual void ResetAppearance()
         {
 //            m_log.WarnFormat("[AVATAR APPEARANCE]: Reset appearance");
-            m_serial = 0;
+            m_serial = VERSION_INITIAL;
             SetDefaultTexture();
         }
         

--- a/OpenSim/Framework/Communications/Services/LoginResponse.cs
+++ b/OpenSim/Framework/Communications/Services/LoginResponse.cs
@@ -165,7 +165,7 @@ namespace OpenSim.Framework.Communications.Services
             lookAt = "[r0.99949799999999999756,r0.03166859999999999814,r0]";
             RegionX = (uint) 255232;
             RegionY = (uint) 254976;
-            CofVersion = "0";
+            CofVersion = AvatarAppearance.VERSION_INITIAL.ToString();
 
             // Classifieds;
             AddClassifiedCategory((Int32) 1, "Shopping");

--- a/OpenSim/Grid/UserServer.Modules/UserLoginService.cs
+++ b/OpenSim/Grid/UserServer.Modules/UserLoginService.cs
@@ -376,7 +376,7 @@ namespace OpenSim.Grid.UserServer.Modules
                 if (appearance != null)
                 {
                     loginParams["appearance"] = appearance.ToHashTable();
-                    m_log.DebugFormat("[LOGIN]: Found appearance for {0} {1}", user.FirstName, user.SurName);
+                    m_log.DebugFormat("[LOGIN]: Found appearance version {0} for {1} {2}", appearance.Serial, user.FirstName, user.SurName);
                 }
                 else
                 {

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -730,6 +730,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 //we have to do the actual close work in another thread because otherwise
                 //this one will stay on the active jobs list and deadlock the closure
                 Util.FireAndForget(this.CloseWorker);
+                m_clientInterfaces.Clear();
             }
         }
 
@@ -8051,6 +8052,8 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                     }
 
                     uint serial = appear.AgentData.SerialNum;
+
+                    m_log.InfoFormat("[LLCV]: Avatar appearance update ({0}) for user {1}", serial, this.Name);
 
                     handlerSetAppearance(appear.ObjectData.TextureEntry, visualparams, items, serial);
                 }

--- a/OpenSim/Region/CoreModules/Avatar/AvatarFactory/AvatarFactoryModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/AvatarFactory/AvatarFactoryModule.cs
@@ -546,9 +546,10 @@ namespace OpenSim.Region.CoreModules.Avatar.AvatarFactory
             CachedUserInfo profile = m_scene.CommsManager.UserService.GetUserDetails(clientView.AgentId);
             if (profile != null)
             {
-                // we need to clean out the existing textures
                 AvatarAppearance appearance = avatar.Appearance;
-                avatar.Appearance.ResetAppearance();
+
+                // we need to clean out the existing textures
+                appearance.Texture = AvatarAppearance.GetDefaultTexture();
 
                 List<AvatarWearable> wearables = new List<AvatarWearable>();
                 lock (_currentlyWaitingCOFBuilds)

--- a/OpenSim/Region/CoreModules/Avatar/AvatarFactory/AvatarFactoryModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/AvatarFactory/AvatarFactoryModule.cs
@@ -657,6 +657,7 @@ namespace OpenSim.Region.CoreModules.Avatar.AvatarFactory
         {
             lock (_pendingUpdates)
             {
+                // m_log.InfoFormat("[LLCV]: Avatar database update ({0}) queued for user {1}", appearance.Serial, user);
                 if (_pendingUpdates.ContainsKey(user))
                 {
                     _pendingUpdates.Remove(user);
@@ -731,6 +732,7 @@ namespace OpenSim.Region.CoreModules.Avatar.AvatarFactory
                 {
                     if (upd.CallBack != null) 
                         upd.CallBack();
+                    m_log.InfoFormat("[LLCV]: Avatar database update ({0}) committing for user {1}", upd.Appearance.Serial, upd.UserId);
                     m_scene.CommsManager.AvatarService.UpdateUserAppearance(upd.UserId, upd.Appearance);
                     if (upd.BakedTextures != null && upd.BakedTextures.Count > 0)
                         m_scene.CommsManager.AvatarService.SetCachedBakedTextures(upd.BakedTextures);

--- a/OpenSim/Region/Framework/Scenes/AvatarRemotePresences.cs
+++ b/OpenSim/Region/Framework/Scenes/AvatarRemotePresences.cs
@@ -169,6 +169,8 @@ namespace OpenSim.Region.Framework.Scenes
 
             StopManagingPresences();
 
+            _sp = null; // release the SP reference
+
             _scene.EventManager.OnMakeRootAgent -= EventManager_OnMakeRootAgent;
             _scene.EventManager.OnMakeChildAgent -= EventManager_OnMakeChildAgent;
         }

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -4393,15 +4393,19 @@ namespace OpenSim.Region.Framework.Scenes
         public void Close()
         {
             m_remotePresences.OnScenePresenceClosed();
+            m_remotePresences = null;
 
             List<SceneObjectGroup> attList = GetAttachments();
 
             // Save and Delete attachments from scene only if we're a root and not a bot
-            if ((!IsChildAgent) && (!IsBot))
+            if (!IsChildAgent)
             {
                 foreach (SceneObjectGroup grp in attList)
                 {
-                    m_scene.SaveAndDeleteAttachment(null, grp, grp.GetFromItemID(), grp.OwnerID);
+                    if (IsBot)
+                        m_scene.DeleteAttachment(grp);
+                    else
+                        m_scene.SaveAndDeleteAttachment(null, grp, grp.GetFromItemID(), grp.OwnerID);
                 }
             }
 
@@ -4419,6 +4423,8 @@ namespace OpenSim.Region.Framework.Scenes
 
             ClearSceneView();
             SceneView.ClearAllTracking();
+            m_sceneView = null; // free the reference
+            m_controllingClient = null;
         }
 
         /// <summary>
@@ -4623,8 +4629,6 @@ namespace OpenSim.Region.Framework.Scenes
             m_controllingClient = client;
             m_regionInfo = region;
             m_scene = scene;
-
-            RegisterToEvents();
         }
 
         internal void AddForce(OpenMetaverse.Vector3 force, ForceType ftype)

--- a/ThirdParty/SmartThreadPool/SmartThreadPool.cs
+++ b/ThirdParty/SmartThreadPool/SmartThreadPool.cs
@@ -517,8 +517,8 @@ namespace Amib.Threading
             _localPCs.SampleWorkItems(_workItemsQueue.Count, _workItemsProcessed);
 
 			int count = Interlocked.Increment(ref _currentWorkItemsCount);
-			//Trace.WriteLine("WorkItemsCount = " + _currentWorkItemsCount.ToString());
-			if (count == 1) 
+            // Trace.WriteLine(this.Name+": WorkItems count++ = " + _currentWorkItemsCount.ToString());
+            if (count == 1) 
 			{
                 IsIdle = false;
                 _isIdleWaitHandle.Reset();
@@ -528,7 +528,7 @@ namespace Amib.Threading
 		private void DecrementWorkItemsCount()
 		{
             int count = Interlocked.Decrement(ref _currentWorkItemsCount);
-            //Trace.WriteLine("WorkItemsCount = " + _currentWorkItemsCount.ToString());
+            // Trace.WriteLine(this.Name+": WorkItems count-- = " + _currentWorkItemsCount.ToString());
             if (count == 0)
             {
                 IsIdle = true;
@@ -769,9 +769,9 @@ namespace Amib.Threading
 						// WorkItemsGroup may enqueue their next work item.
 						workItem.FireWorkItemCompleted();
 
-						// Decrement the number of work items here so the idle 
-						// ManualResetEvent won't fluctuate.
-						DecrementWorkItemsCount();
+                        // Decrement the number of work items here so the idle 
+                        // ManualResetEvent won't fluctuate.
+                        DecrementWorkItemsCount();
 					}
 				}
 			} 


### PR DESCRIPTION
- Fixed initial/default appearance serial/version to be -1 like viewer expects. The viewer defines the initial/default/unknown appearance serial number (version) in LLViewerInventoryCategory, as VERSION_INITIAL=-1 and VERSION_UNKNOWN=-1 (not zero).
- Avoid resetting COF version (appearance.Serial) back to 0. Cleaning out existing textures (resetting them back to defaults) was doing more than changing the textures.

Interim results of investigating leaks and appearance:
- Fixed a serious problem with bots sometimes not actually deleting
attachments when removed (DeleteAttachment not called).
- Several references were not being cleared in Close() methods, holding
references and prolonging object memory leakage.
- Fixed a case where ScenePresence event handers were added twice.
- Several existing log messages improved.
- Some additional log messages to help us diagnose appearance Mantis
3162.