### PR TITLE
Fixes the regression in the db connect string prepending enhancement

### DIFF
--- a/OpenSim/Region/CoreModules/Avatar/Search/AvatarSearchModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Search/AvatarSearchModule.cs
@@ -116,14 +116,20 @@ namespace OpenSim.Region.CoreModules.Avatar.Search
             IConfig myConfig = config.Configs["Startup"];
             string connstr = myConfig.GetString("core_connection_string", String.Empty);
             _rdbConnectionTemplate = myConfig.GetString("rdb_connection_template", String.Empty);
-            if (!_rdbConnectionTemplate.Contains("Data Source"))
+            if (!String.IsNullOrWhiteSpace(_rdbConnectionTemplate))
             {
-                _rdbConnectionTemplate = "Data Source={0};" + _rdbConnectionTemplate;
+                if (!_rdbConnectionTemplate.ToLower().Contains("data source"))
+                {
+                    _rdbConnectionTemplate = "Data Source={0};" + _rdbConnectionTemplate;
+                }
             }
             _rdbConnectionTemplateDebug = myConfig.GetString("rdb_connection_template_debug", String.Empty);
-            if (!_rdbConnectionTemplateDebug.Contains("Data Source"))
+            if (!String.IsNullOrWhiteSpace(_rdbConnectionTemplateDebug))
             {
-                _rdbConnectionTemplateDebug = "Data Source={0};" + _rdbConnectionTemplateDebug;
+                if (!_rdbConnectionTemplateDebug.ToLower().Contains("data source"))
+                {
+                    _rdbConnectionTemplateDebug = "Data Source={0};" + _rdbConnectionTemplateDebug;
+                }
             }
             _connFactory = new ConnectionFactory("MySQL", connstr);
 

--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -117,14 +117,20 @@ namespace OpenSim.Region.CoreModules.World.Land
             IConfig myConfig = config.Configs["Startup"];
             string connstr = myConfig.GetString("core_connection_string", String.Empty);
             _rdbConnectionTemplate = myConfig.GetString("rdb_connection_template", String.Empty);
-            if (!_rdbConnectionTemplate.Contains("Data Source"))
+            if (!String.IsNullOrWhiteSpace(_rdbConnectionTemplate))
             {
-                _rdbConnectionTemplate = "Data Source={0};" + _rdbConnectionTemplate;
+                if (!_rdbConnectionTemplate.ToLower().Contains("data source"))
+                {
+                    _rdbConnectionTemplate = "Data Source={0};" + _rdbConnectionTemplate;
+                }
             }
             _rdbConnectionTemplateDebug = myConfig.GetString("rdb_connection_template_debug", String.Empty);
-            if (!_rdbConnectionTemplateDebug.Contains("Data Source"))
+            if (!String.IsNullOrWhiteSpace(_rdbConnectionTemplateDebug))
             {
-                _rdbConnectionTemplateDebug = "Data Source={0};" + _rdbConnectionTemplateDebug;
+                if (!_rdbConnectionTemplateDebug.ToLower().Contains("data source"))
+                {
+                    _rdbConnectionTemplateDebug = "Data Source={0};" + _rdbConnectionTemplateDebug;
+                }
             }
             _connFactory = new ConnectionFactory("MySQL", connstr);
 


### PR DESCRIPTION
Fixes a problem introduced in
https://github.com/InWorldz/halcyon/commit/b4031c2b83a776e748ed2e335d7022a9e33501b4
where the _rdbConnectionTemplateDebug was used instead of
_rdbConnectionTemplate, and with only a data source (no credentials), if
missing from the INI file (like on IW production machines).  Also
removes case-sensitivity on the "Data Source" existence check.