### PR TITLE
Exit code differentiation between "restart me" and "don't restart me"

### DIFF
--- a/InWorldz/Halcyon/Application.cs
+++ b/InWorldz/Halcyon/Application.cs
@@ -65,6 +65,9 @@ namespace OpenSim
         //could move our main function into OpenSimMain and kill this class
         public static void Main(string[] args)
         {
+            // Under any circumstance other than an explicit exit the exit code should be 1.
+            Environment.ExitCode = 1;
+
             // First line, hook the appdomain to the crash reporter
             AppDomain.CurrentDomain.UnhandledException +=
                 new UnhandledExceptionEventHandler(CurrentDomain_UnhandledException);

--- a/OpenSim/Base/OpenSim.cs
+++ b/OpenSim/Base/OpenSim.cs
@@ -778,8 +778,8 @@ namespace OpenSim
 
                 case "restart":
                     // Let's issue a full server shutdown and let the management tools take care of the restart.
-                    // Use a status of 100 to indicate that this "error" is an explicit restart not a real error.
-                    Shutdown(100);
+                    // Use a status of 63 (0b00111111) to indicate that this "error" is an explicit restart request and not a real error.
+                    Shutdown(63);
                     break;
 
                 case "predecode-j2k":

--- a/OpenSim/Base/OpenSim.cs
+++ b/OpenSim/Base/OpenSim.cs
@@ -777,7 +777,9 @@ namespace OpenSim
                     break;
 
                 case "restart":
-                    m_sceneManager.RestartCurrentScene();
+                    // Let's issue a full server shutdown and let the management tools take care of the restart.
+                    // Use a status of 100 to indicate that this "error" is an explicit restart not a real error.
+                    Shutdown(100);
                     break;
 
                 case "predecode-j2k":

--- a/OpenSim/Framework/Servers/BaseOpenSimServer.cs
+++ b/OpenSim/Framework/Servers/BaseOpenSimServer.cs
@@ -311,7 +311,8 @@ namespace OpenSim.Framework.Servers
         /// </summary>      
         public virtual void Shutdown()
         {
-            Shutdown(0);
+            // Use a status of 64 (0b01000000) to indicate that this "error" is an explicit shutdown and not a real error.
+            Shutdown(64);
         }
 
         /// <summary>

--- a/OpenSim/Framework/Servers/BaseOpenSimServer.cs
+++ b/OpenSim/Framework/Servers/BaseOpenSimServer.cs
@@ -311,12 +311,21 @@ namespace OpenSim.Framework.Servers
         /// </summary>      
         public virtual void Shutdown()
         {
+            Shutdown(0);
+        }
+
+        /// <summary>
+        /// Shutdown the server with the specified exit code.
+        /// </summary>
+        /// <param name="exitCode">The exit code to be returned once shutdown has completed.</param>
+        public void Shutdown(int exitCode)
+        {
             ShutdownSpecific();
-            
+
             m_log.Info("[SHUTDOWN]: Shutdown processing on main thread complete.  Exiting...");
             RemovePIDFile();
-            
-            Environment.Exit(0);
+
+            Environment.Exit(exitCode);
         }
 
         private void HandleQuit(string module, string[] args)

--- a/OpenSim/Grid/GridServer/GridServerBase.cs
+++ b/OpenSim/Grid/GridServer/GridServerBase.cs
@@ -115,7 +115,7 @@ namespace OpenSim.Grid.GridServer
                     System.Threading.Thread.Sleep(delay * 1000);
 
                 // Do this on a new thread so the actual shutdown call returns successfully.
-                Task.Factory.StartNew(() => Shutdown());
+                Task.Factory.StartNew(Shutdown);
             }
             catch (Exception e)
             {

--- a/OpenSim/Grid/GridServer/Program.cs
+++ b/OpenSim/Grid/GridServer/Program.cs
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
 using System.Net;
 using log4net.Config;
 
@@ -34,6 +35,9 @@ namespace OpenSim.Grid.GridServer
     {
         public static void Main(string[] args)
         {
+            // Under any circumstance other than an explicit exit the exit code should be 1.
+            Environment.ExitCode = 1;
+
             ServicePointManager.DefaultConnectionLimit = 12;
 
             XmlConfigurator.Configure();

--- a/OpenSim/Grid/MessagingServer/Main.cs
+++ b/OpenSim/Grid/MessagingServer/Main.cs
@@ -159,7 +159,7 @@ namespace OpenSim.Grid.MessagingServer
                     System.Threading.Thread.Sleep(delay * 1000);
 
                 // Do this on a new thread so the actual shutdown call returns successfully.
-                Task.Factory.StartNew(() => Shutdown());
+                Task.Factory.StartNew(Shutdown);
             }
             catch (Exception e)
             {

--- a/OpenSim/Grid/MessagingServer/Main.cs
+++ b/OpenSim/Grid/MessagingServer/Main.cs
@@ -65,6 +65,9 @@ namespace OpenSim.Grid.MessagingServer
 
         public static void Main(string[] args)
         {
+            // Under any circumstance other than an explicit exit the exit code should be 1.
+            Environment.ExitCode = 1;
+
             ServicePointManager.DefaultConnectionLimit = 12;
 
             XmlConfigurator.Configure();

--- a/OpenSim/Grid/UserServer/Main.cs
+++ b/OpenSim/Grid/UserServer/Main.cs
@@ -80,6 +80,9 @@ namespace OpenSim.Grid.UserServer
 
         public static void Main(string[] args)
         {
+            // Under any circumstance other than an explicit exit the exit code should be 1.
+            Environment.ExitCode = 1;
+
             ServicePointManager.DefaultConnectionLimit = 12;
 
             PIDFileManager pidFile = new PIDFileManager();

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -998,7 +998,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// Given float seconds, this will restart the region.
         /// </summary>
         /// <param name="seconds">float indicating duration before restart.</param>
-        public virtual void Restart(int seconds)
+        public override void Restart(int seconds)
         {
             // RestartNow() does immediate restarting.
             if (seconds == -1)
@@ -1059,16 +1059,17 @@ namespace OpenSim.Region.Framework.Scenes
 
         public void SetSceneCoreDebug(bool ScriptEngine, bool CollisionEvents, bool PhysicsEngine)
         {
-            if (m_scripts_enabled != !ScriptEngine)
+            if (m_scripts_enabled == ScriptEngine)
             {
                 if (ScriptEngine)
                 {
                     m_log.Info("Stopping all Scripts in Scene");
                     foreach (EntityBase ent in Entities)
                     {
-                        if (ent is SceneObjectGroup)
+                        var sceneObjectGroup = ent as SceneObjectGroup;
+                        if (sceneObjectGroup != null)
                         {
-                            ((SceneObjectGroup) ent).RemoveScriptInstances();
+                            sceneObjectGroup.RemoveScriptInstances();
                         }
                     }
                 }

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -1052,9 +1052,9 @@ namespace OpenSim.Region.Framework.Scenes
         // This causes the region to restart immediatley.
         public void RestartNow()
         {
-            // Let's issue a full server shutdown and let ZooKeeper take care of the restart.
-            m_log.Error("[REGION]: Firing Region Shutdown Command");
-            MainConsole.Instance.RunCommand("shutdown");
+            // Let's issue a full server restart request.
+            m_log.Error("[REGION]: Firing Region Restart Command");
+            MainConsole.Instance.RunCommand("restart");
         }
 
         public void SetSceneCoreDebug(bool ScriptEngine, bool CollisionEvents, bool PhysicsEngine)


### PR DESCRIPTION
Now crashes are exit code 1, restarts from any source are exit code 100, and ONLY an explicit shutdown is exit code 0.
