### PR TITLE
Git sucketh greatly

### DIFF
--- a/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
+++ b/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
@@ -351,10 +351,6 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// </summary>
         public void SendInitialFullUpdateToAllClients()
         {
-            //Bots don't get to check for updates
-            if (m_presence.IsBot)
-                return;
-
             m_perfMonMS = Environment.TickCount;
 
             List<ScenePresence> avatars = m_presence.Scene.GetScenePresences();

--- a/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
+++ b/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
@@ -414,10 +414,6 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
         /// </summary>
         public void SendFullUpdateToAllClients()
         {
-            //Bots don't get to check for updates
-            if (m_presence.IsBot)
-                return;
-
             m_perfMonMS = Environment.TickCount;
 
             // only send update from root agents to other clients; children are only "listening posts"


### PR DESCRIPTION
Cherry-picked the two commits that Git just up and decided to NOT INCLUDE during the merge of PR #197.  In theory there should be not differences from master since this is already merged. But apparently there is, and I've learned my lesson to always sacrifice a chicken and stand on one leg when doing a commit.

Fixes Mantis 3213 which _should_ never have happened because it was fixed _before_ the release. Passed the gatekeeper but not the gitkeeper.