### PR TITLE
Fixed the null ref error if the user has no home region

### DIFF
--- a/OpenSim/Framework/Communications/Services/LoginService.cs
+++ b/OpenSim/Framework/Communications/Services/LoginService.cs
@@ -1060,15 +1060,18 @@ namespace OpenSim.Framework.Communications.Services
                 //m_log.InfoFormat("[LOGIN]: StartLocation not available sending to region {0}", regionInfo.regionName);
 
                 // Normal login failed, try to find an alternative region, starting with Home.
-                if ((regionInfo == null) || (regionInfo.RegionID != homeInfo.RegionID))
+                if (homeInfo != null)
                 {
-                    regionInfo = homeInfo;
-                    theUser.CurrentAgent.Position = theUser.HomeLocation;
-                    response.LookAt = String.Format("[r{0},r{1},r{2}]", theUser.HomeLookAt.X.ToString(),
-                                                    theUser.HomeLookAt.Y.ToString(), theUser.HomeLookAt.Z.ToString());
-                    m_log.InfoFormat("[LOGIN]: StartLocation not available, trying user's Home region {0}", regionInfo.RegionName);
-                    if (PrepareLoginToRegion(regionInfo, theUser, response, clientVersion))
-                        return true;
+                    if ((regionInfo == null) || (regionInfo.RegionID != homeInfo.RegionID))
+                    {
+                        regionInfo = homeInfo;
+                        theUser.CurrentAgent.Position = theUser.HomeLocation;
+                        response.LookAt = String.Format("[r{0},r{1},r{2}]", theUser.HomeLookAt.X.ToString(),
+                                                        theUser.HomeLookAt.Y.ToString(), theUser.HomeLookAt.Z.ToString());
+                        m_log.InfoFormat("[LOGIN]: StartLocation not available, trying user's Home region {0}", regionInfo.RegionName);
+                        if (PrepareLoginToRegion(regionInfo, theUser, response, clientVersion))
+                            return true;
+                    }
                 }
 
                 // No Home location available either, try to find a default region from the list


### PR DESCRIPTION
homeInfo was null, make the use of homeInfo conditional on non-null homeInfo.
The GitHub diff looks much larger than it is. The only change is to wrap the block of text in:
```
if (homeInfo != null)
{
...
}
```