### PR TITLE
Fixes to inconsistent ownership after in-world copies

### DIFF
--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -5629,27 +5629,7 @@ namespace OpenSim.Region.Framework.Scenes
                 return false;
             }
 
-            group.SetOwnerId(newOwner.AgentId);
-            group.SetRootPartOwner(part, newOwner.AgentId,
-                    newOwner.ActiveGroupId);
-
-            var partList = group.GetParts();
-
-            if (Permissions.PropagatePermissions())
-            {
-                foreach (SceneObjectPart child in partList)
-                {
-                    child.Inventory.ChangeInventoryOwner(newOwner.AgentId);
-                    child.ApplyNextOwnerPermissions();
-                }
-            }
-
-            group.Rationalize(newOwner.AgentId, false);
-            group.HasGroupChanged = true;
-            group.RezzedFromFolderId = UUID.Zero;
-            InspectForAutoReturn(group);
-            part.GetProperties(newOwner);
-            part.ScheduleFullUpdate(PrimUpdateFlags.ForcedFullUpdate);
+            group.ChangeOwner(newOwner);
             return true;
         }
 


### PR DESCRIPTION
Fixes to the problem Manwa reported in
http://inworldz.com/forums/viewtopic.php?f=17&t=22555
- fixed object duplication via friend edit to ensure the owner of
TaskInventory items is also updated, and next owner permissions applied.
- fixed SetRootPartOwner to recognize owner changes
- added ChangeOwner methods right inside SOG that can be called on
in-world objects
- ObjectDuplicate now creates a copy of the original and then applies
the new owner using the new common ChangeOwner method
- Scene's ChangeLiveSOGOwner mostly replaced with the new
SOG.ChangeOwner method.