### PR TITLE
Implemented llDetectedGrab (Mantis 2544)

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/EngineInterface.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/EngineInterface.cs
@@ -488,7 +488,7 @@ namespace InWorldz.Phlox.Engine
         {
             return new VM.DetectVariables
             {
-                Grab = new Vector3(),
+                Grab = parm.OffsetPos,
                 Key = parm.Key.ToString(),
                 BotID = parm.BotID.ToString(),
                 Group = parm.Group.ToString(),

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -94,6 +94,8 @@ namespace OpenSim.Region.ClientStack.LindenUDP
 
         private bool _receivedCompleteAgentMovement = false;
 
+        private Vector3 m_grabStartPos = Vector3.Zero;
+
         private class AvatarUpdateComparer : IEqualityComparer<ImprovedTerseObjectUpdatePacket.ObjectDataBlock>
         {
             #region IEqualityComparer<ObjectDataBlock> Members
@@ -7499,6 +7501,8 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             }
             #endregion
 
+            m_grabStartPos = Vector3.Zero;  // grab no longer active
+
             DeGrabObject handlerDeGrabObject = OnDeGrabObject;
             if (handlerDeGrabObject != null)
             {
@@ -9100,6 +9104,9 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                         arg.STCoord = surfaceInfo.STCoord;
                         arg.UVCoord = surfaceInfo.UVCoord;
                         touchArgs.Add(arg);
+
+                        // Store the start of grab position for relative offsets from future updates (llDetectedGrab).
+                        this.m_grabStartPos = surfaceInfo.Position;
                     }
                 }
                 handlerGrabObject(grab.ObjectData.LocalID, grab.ObjectData.GrabOffset, this, touchArgs);
@@ -9141,49 +9148,11 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                         touchArgs.Add(arg);
                     }
                 }
-                handlerGrabUpdate(grabUpdate.ObjectData.ObjectID, grabUpdate.ObjectData.GrabOffsetInitial,
+                handlerGrabUpdate(grabUpdate.ObjectData.ObjectID, m_grabStartPos,
                                   grabUpdate.ObjectData.GrabPosition, this, touchArgs);
             }
             return true;
         }
-
-        /*
-        private bool HandleObjectDeGrab(IClientAPI sender, Packet Pack)
-        {
-            ObjectDeGrabPacket deGrab = (ObjectDeGrabPacket)Pack;
-
-            #region Packet Session and User Check
-            if (m_checkPackets)
-            {
-                if (deGrab.AgentData.SessionID != SessionId ||
-                    deGrab.AgentData.AgentID != AgentId)
-                    return true;
-            }
-            #endregion
-
-            DeGrabObject handlerDeGrabObject = OnDeGrabObject;
-            if (handlerDeGrabObject != null)
-            {
-                List<SurfaceTouchEventArgs> touchArgs = new List<SurfaceTouchEventArgs>();
-                if ((deGrab.SurfaceInfo != null) && (deGrab.SurfaceInfo.Length > 0))
-                {
-                    foreach (ObjectDeGrabPacket.SurfaceInfoBlock surfaceInfo in deGrab.SurfaceInfo)
-                    {
-                        SurfaceTouchEventArgs arg = new SurfaceTouchEventArgs();
-                        arg.Binormal = surfaceInfo.Binormal;
-                        arg.FaceIndex = surfaceInfo.FaceIndex;
-                        arg.Normal = surfaceInfo.Normal;
-                        arg.Position = surfaceInfo.Position;
-                        arg.STCoord = surfaceInfo.STCoord;
-                        arg.UVCoord = surfaceInfo.UVCoord;
-                        touchArgs.Add(arg);
-                    }
-                }
-                handlerDeGrabObject(deGrab.ObjectData.LocalID, this, touchArgs);
-           }
-            return true;
-        }
-        */
 
         private bool HandleObjectSpinStart(IClientAPI sender, Packet Pack)
         {

--- a/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
@@ -765,7 +765,7 @@ namespace OpenSim.Region.Framework.Scenes
             return CheckFolderHeirarchyIsAppropriateForPurge(parent, userProfile);
         }
 
-        protected void GrabUpdate(UUID objectID, Vector3 offset, Vector3 pos, IClientAPI remoteClient, List<SurfaceTouchEventArgs> surfaceArgs)
+        protected void GrabUpdate(UUID objectID, Vector3 startPos, Vector3 pos, IClientAPI remoteClient, List<SurfaceTouchEventArgs> surfaceArgs)
         {
             SceneObjectGroup group = m_sceneGraph.GetGroupByPrim(objectID);
             if (group != null)
@@ -775,24 +775,31 @@ namespace OpenSim.Region.Framework.Scenes
                 if (part != null)
                 {
                     SurfaceTouchEventArgs surfaceArg = null;
+                    Vector3 grabOffset = Vector3.Zero;
                     if (surfaceArgs != null && surfaceArgs.Count > 0)
+                    {
                         surfaceArg = surfaceArgs[0];
+                        if (surfaceArg.FaceIndex >= 0)
+                            grabOffset = surfaceArg.Position - startPos;
+                        else
+                            grabOffset = pos - startPos;
+                    }
 
                     // If the touched prim handles touches, deliver it
                     // If not, deliver to root prim,if the root prim doesnt
                     // handle it, deliver a grab to the scene graph
                     if ((part.ScriptEvents & ScriptEvents.touch) != 0)
                     {
-                        EventManager.TriggerObjectGrabUpdate(part.LocalId, 0, part.OffsetPosition, remoteClient, surfaceArg);
+                        EventManager.TriggerObjectGrabUpdate(part.LocalId, 0, grabOffset, remoteClient, surfaceArg);
                     }
                     else if ((group.RootPart.ScriptEvents & ScriptEvents.touch) != 0)
                     {
-                        EventManager.TriggerObjectGrabUpdate(group.RootPart.LocalId, part.LocalId, part.OffsetPosition, remoteClient, surfaceArg);
+                        EventManager.TriggerObjectGrabUpdate(group.RootPart.LocalId, part.LocalId, grabOffset, remoteClient, surfaceArg);
                     }
                     else
                     {
                         //no one can handle it, send a grab
-                        m_sceneGraph.MoveObject(objectID, offset, pos, remoteClient, surfaceArgs);
+                        m_sceneGraph.MoveObject(objectID, startPos, pos, remoteClient, surfaceArgs);
                     }
                 }
                 


### PR DESCRIPTION
- The ObjectData.GrabOffsetInitial field coming from the viewer was
always 0,0,0 and yet llDetectedGrab works in SL without it.  Looks like
a protocol design feature never implemented (or broken in the viewer and
never fixed).
- We now do what I'm assuming SL developers had to do; we store the
initial grab position on the ObjectGrab packet and use the saved one
from there on ObjectGrabUpdate.
- Mapped the unused Phlox VM.DetectVariables.Grab to the unused
parm.OffsetPos and ensure that is initialized from the saved startpos
from the grab.
- [No effective change] Removed the unused and commented-out version of
HandleObjectDeGrab to avoid confusion with the one in use.