### PR TITLE
Fixed Mantis 3227: botFollowAvatar does not return BOT_USER_NOT_FOUND 

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -17040,6 +17040,8 @@ namespace InWorldz.Phlox.Engine
                         return ScriptBaseClass.BOT_USER_NOT_FOUND;
                     case BotMovementResult.Success:
                         return ScriptBaseClass.BOT_SUCCESS;
+                    default:
+                        return ScriptBaseClass.BOT_ERROR;
                 }
             }
             return ScriptBaseClass.BOT_NOT_FOUND;

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
@@ -703,6 +703,9 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
             if ((bot = GetBotWithPermission(botID, attemptingUser)) == null)
                 return BotMovementResult.BotNotFound;
 
+            if (m_scene.GetScenePresence(avatarID) == null)
+                return BotMovementResult.UserNotFound;
+
             bot.MovementController.StartFollowingAvatar(avatarID, options);
             return BotMovementResult.Success;
         }


### PR DESCRIPTION
It previously only returned that value if the user _account_ didn't _exist_ at all. Now it returns BOT_USER_NOT_FOUND in that case, or if the target user is not present in the region. 