### PR TITLE
One path through GetUserProfile wasn't updating CurrentAgent

### DIFF
--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -330,12 +330,7 @@ namespace OpenSim.Framework.Communications
                                 {
                                     // still not found, get it from User service (or db if this is User).
                                     profile = m_storage.GetUserProfileData(uuid);
-                                    if (profile != null)
-                                    {
-                                        profile.CurrentAgent = GetUserAgent(uuid, forceRefresh);
-                                        ReplaceUserData(profile);
-                                    }
-                                    else
+                                    if (profile == null)
                                     {
                                         // not found in storage. If this is now known in temp profiles, return it,
                                         // otherwise remove it from non-temp profile info.
@@ -344,6 +339,11 @@ namespace OpenSim.Framework.Communications
                                             RemoveUserData(uuid);
                                         }
                                     }
+                                }
+                                if (profile != null)
+                                {
+                                    profile.CurrentAgent = GetUserAgent(uuid, forceRefresh);
+                                    ReplaceUserData(profile);
                                 }
                             }
 


### PR DESCRIPTION
Fixes "last location" logins not going to last logoff location, and probably other cases where the cached info was stale. (This is an important fix for a potentially serious problem.)