### PR TITLE
Added PurgeEmptyFolder for InvScanner tool use

### DIFF
--- a/InWorldz/InWorldz.Data.Inventory.Cassandra/LegacyMysqlInventoryStorage.cs
+++ b/InWorldz/InWorldz.Data.Inventory.Cassandra/LegacyMysqlInventoryStorage.cs
@@ -176,6 +176,11 @@ namespace InWorldz.Data.Inventory.Cassandra
             _impl.deleteInventoryFolder(folder);
         }
 
+        public void PurgeEmptyFolder(InventoryFolderBase folder)
+        {
+            PurgeFolder(folder);    // no optimization for this in the legacy implementation
+        }
+
         public void PurgeFolders(IEnumerable<InventoryFolderBase> folders)
         {
             foreach (InventoryFolderBase folder in folders)

--- a/OpenSim/Data/IInventoryStorage.cs
+++ b/OpenSim/Data/IInventoryStorage.cs
@@ -117,6 +117,13 @@ namespace OpenSim.Data
         void PurgeFolder(InventoryFolderBase folder);
 
         /// <summary>
+        /// Removes (deletes) a folder that is KNOWN to be empty.
+        /// Caller must ensure it is already empty: no items or subfolders.
+        /// </summary>
+        /// <param name="folder">The folder to purge</param>
+        void PurgeEmptyFolder(InventoryFolderBase folder);
+
+        /// <summary>
         /// Purges all subfolders and items from the specified folders and then removes the folders
         /// </summary>
         /// <param name="folder">The folder to purge</param>


### PR DESCRIPTION
Assumes caller knows the folder is empty.  This is a variation on the PurgeFolderInternal code but with the code related to having a subtree removed. Optimized use by the InvScanner tool's -delete-empty option.