### PR TITLE
Fixed problem with sit target sitter being cleared on backup

### DIFF
--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1535,7 +1535,7 @@ namespace OpenSim.Region.Framework.Scenes
         public void SetRootPart(SceneObjectPart part)
         {
             m_rootPart = part;
-            part.SetParent(this);
+            part.SetParent(this, false);
 
             if (!IsAttachment)
                 part.ParentID = 0;
@@ -2471,7 +2471,7 @@ namespace OpenSim.Region.Framework.Scenes
             }
             else
             {
-                newPart.SetParent(this);
+                newPart.SetParent(this, true);
             }
             
             m_childParts.AddPart(newPart);

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -3576,16 +3576,21 @@ namespace OpenSim.Region.Framework.Scenes
         /// <summary>
         ///
         /// </summary>
-        public void SetParent(SceneObjectGroup parent)
+        public void SetParent(SceneObjectGroup parent, bool isDuplicate)
         {
-            if (m_parentGroup != parent)
-                parent.SetSitTarget(this, SitTargetPosition, SitTargetOrientation);
+            bool hasChanged = (m_parentGroup != parent);
             m_parentGroup = parent;
+
+            // If this is being called from CopyPart, as part of the persistence backup, 
+            // then it is a duplicate copy of the SOP/SOG that has UUID/LocalID that 
+            // matches the in-world copy, so don't change the in-world SOG/SOP.
+            if (hasChanged && !isDuplicate)
+                parent.SetSitTarget(this, SitTargetPosition, SitTargetOrientation);
         }
 
         public void SetParentAndUpdatePhysics(SceneObjectGroup parent)
         {
-            this.SetParent(parent);
+            this.SetParent(parent, false);
 
             PhysicsActor physActor = PhysActor;
             if (physActor != null)


### PR DESCRIPTION
Calls to SetParent from the backup code (CopyPart) operate on a _duplicate_ of the in-world SOG/SOP, which have _a matching UUID_ to an object instance in-world. When SetParent calls SetSitTarget, it finds the _in-world_ copy (by UUID) and updates the dictionary based on the sitInfo of the _duplicate_ copy, which doesn't have a sitter on it.  (The avatar is only sitting on one object at a time.)  When it found the UUID, it replaced the sit target info with the _available_ sit target copy, allowing a second avatar on the _same_ sit target, even with others available.  Reported by Arkady in the forum http://inworldz.com/forums/viewtopic.php?p=210899#p210899