### PR TITLE
Avatar-as-a-prim

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -8589,7 +8589,7 @@ namespace InWorldz.Phlox.Engine
                 {
                     part.ForEachSittingAvatar((ScenePresence sp) =>
                     {
-                        if (seatedAvatar != UUID.Zero)
+                        if (seatedAvatar == UUID.Zero)
                             seatedAvatar = sp.UUID;
                     });
                     if (seatedAvatar != UUID.Zero)

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -7868,7 +7868,7 @@ namespace InWorldz.Phlox.Engine
 
                 if (av != null)
                 {
-                    SceneObjectPart part = FindAvatarOnObject(key, false);
+                    SceneObjectPart part = FindAvatarOnObject(key);
                     if (part != null)
                     {
                         // if the avatar is sitting on this object, then
@@ -8569,10 +8569,11 @@ namespace InWorldz.Phlox.Engine
             llLinkSitTarget(m_host.LinkNum, offset, rot);
         }
 
-        private SceneObjectPart FindAvatarOnObject(UUID agentId, bool IncludeSitTargetOnly)
+        private SceneObjectPart FindAvatarOnObject(UUID agentId)
         {
             ScenePresence sp = m_host.ParentGroup.Scene.GetScenePresence(agentId);
-            return (sp == null) ? null : sp.SitTargetPart;
+            ScenePresence.PositionInfo posInfo = (sp == null) ? null : sp.GetPosInfo();
+            return (posInfo == null) ? null : posInfo.Parent;
         }
 
         private string AvatarOnSitTarget(int linknumber, bool IncludeSitTargetOnly)

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -10585,30 +10585,233 @@ namespace InWorldz.Phlox.Engine
                     if (sp != null) sp.Rotation = Rot2Quaternion(lq);
                     break;
 
-                // TODO: These no-ops need to still consume the params list items as appropriate
-                case ScriptBaseClass.PRIM_COLOR:
-                case ScriptBaseClass.PRIM_TEXTURE:
-                case ScriptBaseClass.PRIM_GLOW:
-                case ScriptBaseClass.PRIM_FULLBRIGHT:
-                case ScriptBaseClass.PRIM_BUMP_SHINY:
-                case ScriptBaseClass.PRIM_TEXGEN:
-                    ScriptShoutError("texture info cannot be set for avatars.");
+                // silently don't allow other avatar changes
+
+                case (int)ScriptBaseClass.PRIM_PHYSICS_SHAPE_TYPE:
+                    if (remain < 1)
+                        return;
+                    idx++;
                     break;
 
-                case ScriptBaseClass.PRIM_NAME:
-                case ScriptBaseClass.PRIM_DESC:
-                case ScriptBaseClass.PRIM_TYPE:
-                case ScriptBaseClass.PRIM_SLICE:
-                case ScriptBaseClass.PRIM_MATERIAL:
-                case ScriptBaseClass.PRIM_TEMP_ON_REZ:
-                case ScriptBaseClass.PRIM_PHANTOM:
-                case ScriptBaseClass.PRIM_SIZE:
-                case ScriptBaseClass.PRIM_TEXT:
-                case ScriptBaseClass.PRIM_POINT_LIGHT:
-                case ScriptBaseClass.PRIM_FLEXIBLE:
-                    // silently don't allow other avatar changes
+                case (int)ScriptBaseClass.PRIM_OMEGA:
+                    if (remain < 3)
+                        return;
+                    idx += 3;
                     break;
 
+                case (int)ScriptBaseClass.PRIM_TYPE:
+                    if (remain < 3)
+                        return;
+                    code = (int)rules.GetLSLIntegerItem(idx++);
+
+                    remain = rules.Length - idx;
+                    switch (code)
+                    {
+                        case (int)ScriptBaseClass.PRIM_TYPE_BOX:
+                            if (remain < 6)
+                                return;
+                            idx += 6;
+                            break;
+
+                        case (int)ScriptBaseClass.PRIM_TYPE_CYLINDER:
+                            if (remain < 6)
+                                return;
+                            idx += 6;
+                            break;
+
+                        case (int)ScriptBaseClass.PRIM_TYPE_PRISM:
+                            if (remain < 6)
+                                return;
+                            idx += 6;
+                            break;
+
+                        case (int)ScriptBaseClass.PRIM_TYPE_SPHERE:
+                            if (remain < 5)
+                                return;
+                            idx += 5;
+                            break;
+
+                        case (int)ScriptBaseClass.PRIM_TYPE_TORUS:
+                            if (remain < 11)
+                                return;
+                            idx += 11;
+                            break;
+
+                        case (int)ScriptBaseClass.PRIM_TYPE_TUBE:
+                            if (remain < 11)
+                                return;
+                            idx += 11;
+                            break;
+
+                        case (int)ScriptBaseClass.PRIM_TYPE_RING:
+                            if (remain < 11)
+                                return;
+                            idx += 11;
+                            break;
+
+                        case (int)ScriptBaseClass.PRIM_TYPE_SCULPT:
+                            if (remain < 2)
+                                return;
+                            idx += 2;
+                            break;
+                    }
+                    break;  // PRIM_TYPE
+
+                case (int)ScriptBaseClass.PRIM_SLICE:
+                    if (remain < 1)
+                        return;
+                    idx++;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_TEXTURE:
+                    if (remain < 5)
+                        return;
+                    idx += 5;
+                    break;
+
+                case (int)ScriptBaseClass.IW_PRIM_ALPHA:
+                    if (remain < 2)
+                        return;
+                    idx += 2;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_COLOR:
+                    if (remain < 3)
+                        return;
+                    idx += 3;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_FLEXIBLE:
+                    if (remain < 7)
+                        return;
+                    idx += 7;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_POINT_LIGHT:
+                    if (remain < 5)
+                        return;
+                    idx += 5;
+                    break;
+
+                case ScriptBaseClass.IW_PRIM_PROJECTOR:
+                    if (remain < 5)
+                        return;
+                    idx += 5;
+                    break;
+
+                case ScriptBaseClass.IW_PRIM_PROJECTOR_ENABLED:
+                    if (remain < 1)
+                        return;
+                    idx++;
+                    break;
+
+                case ScriptBaseClass.IW_PRIM_PROJECTOR_TEXTURE:
+                    if (remain < 1)
+                        return;
+                    idx++;
+                    break;
+
+                case ScriptBaseClass.IW_PRIM_PROJECTOR_FOV:
+                    if (remain < 1)
+                        return;
+                    idx++;
+                    break;
+
+                case ScriptBaseClass.IW_PRIM_PROJECTOR_FOCUS:
+                    if (remain < 1)
+                        return;
+                    idx++;
+                    break;
+
+                case ScriptBaseClass.IW_PRIM_PROJECTOR_AMBIENCE:
+                    if (remain < 1)
+                        return;
+                    idx++;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_GLOW:
+                    if (remain < 2)
+                        return;
+                    idx += 2;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_BUMP_SHINY:
+                    if (remain < 3)
+                        return;
+                    idx += 3;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_FULLBRIGHT:
+                    if (remain < 2)
+                        return;
+                    idx += 2;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_MATERIAL:
+                    if (remain < 1)
+                        return;
+                    idx++;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_PHANTOM:
+                    if (remain < 1)
+                        return;
+                    idx++;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_PHYSICS:
+                    if (remain < 1)
+                        return;
+                    idx++;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_TEMP_ON_REZ:
+                    if (remain < 1)
+                        return;
+                    idx++;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_TEXGEN:
+                    if (remain < 2)
+                        return;
+                    idx += 2;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_TEXT:
+                    if (remain < 3)
+                        return;
+                    idx += 3;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_NAME:
+                    if (remain < 1)
+                        return;
+                    idx++;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_DESC:
+                    if (remain < 1)
+                        return;
+                    idx++;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_SPECULAR:
+                    if (remain < 8)
+                        return;
+                    idx += 8;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_NORMAL:
+                    if (remain < 5)
+                        return;
+                    idx += 8;
+                    break;
+
+                case (int)ScriptBaseClass.PRIM_ALPHA_MODE:
+                    if (remain < 3)
+                        return;
+                    idx += 3;
+                    break;
             }
         }
 

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -4605,7 +4605,7 @@ namespace InWorldz.Phlox.Engine
         {
             
 
-            if (m_host.ParentGroup.PrimCount > 1)
+            if (m_host.ParentGroup.PartCount > 1)
             {
                 return m_host.LinkNum;
             }
@@ -5765,7 +5765,7 @@ namespace InWorldz.Phlox.Engine
                     {
                         partItemID = item.ItemID;
                         int linkNumber = m_host.LinkNum;
-                        if (m_host.ParentGroup.PrimCount == 1)
+                        if (m_host.ParentGroup.LinkCount == 1)  // if there are seated avatars, single-prim becomes multi, else 0
                             linkNumber = 0;
 
                         object[] resobj = new object[] { linkNumber, num, msg, id };
@@ -10338,22 +10338,7 @@ namespace InWorldz.Phlox.Engine
 
         public int llGetNumberOfPrims()
         {
-            List<ScenePresence> presences = World.GetScenePresences();
-
-            int avatarCount = 0;
-            foreach (ScenePresence presence in presences)
-            {
-                ScenePresence.PositionInfo info = presence.GetPosInfo();
-                if (!presence.IsChildAgent && info.Parent != null)
-                {
-                    if (m_host.ParentGroup.HasChildPrim(info.Parent.UUID))
-                    {
-                        avatarCount++;
-                    }
-                }
-            }
-
-            return m_host.ParentGroup.PrimCount + avatarCount;
+            return m_host.ParentGroup.LinkCount;
         }
 
         public LSL_List GetBoundingBox(string obj, bool isRelative)
@@ -13384,7 +13369,7 @@ namespace InWorldz.Phlox.Engine
             {
                 SceneObjectPart part = World.GetSceneObjectPart(object_uuid);
                 if (part != null)
-                    return part.ParentGroup.PrimCount;
+                    return part.ParentGroup.PartCount;
             }
 
             return 0;
@@ -17473,7 +17458,7 @@ namespace InWorldz.Phlox.Engine
                         {
                             partItemID = item.ItemID;
                             int linkNumber = m_host.LinkNum;
-                            if (m_host.ParentGroup.PrimCount == 1)
+                            if (m_host.ParentGroup.LinkCount == 1)
                                 linkNumber = 0;
 
                             object[] resobj = new object[] { linkNumber, num, msg, id };

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -10481,8 +10481,9 @@ namespace InWorldz.Phlox.Engine
             return new LSL_Vector(m_host.GetGeometricCenter().X, m_host.GetGeometricCenter().Y, m_host.GetGeometricCenter().Z);
         }
 
-        private void GetAvatarAsPrimParam(int linknum, ref List<object> res, int rule)
+        private int GetAvatarAsPrimParam(int linknum, ref List<object> res, int rule)
         {
+            int paramCount = 0;
             ScenePresence sp = m_host.ParentGroup.GetSeatedAvatarByLink(linknum);
             switch (rule)
             {
@@ -10544,15 +10545,23 @@ namespace InWorldz.Phlox.Engine
                     res.Add(new LSL_Vector(Vector3.Zero));
                     break;
 
-                case ScriptBaseClass.PRIM_COLOR:
-                case ScriptBaseClass.PRIM_TEXTURE:
-                case ScriptBaseClass.PRIM_GLOW:
-                case ScriptBaseClass.PRIM_FULLBRIGHT:
-                case ScriptBaseClass.PRIM_BUMP_SHINY:
-                case ScriptBaseClass.PRIM_TEXGEN:
+                // These all expect a single parameter in the params list:
+                case (int)ScriptBaseClass.PRIM_TEXTURE:
+                case (int)ScriptBaseClass.IW_PRIM_ALPHA:
+				case (int)ScriptBaseClass.PRIM_COLOR:
+				case (int)ScriptBaseClass.PRIM_BUMP_SHINY:
+				case (int)ScriptBaseClass.PRIM_FULLBRIGHT:
+				case (int)ScriptBaseClass.PRIM_TEXGEN:
+				case (int)ScriptBaseClass.PRIM_GLOW:
+				case (int)ScriptBaseClass.PRIM_SPECULAR:
+				case (int)ScriptBaseClass.PRIM_NORMAL:
+				case (int)ScriptBaseClass.PRIM_ALPHA_MODE:
+                    paramCount = 1;
                     ScriptShoutError("texture info cannot be accessed for avatars.");
                     break;
             }
+
+            return paramCount;
         }
 
         private void SetAvatarAsPrimParam(ScenePresence sp, LSL_List rules, ref int idx)
@@ -10859,7 +10868,7 @@ namespace InWorldz.Phlox.Engine
                 // Support avatar-as-a-prim link number.
                 if (avatar != null)
                 {
-                    GetAvatarAsPrimParam(linknumber, ref res, code);
+                    idx += GetAvatarAsPrimParam(linknumber, ref res, code);
                     continue;
                 }
 

--- a/OpenSim/Framework/ChildAgentDataUpdate.cs
+++ b/OpenSim/Framework/ChildAgentDataUpdate.cs
@@ -174,7 +174,6 @@ namespace OpenSim.Framework
         {
             AgentID = new UUID(cAgent.AgentID);
 
-            // next: ???
             Size = new Vector3();
             Size.Z = cAgent.AVHeight;
 

--- a/OpenSim/Framework/ChildAgentDataUpdate.cs
+++ b/OpenSim/Framework/ChildAgentDataUpdate.cs
@@ -309,6 +309,8 @@ namespace OpenSim.Framework
         public Vector3 ConstantForces;
         public bool ConstantForcesAreLocal;
 
+        public bool AvatarAsAPrim;
+
         public virtual OSDMap Pack()
         {
             OSDMap args = new OSDMap();
@@ -392,6 +394,8 @@ namespace OpenSim.Framework
                 args["sat_on_prim"] = OSD.FromUUID(SatOnPrim);
                 args["sit_offset"] = OSD.FromString(SatOnPrimOffset.ToString());
             }
+
+            args["avatar_as_a_prim"] = OSD.FromBoolean(AvatarAsAPrim);
 
             return args;
         }
@@ -547,6 +551,9 @@ namespace OpenSim.Framework
 
             if (args.ContainsKey("callback_uri"))
                 CallbackURI = args["callback_uri"].AsString();
+
+            if (args.ContainsKey("avatar_as_a_prim"))
+                AvatarAsAPrim = args["avatar_as_a_prim"].AsBoolean();
 
             if (args.ContainsKey("sat_on_group"))
             {

--- a/OpenSim/Framework/Communications/Messages/AgentPutMessage.cs
+++ b/OpenSim/Framework/Communications/Messages/AgentPutMessage.cs
@@ -159,6 +159,9 @@ namespace OpenSim.Framework.Communications.Messages
         [ProtoMember(36)]
         public bool ConstantForcesAreLocal;
 
+        [ProtoMember(37)]
+        public bool AvatarAsAPrim;
+
         static AgentPutMessage()
         {
             ProtoBuf.Serializer.PrepareSerializer<AgentPutMessage>();
@@ -203,7 +206,8 @@ namespace OpenSim.Framework.Communications.Messages
                 Velocity = data.Velocity,
                 RemoteAgents = data.RemoteAgents,
                 ConstantForces = data.ConstantForces,
-                ConstantForcesAreLocal = data.ConstantForcesAreLocal
+                ConstantForcesAreLocal = data.ConstantForcesAreLocal,
+                AvatarAsAPrim = data.AvatarAsAPrim
             };
 
             return message;
@@ -251,7 +255,8 @@ namespace OpenSim.Framework.Communications.Messages
                 Velocity = this.Velocity,
                 RemoteAgents = this.RemoteAgents,
                 ConstantForces = this.ConstantForces,
-                ConstantForcesAreLocal = this.ConstantForcesAreLocal
+                ConstantForcesAreLocal = this.ConstantForcesAreLocal,
+                AvatarAsAPrim = this.AvatarAsAPrim
             };
 
             return agentData;

--- a/OpenSim/Region/Framework/AvatarTransit/SendStates/SendAvatarState.cs
+++ b/OpenSim/Region/Framework/AvatarTransit/SendStates/SendAvatarState.cs
@@ -189,7 +189,7 @@ namespace OpenSim.Region.Framework.AvatarTransit.SendStates
             //unsit the SP if appropriate
             if (_avatar.TransitArgs.RideOnPart != null)
             {
-                _avatar.TransitArgs.RideOnPart.SetAvatarOnSitTarget(UUID.Zero, false);
+                _avatar.TransitArgs.RideOnPart.AddSeatedAvatar(_avatar.ScenePresence, false);
             }
 
             //this avatar is history.

--- a/OpenSim/Region/Framework/AvatarTransit/SendStates/SendAvatarState.cs
+++ b/OpenSim/Region/Framework/AvatarTransit/SendStates/SendAvatarState.cs
@@ -189,7 +189,7 @@ namespace OpenSim.Region.Framework.AvatarTransit.SendStates
             //unsit the SP if appropriate
             if (_avatar.TransitArgs.RideOnPart != null)
             {
-                _avatar.TransitArgs.RideOnPart.AddSeatedAvatar(_avatar.ScenePresence, false);
+                _avatar.TransitArgs.RideOnPart.RemoveSeatedAvatar(_avatar.ScenePresence, false);
             }
 
             //this avatar is history.

--- a/OpenSim/Region/Framework/AvatarTransit/SendStates/SendAvatarState.cs
+++ b/OpenSim/Region/Framework/AvatarTransit/SendStates/SendAvatarState.cs
@@ -221,20 +221,8 @@ namespace OpenSim.Region.Framework.AvatarTransit.SendStates
             AgentData cAgent = new AgentData();
             agent.CopyToForRootAgent(cAgent);
 
-            if (part != null)
-            {
-                cAgent.Position = part.AbsolutePosition;
-                cAgent.SatOnPrim = part.UUID;
-                cAgent.SatOnPrimOffset = part.SitTargetPosition;
-            }
-            else
-            {
-                // _log.WarnFormat("[SCENE COMM]: SendChildAgentUpdate2 for {0} position {1} was {2}", cAgent.AgentID, pos, cAgent.Position);
+            if (part == null)
                 cAgent.Position = pos;
-            }
-
-            if (sceneObjectGroup != null)
-                cAgent.SatOnGroup = sceneObjectGroup.UUID;
 
             cAgent.LocomotionState = 1;
             cAgent.LocomotionFlags = locomotionFlags;

--- a/OpenSim/Region/Framework/Scenes/AvatarPartsCollection.cs
+++ b/OpenSim/Region/Framework/Scenes/AvatarPartsCollection.cs
@@ -83,34 +83,39 @@ namespace OpenSim.Region.Framework.Scenes
         /// Adds the given avatar to this collection
         /// </summary>
         /// <param name="sp">The avatar to add</param>
-        public int AddPart(ScenePresence sp)
+        public bool AddAvatar(ScenePresence sp)
         {
             lock (m_mutationLock)
             {
-                UUID sopGlobal = sp.UUID;
-                m_avatarsByUuid = m_avatarsByUuid.Add(sp.UUID, sp);
-
-                //all local IDs will be 0 during the initial load
-                if (sp.LocalId != 0)
+                if (!m_avatarsByUuid.ContainsKey(sp.UUID))
                 {
-                    m_avatarsByLocalId = m_avatarsByLocalId.Add(sp.LocalId, sopGlobal);
+                    m_avatarsByUuid = m_avatarsByUuid.Add(sp.UUID, sp);
+
+                    //all local IDs will be 0 during the initial load
+                    if (sp.LocalId != 0)
+                        m_avatarsByLocalId = m_avatarsByLocalId.Add(sp.LocalId, sp.UUID);
+                    return true;
                 }
-                
-                return m_avatarsByUuid.Count;
             }
+            return false;
         }
 
         /// <summary>
         /// Removes the given avatar from this collection
         /// </summary>
         /// <param name="sp">The avatar to remove</param>
-        public void RemovePart(ScenePresence sp)
+        public bool RemoveAvatar(ScenePresence sp)
         {
             lock (m_mutationLock)
             {
-                m_avatarsByUuid = m_avatarsByUuid.Remove(sp.UUID);
-                m_avatarsByLocalId = m_avatarsByLocalId.Remove(sp.LocalId);
+                if (m_avatarsByUuid.ContainsKey(sp.UUID))
+                {
+                    m_avatarsByUuid = m_avatarsByUuid.Remove(sp.UUID);
+                    m_avatarsByLocalId = m_avatarsByLocalId.Remove(sp.LocalId);
+                    return true;
+                }
             }
+            return false;
         }
 
         /// <summary>
@@ -124,7 +129,7 @@ namespace OpenSim.Region.Framework.Scenes
                 ScenePresence sp;
                 if (m_avatarsByUuid.TryGetValue(avatarID, out sp))
                 {
-                    RemovePart(sp);
+                    RemoveAvatar(sp);
                 }
             }
         }

--- a/OpenSim/Region/Framework/Scenes/AvatarPartsCollection.cs
+++ b/OpenSim/Region/Framework/Scenes/AvatarPartsCollection.cs
@@ -1,0 +1,216 @@
+﻿using OpenMetaverse;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections;
+
+namespace OpenSim.Region.Framework.Scenes
+{
+    /// <summary>
+    /// A collection that stores ScenePresences for a group and provides
+    /// the most efficient access for different data types
+    /// </summary>
+    internal class AvatarPartsCollection
+    {
+        /// <summary>
+        /// Provides a better interface to the collection of parts when returned to the caller
+        /// </summary>
+        private class ReadOnlyAvatarsCollection : IReadOnlyCollection<ScenePresence>
+        {
+            private ImmutableDictionary<UUID, ScenePresence> m_collection;
+
+            public ReadOnlyAvatarsCollection(ImmutableDictionary<UUID, ScenePresence> collection)
+            {
+                m_collection = collection;
+            }
+
+            public int Count
+            {
+                get
+                {
+                    return m_collection.Count;
+                }
+            }
+
+            public IEnumerator<ScenePresence> GetEnumerator()
+            {
+                return m_collection.Values.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return m_collection.Values.GetEnumerator();
+            }
+        }
+
+        /// <summary>
+        /// Lock held for mutations only
+        /// </summary>
+        private object m_mutationLock = new object();
+
+        /// <summary>
+        /// Stores a collection of all avatars by their globally unique UUIDs
+        /// </summary>
+        private ImmutableDictionary<UUID, ScenePresence> m_avatarsByUuid =
+            ImmutableDictionary.Create<UUID, ScenePresence>();
+
+        /// <summary>
+        /// Stores a collection of all parts by their locally unique UUIDs
+        /// </summary>
+        private ImmutableDictionary<uint, UUID> m_avatarsByLocalId =
+            ImmutableDictionary.Create<uint, UUID>();
+
+
+        public AvatarPartsCollection()
+        {
+        }
+
+        /// <summary>
+        /// Returns the number of avatars in this collection
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                return m_avatarsByUuid.Count;
+            }
+        }
+
+        /// <summary>
+        /// Adds the given avatar to this collection
+        /// </summary>
+        /// <param name="sp">The avatar to add</param>
+        public int AddPart(ScenePresence sp)
+        {
+            lock (m_mutationLock)
+            {
+                UUID sopGlobal = sp.UUID;
+                m_avatarsByUuid = m_avatarsByUuid.Add(sp.UUID, sp);
+
+                //all local IDs will be 0 during the initial load
+                if (sp.LocalId != 0)
+                {
+                    m_avatarsByLocalId = m_avatarsByLocalId.Add(sp.LocalId, sopGlobal);
+                }
+                
+                return m_avatarsByUuid.Count;
+            }
+        }
+
+        /// <summary>
+        /// Removes the given avatar from this collection
+        /// </summary>
+        /// <param name="sp">The avatar to remove</param>
+        public void RemovePart(ScenePresence sp)
+        {
+            lock (m_mutationLock)
+            {
+                m_avatarsByUuid = m_avatarsByUuid.Remove(sp.UUID);
+                m_avatarsByLocalId = m_avatarsByLocalId.Remove(sp.LocalId);
+            }
+        }
+
+        /// <summary>
+        /// Clears all parts from this collection
+        /// </summary>
+        public void Clear()
+        {
+            lock (m_mutationLock)
+            {
+                m_avatarsByUuid = m_avatarsByUuid.Clear();
+                m_avatarsByLocalId = m_avatarsByLocalId.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Returns all parts in this collection
+        /// </summary>
+        public IReadOnlyCollection<ScenePresence> GetAllParts()
+        {
+            return new ReadOnlyAvatarsCollection(m_avatarsByUuid);
+        }
+
+        /// <summary>
+        /// Calls the given function on each avatar we know about
+        /// </summary>
+        /// <param name="action">The function to call</param>
+        public void ForEachPart(Action<ScenePresence> action)
+        {
+            foreach (var sp in m_avatarsByUuid.Values)
+            {
+                action(sp);
+            }
+        }
+
+        /// <summary>
+        /// Returns the avatar matching the given full ID or null
+        /// </summary>
+        /// <param name="fullId">The full ID of the avatar we're searching for</param>
+        /// <returns>The matching avatar that was found or null</returns>
+        public ScenePresence FindPartByFullId(UUID fullId)
+        {
+            ScenePresence outPart = null;
+            m_avatarsByUuid.TryGetValue(fullId, out outPart);
+
+            return outPart;
+        }
+
+        /// <summary>
+        /// Returns the avatar matching the given local ID or null
+        /// </summary>
+        /// <param name="localId">The local ID of the avatar we're searching for</param>
+        /// <returns>The matching avatar that was found or null</returns>
+        public ScenePresence FindPartByLocalId(uint localId)
+        {
+            //this is a 2 avatar lookup to ensure consistency between the collections 
+            UUID outFullId;
+            if (! m_avatarsByLocalId.TryGetValue(localId, out outFullId))
+            {
+                return null;
+            }
+
+            return FindPartByFullId(outFullId);
+        }
+
+        /// <summary>
+        /// Adds the given avatar to this collection only if it does not already exist
+        /// </summary>
+        /// <param name="sp">The avatar to add</param>
+        public void AddPartIfNotExists(ScenePresence sp)
+        {
+            lock (m_mutationLock)
+            {
+                if (! m_avatarsByUuid.ContainsKey(sp.UUID))
+                {
+                    m_avatarsByUuid = m_avatarsByUuid.Add(sp.UUID, sp);
+                    m_avatarsByLocalId = m_avatarsByLocalId.Add(sp.LocalId, sp.UUID);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reindexes a avatar which has been assigned new local id
+        /// </summary>
+        /// <param name="sp">The part to update</param>
+        /// <param name="oldLocalId">The old localid</param>
+        /// <param name="value">The new localid</param>
+        public void AvatarLocalIdUpdated(ScenePresence sp, uint oldLocalId, uint value)
+        {
+            if (value == oldLocalId) return; // nothing to do
+
+            // different local IDs
+            lock (m_mutationLock)
+            {
+                //add the new local ID then remove the old
+                if (oldLocalId != 0)
+                {
+                    m_avatarsByLocalId = m_avatarsByLocalId.Remove(oldLocalId);
+                }
+                if (value != 0)
+                {
+                    m_avatarsByLocalId = m_avatarsByLocalId.Add(value, sp.UUID);
+                }
+            }
+        }
+    }
+}

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -4397,7 +4397,7 @@ namespace OpenSim.Region.Framework.Scenes
                 uint tRegionX = RegionInfo.RegionLocX;
                 uint tRegionY = RegionInfo.RegionLocY;
                 //Send Data to ScenePresence
-                childAgentUpdate.ChildAgentDataUpdate(cAgentData, tRegionX, tRegionY, rRegionX, rRegionY);
+                childAgentUpdate.ChildAgentPositionUpdate(cAgentData, tRegionX, tRegionY, rRegionX, rRegionY);
                 // Not Implemented:
                 //TODO: Do we need to pass the message on to one of our neighbors?
             }

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -334,7 +334,7 @@ namespace OpenSim.Region.Framework.Scenes
 
                 if (entityAdded)
                 {
-                    m_numPrim += sceneObject.PrimCount;
+                    m_numPrim += sceneObject.PartCount;
                     m_parentScene.EventManager.TriggerParcelPrimCountTainted();
 
                     if (attachToBackup)
@@ -391,7 +391,7 @@ namespace OpenSim.Region.Framework.Scenes
 
                     if (!resultOfObjectLinked)
                     {
-                        m_numPrim -= group.PrimCount;
+                        m_numPrim -= group.PartCount;
 
                         if ((group.RootPart.Flags & PrimFlags.Physics) == PrimFlags.Physics)
                         {
@@ -2018,6 +2018,9 @@ namespace OpenSim.Region.Framework.Scenes
                     parentGroup.LinkOtherGroupPrimsToThisGroup(child);
                 }
 
+                // Now fix avatar link numbers
+                parentGroup.RecalcSeatedAvatarLinks();
+
                 // We need to explicitly resend the newly link prim's object properties since no other actions
                 // occur on link to invoke this elsewhere (such as object selection)
                 parentGroup.RootPart.AddFlag(PrimFlags.CreateSelected);
@@ -2061,6 +2064,7 @@ namespace OpenSim.Region.Framework.Scenes
                             continue;
                         if ((part.ParentGroup.RootPart.OwnerMask & (uint)PermissionMask.Modify) != (uint)PermissionMask.Modify)
                             continue;
+
                         if (part.LinkNum < 2) // Root or single
                             rootParts.Add(part);
                         else
@@ -2152,6 +2156,12 @@ namespace OpenSim.Region.Framework.Scenes
                     }
                 }
 
+                // Now fix avatar link numbers
+                foreach (SceneObjectGroup g in affectedGroups)
+                {
+                    g.RecalcSeatedAvatarLinks();
+                }
+
                 // Finally, trigger events in the roots
                 //
                 foreach (SceneObjectGroup g in affectedGroups)
@@ -2240,7 +2250,7 @@ namespace OpenSim.Region.Framework.Scenes
             SceneObjectGroup original = GetGroupByPrim(originalPrimID);
             if (original != null)
             {
-                if (m_parentScene.Permissions.CanDuplicateObject(original.PrimCount, original.UUID, AgentID, original.AbsolutePosition))
+                if (m_parentScene.Permissions.CanDuplicateObject(original.PartCount, original.UUID, AgentID, original.AbsolutePosition))
                 {
                     ScenePresence sp;
                     if (!TryGetAvatar(AgentID, out sp)) sp = null;
@@ -2276,7 +2286,7 @@ namespace OpenSim.Region.Framework.Scenes
                     // think it's selected, so it will never send a deselect...
                     copy.SetUnselectedForCopy();
 
-                    m_numPrim += copy.PrimCount;
+                    m_numPrim += copy.PartCount;
 
                     if (copy.OwnerID != AgentID)
                         copy.ChangeOwner(AgentID, GroupID);

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.Inventory.cs
@@ -46,7 +46,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         public void ForceInventoryPersistence()
         {
-            m_children.ForEachPart((SceneObjectPart part) => {
+            m_childParts.ForEachPart((SceneObjectPart part) => {
                 part.Inventory.ForceInventoryPersistence();
             });
         }
@@ -60,7 +60,7 @@ namespace OpenSim.Region.Framework.Scenes
             // Don't start scripts if they're turned off in the region!
             if (!m_scene.RegionInfo.RegionSettings.DisableScripts)
             {
-                m_children.ForEachPart((SceneObjectPart part) => {
+                m_childParts.ForEachPart((SceneObjectPart part) => {
                     part.Inventory.CreateScriptInstances(startParam, startFlags, engine, stateSource, listener);
                 });
             }
@@ -71,7 +71,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         public void RemoveScriptInstances()
         {
-            m_children.ForEachPart((SceneObjectPart part) => {
+            m_childParts.ForEachPart((SceneObjectPart part) => {
                 part.Inventory.RemoveScriptInstances();
             });
         }
@@ -82,7 +82,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         public void ResetItems(bool isNewInstance, bool isScriptReset, UUID itemId)
         {
-            m_children.ForEachPart((SceneObjectPart part) => {
+            m_childParts.ForEachPart((SceneObjectPart part) => {
                 part.Inventory.ResetItems(isNewInstance, isScriptReset, itemId);
             });
         }
@@ -295,7 +295,7 @@ namespace OpenSim.Region.Framework.Scenes
             uint perms = (uint)(PermissionMask.All | PermissionMask.Export);
             uint ownerMask = ScenePermBits.BASEMASK;
 
-            m_children.ForEachPart((SceneObjectPart part) => {
+            m_childParts.ForEachPart((SceneObjectPart part) => {
                 ownerMask &= part.OwnerMask;
                 if (includeContents)
                     perms &= part.Inventory.MaskEffectivePermissions();
@@ -315,7 +315,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         public void ApplyNextOwnerPermissions()
         {
-            m_children.ForEachPart((SceneObjectPart part) => {
+            m_childParts.ForEachPart((SceneObjectPart part) => {
                 part.ApplyNextOwnerPermissions();
             });
         }
@@ -326,7 +326,7 @@ namespace OpenSim.Region.Framework.Scenes
             uint perms = (uint)(PermissionMask.All | PermissionMask.Export);
             uint nextOwnerMask = ScenePermBits.BASEMASK;
             
-            m_children.ForEachPart((SceneObjectPart part) => {
+            m_childParts.ForEachPart((SceneObjectPart part) => {
                 nextOwnerMask &= part.NextOwnerMask;
                 if (includeContents)
                     perms &= part.Inventory.MaskEffectiveNextPermissions();
@@ -352,7 +352,7 @@ namespace OpenSim.Region.Framework.Scenes
             Dictionary<UUID, string> states = new Dictionary<UUID, string>();
             StopScriptReason stopScriptReason = fromCrossing ? StopScriptReason.Crossing : StopScriptReason.Derez;
 
-            m_children.ForEachPart((SceneObjectPart part) => {
+            m_childParts.ForEachPart((SceneObjectPart part) => {
                 foreach (KeyValuePair<UUID, string> s in part.Inventory.GetScriptStates(stopScriptReason))
                 {
                     states[s.Key] = s.Value;

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -4230,7 +4230,9 @@ namespace OpenSim.Region.Framework.Scenes
 
             ForEachSittingAvatar((ScenePresence sp) =>
             {
-                crossingUsers.Value.Add(sp.CrossIntoNewRegionWithGroup(this, sp.SitTargetPart, newRegionHandle));
+                PositionInfo posInfo = sp.GetPosInfo();
+                if (posInfo != null)
+                    crossingUsers.Value.Add(sp.CrossIntoNewRegionWithGroup(this, posInfo.Parent, newRegionHandle));
             });
 
             if (crossingUsers.IsValueCreated)

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -4183,17 +4183,25 @@ namespace OpenSim.Region.Framework.Scenes
 
         // These two must be called from the correspondingly-named SceneObjectPart methods.
         // They handle updates to the part data and script notifications.
-        public void AddSeatedAvatar(ScenePresence sp)
+        public void AddSeatedAvatar(ScenePresence sp, bool sendEvent)
         {
-            m_childAvatars.AddPart(sp);
-            // Now fix avatar link numbers
-            RecalcSeatedAvatarLinks();
+            if (m_childAvatars.AddAvatar(sp))
+            {
+                // Now fix avatar link numbers
+                RecalcSeatedAvatarLinks();
+                if (sendEvent)
+                    TriggerScriptChangedEvent(Changed.LINK);
+            }
         }
-        public void RemoveSeatedAvatar(ScenePresence sp)
+        public void RemoveSeatedAvatar(ScenePresence sp, bool sendEvent)
         {
-            m_childAvatars.RemovePart(sp);
-            // Now fix avatar link numbers
-            RecalcSeatedAvatarLinks();
+            if (m_childAvatars.RemoveAvatar(sp))
+            {
+                // Now fix avatar link numbers
+                RecalcSeatedAvatarLinks();
+                if (sendEvent)
+                    TriggerScriptChangedEvent(Changed.LINK);
+            }
         }
         public ScenePresence GetSeatedAvatarByLink(int linknum)
         {

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -3326,6 +3326,15 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
+        // Called the same way on both old and new parent part.
+        public void ReparentSeatedAvatar(ScenePresence sp, SceneObjectPart newParent)
+        {
+            if (newParent == this)
+                m_seatedAvatars.AddPart(sp);
+            else
+                m_seatedAvatars.RemovePart(sp);
+        }
+
         public void SetBuoyancy(float fvalue)
         {
             PhysicsActor physActor = PhysActor;

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -3306,33 +3306,25 @@ namespace OpenSim.Region.Framework.Scenes
 
         public void AddSeatedAvatar(ScenePresence sp, bool sendEvent)
         {
-            m_seatedAvatars.AddPart(sp);
+            m_seatedAvatars.AddAvatar(sp);
             if (ParentGroup != null)
-            {
-                ParentGroup.AddSeatedAvatar(sp);    // event sent below if needed
-                if (sendEvent)
-                    ParentGroup.TriggerScriptChangedEvent(Changed.LINK);
-            }
+                ParentGroup.AddSeatedAvatar(sp, sendEvent);    // event sent if needed
         }
 
         public void RemoveSeatedAvatar(ScenePresence sp, bool sendEvent)
         {
-            m_seatedAvatars.RemovePart(sp);
+            m_seatedAvatars.RemoveAvatar(sp);
             if (ParentGroup != null)
-            {
-                ParentGroup.RemoveSeatedAvatar(sp);    // event sent below if needed
-                if (sendEvent)
-                    ParentGroup.TriggerScriptChangedEvent(Changed.LINK);
-            }
+                ParentGroup.RemoveSeatedAvatar(sp, sendEvent); // event sent if needed
         }
 
         // Called the same way on both old and new parent part.
         public void ReparentSeatedAvatar(ScenePresence sp, SceneObjectPart newParent)
         {
             if (newParent == this)
-                m_seatedAvatars.AddPart(sp);
+                m_seatedAvatars.AddAvatar(sp);
             else
-                m_seatedAvatars.RemovePart(sp);
+                m_seatedAvatars.RemoveAvatar(sp);
         }
 
         public void SetBuoyancy(float fvalue)

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -473,6 +473,14 @@ namespace OpenSim.Region.Framework.Scenes
             get { return m_sitTargetPart;  }
         }
 
+        // LinkNum 0 means avatar not seated
+        private int m_linkNum = 0;
+        public int LinkNum
+        {
+            get { return m_linkNum; }
+            set { m_linkNum = value; }
+        }
+
         private bool m_avatarMovesWithPart = true; // i.e. legacy mode, NOT avatar-as-a-prim (SL) mode
         public bool AvatarMovesWithPart
         {

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1298,14 +1298,17 @@ namespace OpenSim.Region.Framework.Scenes
                     m_requestedSitTargetUUID = part.UUID;
                     m_requestedSitTargetID = part.LocalId;
 
-                    Vector3 sitTargetPos = part.SitTargetPosition;
-                    Quaternion sitTargetOrient = part.SitTargetOrientation;
+                    if (m_avatarMovesWithPart)
+                    {
+                        Vector3 sitTargetPos = part.SitTargetPosition;
+                        Quaternion sitTargetOrient = part.SitTargetOrientation;
 
-                    Vector3 newPos = sitTargetPos;
-                    newPos += m_sitTargetCorrectionOffset;
-                    m_bodyRot = sitTargetOrient;
-                    //Rotation = sitTargetOrient;
-                    SetAgentPositionInfo(null, true, newPos, part, part.AbsolutePosition, Vector3.Zero);
+                        Vector3 newPos = sitTargetPos;
+                        newPos += m_sitTargetCorrectionOffset;
+                        m_bodyRot = sitTargetOrient;
+                        //Rotation = sitTargetOrient;
+                        SetAgentPositionInfo(null, true, newPos, part, part.AbsolutePosition, Vector3.Zero);
+                    }
                 }
                 //m_animPersistUntil = 0;    // abort any timed animation
 
@@ -4103,6 +4106,8 @@ namespace OpenSim.Region.Framework.Scenes
             }
 
             cAgent.ActiveGroupID = m_controllingClient.ActiveGroupId;
+
+            cAgent.AvatarAsAPrim = !AvatarMovesWithPart;    // default (false) in protocol is legacy value (AvatarMovesWithPart==true).
         }
 
         public void CopyFrom(AgentData cAgent)
@@ -4159,6 +4164,8 @@ namespace OpenSim.Region.Framework.Scenes
 
             m_restoredConstantForce = cAgent.ConstantForces;
             m_restoredConstantForceIsLocal = cAgent.ConstantForcesAreLocal;
+
+            AvatarMovesWithPart = !cAgent.AvatarAsAPrim;    // default (false) in protocol is legacy value (AvatarMovesWithPart==true).
 
             if (cAgent.LocomotionState == 1)
             {

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -3252,6 +3252,11 @@ namespace OpenSim.Region.Framework.Scenes
             SceneObjectPart part = parent;
             SceneObjectPart rootPart = (part == null) ? null : part.ParentGroup.RootPart;
 
+            if (!this.AvatarMovesWithPart)
+            {   // avatar-as-a-prim mode
+                return;
+            }
+
             // Viewer seems to draw the avatar based on the hip position.
             // If you don't include HipOffset (which is raising the avatar 
             // since it's normally negative), then the viewer will draw 

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -762,6 +762,8 @@ namespace OpenSim.Region.Framework.Scenes
                     m_posInfo.Position += oldPart.OffsetPosition;
                     m_posInfo.m_parentPos = rootPart.GroupPosition;
                     m_posInfo.m_parent = rootPart;
+                    oldPart.ReparentSeatedAvatar(this, rootPart);
+                    rootPart.ReparentSeatedAvatar(this, rootPart);
                 }
 
                 // now in Avatar-As-A-Prim mode, only moves with root prim, not child prims

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -749,6 +749,44 @@ namespace OpenSim.Region.Framework.Scenes
             return isSafe;
         }
 
+        public void SetAvatarAsAPrimMode()
+        {
+            lock (m_posInfo)
+            {
+                SceneObjectPart oldPart = m_posInfo.m_parent;
+                SceneObjectPart rootPart = oldPart.ParentGroup.RootPart;
+                if (rootPart != oldPart)
+                {
+                    // Reparent to root prim if not already
+                    m_bodyRot = m_bodyRot / m_posInfo.m_parent.RotationOffset;
+                    m_posInfo.Position += oldPart.OffsetPosition;
+                    m_posInfo.m_parentPos = rootPart.GroupPosition;
+                    m_posInfo.m_parent = rootPart;
+                }
+
+                // now in Avatar-As-A-Prim mode, only moves with root prim, not child prims
+                m_avatarMovesWithPart = false;
+            }
+        }
+
+        public void UpdateSeatedPosition(Vector3 newpos)
+        {
+            lock (m_posInfo)
+            {
+                m_posInfo.Position = newpos;
+            }
+            SendTerseUpdateToAllClients();
+        }
+
+        public void UpdateSeatedRotation(Quaternion newrot)
+        {
+            lock (m_posInfo)
+            {
+                m_bodyRot = newrot;
+            }
+            SendTerseUpdateToAllClients();
+        }
+
         /// <summary>
         /// If this is true, agent doesn't have a representation in this scene.
         ///    this is an agent 'looking into' this scene from a nearby scene(region)


### PR DESCRIPTION
Major changes for avatar-as-a-prim (AaaP). Should be mostly backwards-compatible with existing scripts where possible. If a script positions or rotates an avatar as if it was a prim, that avatar (SP) switches into avatar-as-a-prim mode (AvatarMovesWithPart becomes false). This AaaP mode resets to legacy mode if the avatar stands or leaves the region.

This PR may also fix obscure problems with culling missing or including some prims inappropriately, as well as several timing problems on region crossings/entry that could place the avatar in the sky or at 0,0,0.