### PR TITLE
ROW_FORMAT compatibility

### DIFF
--- a/bin/inworldz-core-base.sql
+++ b/bin/inworldz-core-base.sql
@@ -1210,7 +1210,7 @@ CREATE TABLE `regions` (
   KEY `regionHandle` (`regionHandle`),
   KEY `overrideHandles` (`eastOverrideHandle`,`westOverrideHandle`,`southOverrideHandle`,`northOverrideHandle`),
   KEY `IDX_XY` (`locX`,`locY`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Rev. 3';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Rev. 3';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/bin/inworldz-core-base.sql
+++ b/bin/inworldz-core-base.sql
@@ -507,7 +507,7 @@ CREATE TABLE `events` (
   `mature` enum('true','false') NOT NULL,
   PRIMARY KEY (`eventid`),
   KEY `IDX_DATE` (`dateUTC`)
-) ENGINE=InnoDB AUTO_INCREMENT=24408 DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB AUTO_INCREMENT=24408 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --


### PR DESCRIPTION
Removed **both** of the ROW_FORMAT directives.  One is no longer compatible, one is the default anyway. Should avoid future compatibility problems, e.g. on other engines (ISAM).