### PR TITLE
Fixed Mantis 3231 - llMoveToTarget does not support Z changes

### DIFF
--- a/InWorldz/InWorldz.PhysxPhysics/PhysxCharacter.cs
+++ b/InWorldz/InWorldz.PhysxPhysics/PhysxCharacter.cs
@@ -811,7 +811,7 @@ namespace InWorldz.PhysxPhysics
             cforces.Z = 0;
 
             OpenMetaverse.Vector3 vCombined = ApplyAirBrakes(_vGravity + _vForces + cforces + this.VTargetWithRunAndRamp) * secondsSinceLastSync;
-            //m_log.DebugFormat("[CHAR]: vGrav: {0}, vForces: {1}, vTarget {2}", _vGravity, _vForces, this.VTargetWithRun);
+            //m_log.DebugFormat("[CHAR]: vGrav: {0}, vForces: {1}, cForces: {2}, vTarget {3}", _vGravity, _vForces, cforces, this.VTargetWithRunAndRamp);
 
             if (vCombined == OpenMetaverse.Vector3.Zero) 
             {

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1885,8 +1885,13 @@ namespace OpenSim.Region.Framework.Scenes
                                     * Matrix4.CreateFromQuaternion(Quaternion.Inverse(bodyRotation)); // change to avatar coords
                                 LocalVectorToTarget.Normalize();
                                 agent_control_v3 += LocalVectorToTarget;
-                                physActor.AddForce(LocalVectorToTarget, ForceType.LocalLinearImpulse);
 
+                                Vector3 movementPush = (m_moveToPositionTarget - AbsolutePosition);
+                                movementPush.Normalize();
+                                movementPush.Z *= physActor.Mass;
+                                if (physActor.IsColliding)
+                                    movementPush.Z *= FLY_LAUNCH_FORCE;
+                                physActor.AddForce(movementPush, ForceType.GlobalLinearImpulse);
 
                                 // update avatar movement flags. the avatar coordinate system is as follows:
                                 //

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1880,12 +1880,11 @@ namespace OpenSim.Region.Framework.Scenes
                                 // Theoretically we might need a more complex PID approach here if other 
                                 // unknown forces are acting on the avatar and we need to adaptively respond
                                 // to such forces, but the following simple approach seems to works fine.
-                                Vector3 LocalVectorToTarget3D =
+                                Vector3 LocalVectorToTarget =
                                     (m_moveToPositionTarget - AbsolutePosition) // vector from cur. pos to target in global coords
                                     * Matrix4.CreateFromQuaternion(Quaternion.Inverse(bodyRotation)); // change to avatar coords
-                                Vector3 LocalVectorToTarget2D = new Vector3((float)(LocalVectorToTarget3D.X), (float)(LocalVectorToTarget3D.Y), (float)(LocalVectorToTarget3D.Z));
-                                LocalVectorToTarget2D.Normalize();
-                                agent_control_v3 += LocalVectorToTarget2D;
+                                LocalVectorToTarget.Normalize();
+                                agent_control_v3 += LocalVectorToTarget;
 
                                 // update avatar movement flags. the avatar coordinate system is as follows:
                                 //
@@ -1908,34 +1907,34 @@ namespace OpenSim.Region.Framework.Scenes
 
                                 // based on the above avatar coordinate system, classify the movement into 
                                 // one of left/right/back/forward.
-                                if (LocalVectorToTarget2D.Y > 0)//MoveLeft
+                                if (LocalVectorToTarget.Y > 0)//MoveLeft
                                 {
                                     m_movementflag += (uint)Dir_ControlFlags.DIR_CONTROL_FLAG_LEFT;
                                     update_movementflag = true;
                                 }
-                                else if (LocalVectorToTarget2D.Y < 0) //MoveRight
+                                else if (LocalVectorToTarget.Y < 0) //MoveRight
                                 {
                                     m_movementflag += (uint)Dir_ControlFlags.DIR_CONTROL_FLAG_RIGHT;
                                     update_movementflag = true;
                                 }
-                                if (LocalVectorToTarget2D.X < 0) //MoveBack
+                                if (LocalVectorToTarget.X < 0) //MoveBack
                                 {
                                     m_movementflag += (uint)Dir_ControlFlags.DIR_CONTROL_FLAG_BACK;
                                     update_movementflag = true;
                                 }
-                                else if (LocalVectorToTarget2D.X > 0) //Move Forward
+                                else if (LocalVectorToTarget.X > 0) //Move Forward
                                 {
                                     m_movementflag += (uint)Dir_ControlFlags.DIR_CONTROL_FLAG_FORWARD;
                                     update_movementflag = true;
                                 }
-                                if (LocalVectorToTarget2D.Z > 0) //Up
+                                if (LocalVectorToTarget.Z > 0) //Up
                                 {
                                     // Don't set these flags for up - doing so will make the avatar
                                     // keep trying to jump even if walking along level ground.
                                     // m_movementflag += (uint)Dir_ControlFlags.DIR_CONTROL_FLAG_UP;
                                     update_movementflag = true;
                                 }
-                                else if (LocalVectorToTarget2D.Z < 0) //Down
+                                else if (LocalVectorToTarget.Z < 0) //Down
                                 {
                                     // Don't set these flags for down - doing so will make the avatar crouch.
                                     // m_movementflag += (uint)Dir_ControlFlags.DIR_CONTROL_FLAG_DOWN;

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1951,7 +1951,8 @@ namespace OpenSim.Region.Framework.Scenes
                     }
 
                     // Determine whether the user has said to stop and the agent is not sitting.
-                    physActor.SetAirBrakes = (m_AgentControlFlags & (uint)AgentManager.ControlFlags.AGENT_CONTROL_STOP) != 0 && !IsInTransitOnPrim;
+                    physActor.SetAirBrakes = (m_AgentControlFlags & (uint)AgentManager.ControlFlags.AGENT_CONTROL_STOP) != 0 && !IsInTransitOnPrim && !m_moveToPositionInProgress;
+
                 }
                 
                 // Cause the avatar to stop flying if it's colliding

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1885,6 +1885,8 @@ namespace OpenSim.Region.Framework.Scenes
                                     * Matrix4.CreateFromQuaternion(Quaternion.Inverse(bodyRotation)); // change to avatar coords
                                 LocalVectorToTarget.Normalize();
                                 agent_control_v3 += LocalVectorToTarget;
+                                physActor.AddForce(LocalVectorToTarget, ForceType.LocalLinearImpulse);
+
 
                                 // update avatar movement flags. the avatar coordinate system is as follows:
                                 //

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1875,7 +1875,7 @@ namespace OpenSim.Region.Framework.Scenes
                         {
                             try
                             {
-                                // move avatar in 2D at one meter/second towards target, in avatar coordinate frame.
+                                // move avatar in 3D at one meter/second towards target, in avatar coordinate frame.
                                 // This movement vector gets added to the velocity through AddNewMovement().
                                 // Theoretically we might need a more complex PID approach here if other 
                                 // unknown forces are acting on the avatar and we need to adaptively respond
@@ -1883,8 +1883,7 @@ namespace OpenSim.Region.Framework.Scenes
                                 Vector3 LocalVectorToTarget3D =
                                     (m_moveToPositionTarget - AbsolutePosition) // vector from cur. pos to target in global coords
                                     * Matrix4.CreateFromQuaternion(Quaternion.Inverse(bodyRotation)); // change to avatar coords
-                                // Ignore z component of vector
-                                Vector3 LocalVectorToTarget2D = new Vector3((float)(LocalVectorToTarget3D.X), (float)(LocalVectorToTarget3D.Y), 0f);
+                                Vector3 LocalVectorToTarget2D = new Vector3((float)(LocalVectorToTarget3D.X), (float)(LocalVectorToTarget3D.Y), (float)(LocalVectorToTarget3D.Z));
                                 LocalVectorToTarget2D.Normalize();
                                 agent_control_v3 += LocalVectorToTarget2D;
 
@@ -1927,6 +1926,19 @@ namespace OpenSim.Region.Framework.Scenes
                                 else if (LocalVectorToTarget2D.X > 0) //Move Forward
                                 {
                                     m_movementflag += (uint)Dir_ControlFlags.DIR_CONTROL_FLAG_FORWARD;
+                                    update_movementflag = true;
+                                }
+                                if (LocalVectorToTarget2D.Z > 0) //Up
+                                {
+                                    // Don't set these flags for up - doing so will make the avatar
+                                    // keep trying to jump even if walking along level ground.
+                                    // m_movementflag += (uint)Dir_ControlFlags.DIR_CONTROL_FLAG_UP;
+                                    update_movementflag = true;
+                                }
+                                else if (LocalVectorToTarget2D.Z < 0) //Down
+                                {
+                                    // Don't set these flags for down - doing so will make the avatar crouch.
+                                    // m_movementflag += (uint)Dir_ControlFlags.DIR_CONTROL_FLAG_DOWN;
                                     update_movementflag = true;
                                 }
                             }


### PR DESCRIPTION
This PR removes the 2-D restriction on llMoveToTarget and allows 3-D movement. Fixes Mantis 3231.