### PR TITLE
Fix dependency issue on InWorldz.Testing

### DIFF
--- a/prebuild.xml
+++ b/prebuild.xml
@@ -2370,6 +2370,8 @@
       <Reference name="OpenSim.Region.Framework"/>
       <Reference name="OpenSim.Region.Interfaces"/>
       <Reference name="OpenSim.Framework.Servers.HttpServer"/>
+      <Reference name="OpenSim.Region.ScriptEngine.Interfaces"/>
+      <Reference name="OpenSim.Region.ScriptEngine.Shared"/>
       <!--
       <Reference name="Microsoft.JScript"/>
       -->


### PR DESCRIPTION
Fix dependency issue on InWorldz.Testing.  Needed additional dependencies into the ScriptEngine due to new MockScriptEngine class.  Not sure why this was working on my branch unless VisualStudio was being helpful and updating csproj files with the missing dependencies (I have ReSharper installed and it may very well do that).  Tested with a fresh checkout and build but it would be worth trying this before a merge,