### PR TITLE
A small fix regarding setup on new installations

### DIFF
--- a/OpenSim/Framework/Configuration/XML/XmlConfiguration.cs
+++ b/OpenSim/Framework/Configuration/XML/XmlConfiguration.cs
@@ -144,16 +144,33 @@ namespace OpenSim.Framework.Configuration.XML
             // Perform commit out of place in case of insufficient disk space.
             String oldFile = fileName + ".old";
             String newFile = fileName + ".new";
-            if (File.Exists(newFile))
-                File.Delete(newFile);
-            doc.Save(newFile);
-            if (File.Exists(oldFile))
-                File.Delete(oldFile);
-            File.Move(fileName, oldFile);
-            File.Move(newFile, fileName);
-            if (File.Exists(fileName) && File.Exists(oldFile))
-                File.Delete(oldFile);
-            needsCommit = false;
+            try
+            {
+                if (File.Exists(newFile))
+                {
+                    File.Delete(newFile);
+                }
+                doc.Save(newFile);
+                if (File.Exists(oldFile))
+                {
+                    File.Delete(oldFile);
+                }
+                File.Move(fileName, oldFile);
+                File.Move(newFile, fileName);
+                if (File.Exists(fileName) && File.Exists(oldFile))
+                {
+                    File.Delete(oldFile);
+                }
+                needsCommit = false;
+            }
+            catch (IOException ex)
+            {
+                if (!File.Exists(fileName) && File.Exists(newFile)) //On new installations with missing configurations
+                {
+                    File.Move(newFile, fileName);
+                }
+            }
+
         }
 
         public void Close()


### PR DESCRIPTION
The logic should be untouched (besides the formatting) 
but on IOExceptions that happends on first-time-installation, it now creates a new Region settings file properly.

I am shutting down my fixes for now, so might as well share this little contribution.