### PR TITLE
Fixes to ensure region backups are made, fixes "(RSF) Rookery" problem.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,4 @@ bin4
 *.oar
 bin/blacklist.old
 bin/blacklist.txt
+*.oarstatus

--- a/OpenSim/Region/Framework/Scenes/SceneManager.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneManager.cs
@@ -993,7 +993,11 @@ namespace OpenSim.Region.Framework.Scenes
         {
             Scene targetScene = this.FindSceneByName(regionName);
 
-            if (targetScene == null) throw new Exception(String.Format("Region {0} was not found", regionName));
+            if (targetScene == null)
+            {
+                targetScene = CurrentOrFirstScene;
+                m_log.ErrorFormat("Region '{0}' was not found for OAR save - assuming '{1}'.", regionName, targetScene.RegionInfo.RegionName);
+            }
 
             if (!HasScriptEngine(targetScene))
                 m_log.Warn("[SCENE]: Warning: Script engine disabled. No script states will be saved in OAR file.");
@@ -1037,16 +1041,8 @@ namespace OpenSim.Region.Framework.Scenes
         public Scene FindSceneByName(string name)
         {
             Scene targetScene = null;
-            this.ForEachScene(
-                delegate(Scene scene)
-                {
-                    if (scene.RegionInfo.RegionName == name)
-                    {
-                        targetScene = scene;
-                    }
-                }
-            );
-
+            if (!TryGetScene(name, out targetScene))
+                return null;
             return targetScene;
         }
     }


### PR DESCRIPTION
- If the specified region cannot be found, instead of throwing an exception, report the error but default to the actual current region/scene so that a backup is done.
- Fixed case-sensitive region name compares by replacing most of FindSceneByName with the usual TryGetScene function.
- Added *.oarstatus to gitignores