### PR TITLE
Crossplatform remote access API authentication

### DIFF
--- a/InWorldz/InWorldz.RemoteAdmin/RemoteAdmin.cs
+++ b/InWorldz/InWorldz.RemoteAdmin/RemoteAdmin.cs
@@ -165,12 +165,15 @@ namespace InWorldz.RemoteAdmin
             return response;
         }
 
-        public void CheckSessionValid(UUID sessionid)
+        public void CheckSessionValid(UUID sessionid, string remoteClientIPAndPort = "REMOTE ADDRESS NOT SET")
         {
             lock (m_activeSessions)
             {
                 if (!m_activeSessions.ContainsKey(sessionid))
+                {
+                    m_log.WarnFormat("[RADMIN]: Attempted access with invalid session ID from {0}", remoteClientIPAndPort);
                     throw new Exception("SESSION_INVALID");
+                }
                 m_activeSessions[sessionid] = DateTime.Now;
             }
         }
@@ -225,6 +228,7 @@ namespace InWorldz.RemoteAdmin
             }
             else
             {
+                m_log.WarnFormat("[RADMIN]: Attempted access with invalid username or password from {0}", remoteClient);
                 throw new Exception("Invalid Username or Password");
             }
 
@@ -240,18 +244,19 @@ namespace InWorldz.RemoteAdmin
                 if (m_activeSessions.ContainsKey(sessionId))
                 {
                     m_activeSessions.Remove(sessionId);
-                    return (true);
+                    return true;
                 }
                 else
                 {
-                    return (false);
+                    m_log.WarnFormat("[RADMIN]: Attempted logout with invalid session ID from {0}", remoteClient);
+                    return false;
                 }
             }
         }
 
         private object ConsoleCommandHandler(IList args, IPEndPoint client)
         {
-            CheckSessionValid(new UUID((string)args[0]));
+            CheckSessionValid(new UUID((string)args[0]), client.ToString());
 
             string command = (string)args[1];
             MainConsole.Instance.RunCommand(command);

--- a/InWorldz/InWorldz.RemoteAdmin/RemoteAdminPlugin.cs
+++ b/InWorldz/InWorldz.RemoteAdmin/RemoteAdminPlugin.cs
@@ -90,7 +90,12 @@ namespace InWorldz.RemoteAdmin
         public void Initialize(OpenSimBase openSim)
         {
             m_app = openSim;
-            m_admin = new RemoteAdmin();
+
+            IConfig netConfig = openSim.ConfigSource.Source.Configs["Network"];
+            if (netConfig == null)
+                m_admin = new RemoteAdmin("", "");
+            else
+                m_admin = new RemoteAdmin(netConfig.GetString("RemoteAccessHash", String.Empty), netConfig.GetString("RemoteAccessSalt", String.Empty));
         }
 
         public void PostInitialize()
@@ -104,7 +109,7 @@ namespace InWorldz.RemoteAdmin
             m_admin.AddCommand("Region", "SaveOAR", SaveOARHandler);
             m_admin.AddCommand("Region", "ChangeParcelFlags", RegionChangeParcelFlagsHandler);
 
-            m_admin.AddHandler(MainServer.Instance);    
+            m_admin.AddHandler(MainServer.Instance);
         }
 
         public void Dispose()

--- a/InWorldz/InWorldz.RemoteAdmin/RemoteAdminPlugin.cs
+++ b/InWorldz/InWorldz.RemoteAdmin/RemoteAdminPlugin.cs
@@ -121,7 +121,7 @@ namespace InWorldz.RemoteAdmin
 
         private object RegionRestartHandler(IList args, IPEndPoint remoteClient)
         {
-            m_admin.CheckSessionValid(new UUID((string)args[0]));
+            m_admin.CheckSessionValid(new UUID((string)args[0]), remoteClient.ToString());
 
             UUID regionID = new UUID((string)args[1]);
             Scene rebootedScene;
@@ -135,7 +135,7 @@ namespace InWorldz.RemoteAdmin
 
         public object RegionShutdownHandler(IList args, IPEndPoint remoteClient)
         {
-            m_admin.CheckSessionValid(new UUID((string)args[0]));
+            m_admin.CheckSessionValid(new UUID((string)args[0]), remoteClient.ToString());
 
             try
             {
@@ -222,7 +222,7 @@ namespace InWorldz.RemoteAdmin
         
         public object RegionSendAlertHandler(IList args, IPEndPoint remoteClient)
         {
-            m_admin.CheckSessionValid(new UUID((string)args[0]));
+            m_admin.CheckSessionValid(new UUID((string)args[0]), remoteClient.ToString());
 
             if (args.Count < 3)
                 return false;
@@ -264,7 +264,7 @@ namespace InWorldz.RemoteAdmin
         /// </remarks>
         public object LoadOARHandler(IList args, IPEndPoint remoteClient)
         {
-            m_admin.CheckSessionValid(new UUID((string)args[0]));
+            m_admin.CheckSessionValid(new UUID((string)args[0]), remoteClient.ToString());
 
             Scene scene;
             if (!m_app.SceneManager.TryGetScene((string)args[1], out scene))
@@ -324,7 +324,7 @@ namespace InWorldz.RemoteAdmin
         /// </remarks>
         public object SaveOARHandler(IList args, IPEndPoint remoteClient)
         {
-            m_admin.CheckSessionValid(new UUID((string)args[0]));
+            m_admin.CheckSessionValid(new UUID((string)args[0]), remoteClient.ToString());
 
             Scene scene;
             if (!m_app.SceneManager.TryGetScene((string)args[1], out scene))
@@ -383,7 +383,7 @@ namespace InWorldz.RemoteAdmin
         /// </remarks>
         public object RegionBackupHandler(IList args, IPEndPoint remoteClient)
         {
-            m_admin.CheckSessionValid(new UUID((string)args[0]));
+            m_admin.CheckSessionValid(new UUID((string)args[0]), remoteClient.ToString());
 
             String regionName = (string)args[1];
             String filename = (string)args[2];
@@ -433,7 +433,7 @@ namespace InWorldz.RemoteAdmin
         /// </remarks>
         public object RegionRestoreHandler(IList args, IPEndPoint remoteClient)
         {
-            m_admin.CheckSessionValid(new UUID((string)args[0]));
+            m_admin.CheckSessionValid(new UUID((string)args[0]), remoteClient.ToString());
 
             Scene scene;
             if (!m_app.SceneManager.TryGetScene((string)args[1], out scene))
@@ -473,7 +473,7 @@ namespace InWorldz.RemoteAdmin
         /// <summary>
         public object RegionChangeParcelFlagsHandler(IList args, IPEndPoint remoteClient)
         {
-            m_admin.CheckSessionValid(new UUID((string)args[0]));
+            m_admin.CheckSessionValid(new UUID((string)args[0]), remoteClient.ToString());
 
             Scene scene;
             if (!m_app.SceneManager.TryGetScene((string)args[1], out scene))

--- a/OpenSim/Framework/GridConfig.cs
+++ b/OpenSim/Framework/GridConfig.cs
@@ -46,6 +46,22 @@ namespace OpenSim.Framework
         public string UserRecvKey = String.Empty;
         public string UserSendKey = String.Empty;
 
+        private string m_remoteAccessHash = String.Empty;
+        public string RemoteAccessHash
+        {
+            get {
+                return m_remoteAccessHash;
+            }
+        }
+
+        private string m_remoteAccessSalt = String.Empty;
+        public string RemoteAccessSalt
+        {
+            get {
+                return m_remoteAccessSalt;
+            }
+        }
+
         public GridConfig(string description, string filename)
         {
             m_configMember =
@@ -88,13 +104,18 @@ namespace OpenSim.Framework
 
             m_configMember.addConfigurationOption("allow_forceful_banlines",
                                                 ConfigurationOption.ConfigurationTypes.TYPE_STRING,
-                                                "Allow Forceful Banlines", "TRUE", true);   
+                                                "Allow Forceful Banlines", "TRUE", true);
             
             m_configMember.addConfigurationOption("allow_region_registration", 
                                                 ConfigurationOption.ConfigurationTypes.TYPE_BOOLEAN,
                                                 "Allow regions to register immediately upon grid server startup? true/false", 
                                                 "True", 
-                                                false);            
+                                                false);
+
+            m_configMember.addConfigurationOption("remote_access_salt", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                "The salt for the hash of the remote access code.", "", true);
+            m_configMember.addConfigurationOption("remote_access_hash", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                "The salted SHA-256 hash of the remote access code. SHA256(remote_access_salt + passcode)", "", true);
         }
 
         public bool handleIncomingConfiguration(string configuration_key, object configuration_result)
@@ -139,7 +160,13 @@ namespace OpenSim.Framework
                     break;
                 case "allow_region_registration":
                     AllowRegionRegistration = (bool)configuration_result;
-                    break;                
+                    break;
+                case "remote_access_salt":
+                    m_remoteAccessSalt = (string)configuration_result;
+                    break;
+                case "remote_access_hash":
+                    m_remoteAccessHash = (string)configuration_result;
+                    break;
             }
 
             return true;

--- a/OpenSim/Framework/MessageServerConfig.cs
+++ b/OpenSim/Framework/MessageServerConfig.cs
@@ -47,6 +47,22 @@ namespace OpenSim.Framework
         public string UserSendKey = String.Empty;
         public string UserServerURL = String.Empty;
 
+        private string m_remoteAccessHash = String.Empty;
+        public string RemoteAccessHash
+        {
+            get {
+                return m_remoteAccessHash;
+            }
+        }
+
+        private string m_remoteAccessSalt = String.Empty;
+        public string RemoteAccessSalt
+        {
+            get {
+                return m_remoteAccessSalt;
+            }
+        }
+
         public MessageServerConfig(string description, string filename)
         {
             m_configMember =
@@ -88,6 +104,11 @@ namespace OpenSim.Framework
                                                 "Use SSL? true/false", ConfigSettings.DefaultMessageServerHttpSSL.ToString(), false);
             m_configMember.addConfigurationOption("published_ip", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
                                                 "My Published IP Address", "127.0.0.1", false);
+
+            m_configMember.addConfigurationOption("remote_access_salt", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                "The salt for the hash of the remote access code.", "", true);
+            m_configMember.addConfigurationOption("remote_access_hash", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                "The salted SHA-256 hash of the remote access code. SHA256(remote_access_salt + passcode)", "", true);
         }
 
         public bool handleIncomingConfiguration(string configuration_key, object configuration_result)
@@ -129,6 +150,12 @@ namespace OpenSim.Framework
                     break;
                 case "published_ip":
                     MessageServerIP = (string) configuration_result;
+                    break;
+                case "remote_access_salt":
+                    m_remoteAccessSalt = (string)configuration_result;
+                    break;
+                case "remote_access_hash":
+                    m_remoteAccessHash = (string)configuration_result;
                     break;
             }
 

--- a/OpenSim/Framework/UserConfig.cs
+++ b/OpenSim/Framework/UserConfig.cs
@@ -92,6 +92,22 @@ namespace OpenSim.Framework
 
         public bool EnableHGLogin = true;
 
+        private string m_remoteAccessHash = String.Empty;
+        public string RemoteAccessHash
+        {
+            get {
+                return m_remoteAccessHash;
+            }
+        }
+
+        private string m_remoteAccessSalt = String.Empty;
+        public string RemoteAccessSalt
+        {
+            get {
+                return m_remoteAccessSalt;
+            }
+        }
+
         public UserConfig()
         {
             // weird, but UserManagerBase needs this.
@@ -151,6 +167,11 @@ namespace OpenSim.Framework
 
             m_configMember.addConfigurationOption("default_loginLevel", ConfigurationOption.ConfigurationTypes.TYPE_UINT32,
                                                 "Minimum Level a user should have to login [0 default]", "0", false);
+
+            m_configMember.addConfigurationOption("remote_access_salt", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                "The salt for the hash of the remote access code.", "", true);
+            m_configMember.addConfigurationOption("remote_access_hash", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                "The salted SHA-256 hash of the remote access code. SHA256(rremote_access_salt + passcode)", "", true);
         }
 
         public bool handleIncomingConfiguration(string configuration_key, object configuration_result)
@@ -207,6 +228,12 @@ namespace OpenSim.Framework
                     break;
                 case "profile_server_uri":
                     ProfileServerURI = (string)configuration_result;
+                    break;
+                case "remote_access_salt":
+                    m_remoteAccessSalt = (string)configuration_result;
+                    break;
+                case "remote_access_hash":
+                    m_remoteAccessHash = (string)configuration_result;
                     break;
             }
 

--- a/OpenSim/Framework/Util.cs
+++ b/OpenSim/Framework/Util.cs
@@ -615,6 +615,23 @@ namespace OpenSim.Framework
             return SHA1.ComputeHash(src);
         }
 
+        /// <summary>
+        /// Return an SHA256 hash of the given string
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public static string SHA256Hash(string data)
+        {
+            byte[] hash = ComputeSHA256Hash(data);
+            return BitConverter.ToString(hash).Replace("-", String.Empty);
+        }
+
+        private static byte[] ComputeSHA256Hash(string src)
+        {
+            var SHA256 = new SHA256CryptoServiceProvider();
+            return SHA256.ComputeHash(Encoding.Default.GetBytes(src));
+        }
+
         public static int fast_distance2d(int x, int y)
         {
             x = Math.Abs(x);

--- a/OpenSim/Framework/Util.cs
+++ b/OpenSim/Framework/Util.cs
@@ -176,6 +176,11 @@ namespace OpenSim.Framework
         }
 
 
+        public static string CreateSaltedPasscodeHash(string salt, string passcode)
+        {
+            return SHA256Hash(salt + passcode);
+        }
+
         /// <summary
         /// Authenticate a username/password pair against the user we are running under.
         /// </summary>
@@ -187,8 +192,7 @@ namespace OpenSim.Framework
         public static bool AuthenticateAsSystemUser(string username, string password)
         {
             #if __MonoCS__
-                // TODO: find a way to check the user info cross platform.  In the mean time better security by NOT allowing remote admin.
-                return false;
+                return false; // If a hashed passcode wasn't set up, then there's no other option.  Crossplatform checks of system users has no way to exist: not all systems even use passwords, some use more advanced tech.
             #else
                 // Is the username the same as the logged in user and do they have the password correct?
                 PrincipalContext pc = new PrincipalContext(ContextType.Machine);

--- a/OpenSim/Grid/GridServer/GridServerBase.cs
+++ b/OpenSim/Grid/GridServer/GridServerBase.cs
@@ -96,7 +96,7 @@ namespace OpenSim.Grid.GridServer
 
         public object GridServerShutdownHandler(IList args, IPEndPoint remoteClient)
         {
-            m_radmin.CheckSessionValid(new UUID((string)args[0]));
+            m_radmin.CheckSessionValid(new UUID((string)args[0]), remoteClient.ToString());
 
             try
             {

--- a/OpenSim/Grid/GridServer/GridServerBase.cs
+++ b/OpenSim/Grid/GridServer/GridServerBase.cs
@@ -87,7 +87,7 @@ namespace OpenSim.Grid.GridServer
 
             m_httpServer.Start();
 
-            m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin();
+            m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin(m_config.RemoteAccessHash, m_config.RemoteAccessSalt);
             m_radmin.AddCommand("GridService", "Shutdown", GridServerShutdownHandler);
             m_radmin.AddHandler(m_httpServer);
 

--- a/OpenSim/Grid/MessagingServer/Main.cs
+++ b/OpenSim/Grid/MessagingServer/Main.cs
@@ -140,7 +140,7 @@ namespace OpenSim.Grid.MessagingServer
 
         public object MessagingServerShutdownHandler(IList args, IPEndPoint remoteClient)
         {
-            m_radmin.CheckSessionValid(new UUID((string)args[0]));
+            m_radmin.CheckSessionValid(new UUID((string)args[0]), remoteClient.ToString());
 
             try
             {

--- a/OpenSim/Grid/MessagingServer/Main.cs
+++ b/OpenSim/Grid/MessagingServer/Main.cs
@@ -121,7 +121,7 @@ namespace OpenSim.Grid.MessagingServer
                 m_httpServer.AddStreamHandler(new XmlRpcStreamHandler("POST", Util.XmlRpcRequestPrefix("region_startup"), m_regionModule.RegionStartup));
                 m_httpServer.AddStreamHandler(new XmlRpcStreamHandler("POST", Util.XmlRpcRequestPrefix("region_shutdown"), m_regionModule.RegionShutdown));
 
-                m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin();
+                m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin(Cfg.RemoteAccessHash, Cfg.RemoteAccessSalt);
                 m_radmin.AddCommand("MessagingService", "Shutdown", MessagingServerShutdownHandler);
                 m_radmin.AddHandler(m_httpServer);
 

--- a/OpenSim/Grid/UserServer/Main.cs
+++ b/OpenSim/Grid/UserServer/Main.cs
@@ -249,7 +249,7 @@ namespace OpenSim.Grid.UserServer
             m_messagesService.RegisterHandlers(m_httpServer);
             m_gridInfoService.RegisterHandlers(m_httpServer);
 
-            m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin();
+            m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin(Cfg.RemoteAccessHash, Cfg.RemoteAccessSalt);
             m_radmin.AddCommand("UserService", "Shutdown", UserServerShutdownHandler);
             m_radmin.AddHandler(m_httpServer);
         }

--- a/OpenSim/Grid/UserServer/Main.cs
+++ b/OpenSim/Grid/UserServer/Main.cs
@@ -256,7 +256,7 @@ namespace OpenSim.Grid.UserServer
 
         public object UserServerShutdownHandler(IList args, IPEndPoint remoteClient)
         {
-            m_radmin.CheckSessionValid(new UUID((string)args[0]));
+            m_radmin.CheckSessionValid(new UUID((string)args[0]), remoteClient.ToString());
 
             try
             {

--- a/bin/Halcyon.sample.ini
+++ b/bin/Halcyon.sample.ini
@@ -186,6 +186,21 @@
     ; " (Mozilla Compatible)" to the text where there are problems with a web server
     ;user_agent = "Halcyon LSL (Mozilla Compatible)"
 
+    ; SHA256 hash of the RemoteAccessSalt and the remote access passcode.
+    ; If left blank on Windows the username and password of the user that is
+    ;  running the simulator will be consulted. Under all other operating
+    ;  systems leaving this blank will disable remote access.
+    ; The passcode can be the same or different as you wish, but the salt and
+    ;  therefore the hash should be different from server to server.
+    ; The following commands can be used to generate the hash:
+    ;  Linux or macOS: ./createAccessCode.sh
+    ;RemoteAccessHash = ""
+
+    ; Salt used in the generation of the RemoteAccessHash.
+    ; It is recommended to use a unique random series of characters per Halcyon
+    ;  installation for the salt. The passcode can be the same or different as
+    ;  you wish, but the salt and therefore the hash should be different.
+    ;RemoteAccessSalt = ""
 
 [Chat]
     ; Controls whether the chat module is enabled.  Default is true.

--- a/bin/createAccessCode.sh
+++ b/bin/createAccessCode.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+read -p "Salt: " -r salt
+read -p "Passcode: " -r -s passcode
+
+# Starting and trailing whitespace cause compatability issues with the C#.
+salt="$(echo -ne "$salt" |  sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+
+printf "\n\nRemoteAccessSalt = \"%s\"\nRemoteAccessHash = \"" "$salt"
+
+if hash sha256sum 2> /dev/null; then
+	printf "$salt$passcode" | sha256sum | cut -d' ' -f1 | tr -d "\n"
+else
+	if hash shasum 2> /dev/null; then
+		printf "$salt$passcode" | shasum --algorithm 256 | cut -d' ' -f1 | tr -d "\n"
+	else
+		echo "Could not find a usable SHA256 generator."
+		exit 1
+	fi
+fi
+
+printf "\"\n"


### PR DESCRIPTION
Under Mono there's no way to check the username+password against the user, mainly because there's no guarantee that passwords are even used.

I realized that this system was acting more as an auth token than a user login. So I simplified the concept to a single passcode.
However, their's no guarantee that the configuration files or the system's memory will be kept secure.  So I decided to keep the code around only as a salted SHA256 hash.
I didn't go to the extreme and implement key stretching, but that could be added if there's enough worry.

Under .NET on Windows the old active user authentication process is still used if the hash is blank or not set.  This provides backwards compatibility with pre-existing setups.