### PR TITLE
Fix for #251. Improved error handling for missing permissions module

### DIFF
--- a/OpenSim/Base/OpenSimBase.cs
+++ b/OpenSim/Base/OpenSimBase.cs
@@ -446,6 +446,18 @@ namespace OpenSim
             }
             else m_log.Error("[MODULES]: The new RegionModulesController is missing...");
 
+            // Check if a (any) permission module has been loaded.
+            // This can be any permissions module, including the default PermissionsModule with m_bypassPermissions==true.
+            // To disable permissions, specify [Startup] permissionmodules=DefaultPermissionsModule in the .ini file, and 
+            // serverside_object_permissions=false, optionally propagate_permissions=false.
+            if (!scene.Permissions.IsAvailable())
+            {
+                m_log.Error("[MODULES]: Permissions module is not set, or set incorrectly.");
+                Environment.Exit(1);
+                // Note that an Exit here can trigger a PhysX exception but if that happens it is the result of this 
+                // permissions problem and hopefully the lot will show this error and intentional exit.
+            }
+
             scene.SetModuleInterfaces();
 
             // this must be done before prims try to rez or they'll rez over no land

--- a/OpenSim/Region/CoreModules/World/Permissions/PermissionsModule.cs
+++ b/OpenSim/Region/CoreModules/World/Permissions/PermissionsModule.cs
@@ -123,7 +123,10 @@ namespace OpenSim.Region.CoreModules.World.Permissions
             List<string> modules=new List<string>(permissionModules.Split(','));
 
             if (!modules.Contains("DefaultPermissionsModule"))
+            {
+                m_log.Info("[PERMISSIONS]: Startup option: 'permissionmodules' does not include 'DefaultPermissionsModule', PermissionModule not initialized.");
                 return;
+            }
 
             m_allowGridGods = myConfig.GetBoolean("allow_grid_gods", false);
             m_bypassPermissions = !myConfig.GetBoolean("serverside_object_permissions", false);

--- a/OpenSim/Region/Framework/Scenes/Scene.Permissions.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Permissions.cs
@@ -205,6 +205,12 @@ namespace OpenSim.Region.Framework.Scenes
             return true;
         }
 
+        // Minimum functionality: if the GenerateClientFlagsHandler is not set, there is no permissions module available.
+        public bool IsAvailable()
+        {
+            return (OnGenerateClientFlags != null);
+        }
+
         public bool PropagatePermissions()
         {
             PropagatePermissionsHandler handler = OnPropagatePermissions;


### PR DESCRIPTION
See issue #251.  The region server now includes a console/log message if the PermissionsModule is skipped.  Also,  if _no_ permission module is loaded, not even with permissions bypassed, the startup is aborted.

The DefaultPermissionsModule (PermissionsModule.cs) supports bypassing permissions _entirely_, if that is desired. However it is considered a configuration error to (probably accidentally) fail to load _any_ permissions module at all.