### PR TITLE
Fixed Mantis 3228 "Notecard saved." messages

### DIFF
--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -171,8 +171,6 @@ namespace OpenSim.Region.Framework.Scenes
                             remoteClient.SendAgentAlertMessage("Insufficient permissions to edit notecard", false);
                             return new UpdateItemResponse();
                         }
-
-                        remoteClient.SendAgentAlertMessage("Notecard saved", false);
                     }
                     else if ((InventoryType)item.InvType == InventoryType.LSL)
                     {

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
@@ -644,14 +644,6 @@ namespace OpenSim.Region.Framework.Scenes
                     {
                         item.AssetID = fromItem.AssetID;
                     }
-                    else if ((InventoryType)item.Type == InventoryType.Notecard)
-                    {
-                        ScenePresence presence = m_part.ParentGroup.Scene.GetScenePresence(item.OwnerID);
-                        if (presence != null)
-                        {
-                            presence.ControllingClient.SendAgentAlertMessage("Notecard saved", false);
-                        }
-                    }
 
                     // Check if next owner perms were changed
                     if (item.InvType == (int)InventoryType.Object)


### PR DESCRIPTION
These are now causing multiple viewer popups that need to be closed when connected to IW servers, and have been removed from SL servers. These messages were only added to match previous SL behavior, so I have changed IW servers to match the new SL behavior (removed these extra popups).