### PR TITLE
Hopefully the correct fix for PR #259 (regression)

### DIFF
--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -330,7 +330,13 @@ namespace OpenSim.Framework.Communications
                                 {
                                     // still not found, get it from User service (or db if this is User).
                                     profile = m_storage.GetUserProfileData(uuid);
-                                    if (profile == null)
+                                    if (profile != null)
+                                    {
+                                        // Refresh agent data (possibly forced refresh)
+                                        profile.CurrentAgent = GetUserAgent(uuid, forceRefresh);
+                                        ReplaceUserData(profile);
+                                    }
+                                    else
                                     {
                                         // not found in storage. If this is now known in temp profiles, return it,
                                         // otherwise remove it from non-temp profile info.
@@ -340,8 +346,9 @@ namespace OpenSim.Framework.Communications
                                         }
                                     }
                                 }
-                                if (profile != null)
+                                else
                                 {
+                                    // Refresh agent data (possibly forced refresh)
                                     profile.CurrentAgent = GetUserAgent(uuid, forceRefresh);
                                     ReplaceUserData(profile);
                                 }


### PR DESCRIPTION
PR #259 affected the bot-related ```else``` clause above this change below. Rather than moving the ```if``` case out for all paths to use, this change duplicates it inside an ```else``` so that none of the previous working paths are affected. Only the case where the TryGetUserProfile returned a valid profile was missing the CurrentAgent data refresh, so restoring the old code and adding the ```else``` clause does that.

Ignoring #259, this commit just adds the else to the revision before #259, the ```else``` clause highlighted below (and one comment edited):
![else added](https://i.gyazo.com/3850c9b6b64944198b9af7424306facf.png)