### PR TITLE
Release 0.9.28

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -7892,12 +7892,12 @@ namespace InWorldz.Phlox.Engine
                 if (av != null)
                 {
                     SceneObjectPart part = FindAvatarOnObject(key);
-                    if (part != null)
+                    if (part.ParentGroup == m_host.ParentGroup)
                     {
                         // if the avatar is sitting on this object, then
                         // we can unsit them.  We don't want random scripts unsitting random people
                         // Lets avoid the popcorn avatar scenario.
-                        av.StandUp(part, false, true);
+                        av.StandUp(false, true);
                     }
                     else
                     {
@@ -7915,7 +7915,7 @@ namespace InWorldz.Phlox.Engine
                                 (m_host.OwnerID == m_host.GroupID && m_host.GroupID == parcel.landData.GroupID && parcel.landData.IsGroupOwned) ||
                                 scene.Permissions.CanIssueEstateCommand(m_host.OwnerID, false) || World.Permissions.IsGod(m_host.OwnerID))
                             {
-                                av.StandUp(null, false, true);
+                                av.StandUp(false, true);
                             }
                         }
                     }
@@ -14718,7 +14718,7 @@ namespace InWorldz.Phlox.Engine
                 ScenePresence avatar = World.GetScenePresence(m_host.AttachedAvatar);
                 if (avatar == null)
                     return 0;
-                avatar.StandUp(null, false, true);
+                avatar.StandUp(false, true);
                 avatar.Teleport(position);
             }
             else

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
@@ -144,7 +144,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
             if (sp == null)
                 return false;
 
-            sp.StandUp(null, false, true);
+            sp.StandUp(false, true);
             return true;
         }
 

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotManager.cs
@@ -798,7 +798,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
             if (sp == null)
                 return false;
 
-            sp.StandUp(null, false, true);
+            sp.StandUp(false, true);
             sp.Teleport(position);
             return true;
         }

--- a/OpenSim/Region/CoreModules/Agent/BotManager/MovementAction.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/MovementAction.cs
@@ -223,7 +223,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
 
         public void Teleport(ScenePresence botPresence, Vector3 pos)
         {
-            botPresence.StandUp(null, false, true);
+            botPresence.StandUp(false, true);
             botPresence.Teleport(pos);
         }
 

--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -391,7 +391,7 @@ namespace OpenSim.Region.CoreModules.World.Land
             if (posInfo.Parent != null)
             {
                 // can't find the prim seated on, stand up
-                avatar.StandUp(null, false, true);
+                avatar.StandUp(false, true);
 
                 // fall through to unseated avatar code.
             }

--- a/OpenSim/Region/CoreModules/World/Land/LandObject.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandObject.cs
@@ -555,7 +555,7 @@ namespace OpenSim.Region.CoreModules.World.Land
             if (posInfo.Parent != null)
             {
                 // can't find the prim seated on, stand up
-                sp.StandUp(null, false, true);
+                sp.StandUp(false, true);
 
                 // fall through to unseated avatar code.
             }

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2501,7 +2501,7 @@ namespace OpenSim.Region.Framework.Scenes
                 group.ForEachSittingAvatar((ScenePresence sp) =>
                 {
                     if (!sp.IsChildAgent)
-                        sp.StandUp(null, fromCrossing, false);
+                        sp.StandUp(fromCrossing, false);
                 });
             }
 
@@ -3590,7 +3590,7 @@ namespace OpenSim.Region.Framework.Scenes
             if (avatar != null)
             {
                 isChildAgent = avatar.IsChildAgent;
-                avatar.StandUp(null, false, true);
+                avatar.StandUp(false, true);
             }
 
             try
@@ -4795,7 +4795,7 @@ namespace OpenSim.Region.Framework.Scenes
                     position.Z = newPosZ;
                 }
 
-                avatar.StandUp(null, false, true);
+                avatar.StandUp(false, true);
                 avatar.ControllingClient.SendLocalTeleport(position, lookAt, (uint)teleportFlags);
                 avatar.Teleport(position);
 
@@ -4811,7 +4811,7 @@ namespace OpenSim.Region.Framework.Scenes
                     "[SCENE COMMUNICATION SERVICE]: RequestTeleportToLocation to {0} in {1}",
                     position, destRegionName);
 
-                avatar.StandUp(null, false, true);
+                avatar.StandUp(false, true);
 
                 AvatarTransit.TransitArguments args = new AvatarTransit.TransitArguments
                 {

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1664,7 +1664,7 @@ namespace OpenSim.Region.Framework.Scenes
                 m_childAvatars.ForEach((ScenePresence SP) => {
                     m_log.WarnFormat("[SCENE]: DeleteGroup {0} with avatar {1} seated on prim (crossing={2}).",
                                         UUID.ToString(), SP.ControllingClient.AgentId, fromCrossing.ToString());
-                    SP.StandUp(null, fromCrossing, false);
+                    SP.StandUp(fromCrossing, false);
                 });
 
                 m_childParts.ForEachPart((SceneObjectPart part) => {

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -2253,13 +2253,10 @@ namespace OpenSim.Region.Framework.Scenes
 
                 if ((known_part != null) || (info.Parent != null))
                 {
-                    part = info.Parent;
-                    if (known_part != null)
-                    {
-                        if ((part != null) && (part != info.Parent))
-                            m_log.ErrorFormat("[SCENE PRESENCE]: StandUp for {0} with parentID={1} does not match seated part {2}.", this.Name, (info.Parent==null)? 0 : info.Parent.LocalId, part.LocalId.ToString());
-                        part = known_part;
-                    }
+                    if (m_requestedSitTargetUUID != UUID.Zero)
+                        part = Scene.GetSceneObjectPart(m_requestedSitTargetUUID);  // stand from sit target
+                    else
+                        part = info.Parent;     // stand from prim without sit target
 
                     if (part == null)
                     {

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1757,7 +1757,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             if ((flags & (uint) AgentManager.ControlFlags.AGENT_CONTROL_STAND_UP) != 0)
             {
-                StandUp(null, false, true);
+                StandUp(false, true);
             }
 
             m_mouseLook = (flags & (uint) AgentManager.ControlFlags.AGENT_CONTROL_MOUSELOOK) != 0;
@@ -2230,7 +2230,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// Perform the logic necessary to stand the client up.  This method also executes
         /// the stand animation.
         /// </summary>
-        public void StandUp(SceneObjectPart known_part, bool fromCrossing, bool recheckGroupForAutoreturn)
+        public void StandUp(bool fromCrossing, bool recheckGroupForAutoreturn)
         {
             SceneObjectPart part = null;
             float partTop = 0.0f;
@@ -2251,7 +2251,7 @@ namespace OpenSim.Region.Framework.Scenes
 
                 PositionInfo info = GetPosInfo();
 
-                if ((known_part != null) || (info.Parent != null))
+                if (info.Parent != null)
                 {
                     if (m_requestedSitTargetUUID != UUID.Zero)
                         part = Scene.GetSceneObjectPart(m_requestedSitTargetUUID);  // stand from sit target
@@ -2583,7 +2583,7 @@ namespace OpenSim.Region.Framework.Scenes
                 return;
             }
 
-            StandUp(null, false, true);
+            StandUp(false, true);
 
             //SceneObjectPart part = m_scene.GetSceneObjectPart(targetID);
             SceneObjectPart part = FindNextAvailableSitTarget(targetID);
@@ -2618,7 +2618,7 @@ namespace OpenSim.Region.Framework.Scenes
 //            m_log.InfoFormat("[SCENE PRESENCE]: HandleAgentRequestSit agent {0} at {1} requesing sit at {2} ", agentID.ToString(), m_pos.ToString(), offset.ToString());
 //            m_movementflag = 0;
 
-            StandUp(null, false, true);
+            StandUp(false, true);
 
             if (!String.IsNullOrEmpty(sitAnimation))
             {
@@ -4960,7 +4960,7 @@ namespace OpenSim.Region.Framework.Scenes
                 }
             }
 
-            StandUp(null, false, true); // SL stands up the user on a forced controls release
+            StandUp(false, true); // SL stands up the user on a forced controls release
 
             if (!found) // fail-safe... do *something* when this is called.
                 ControllingClient.SendTakeControls2(-1, false, false, -1, false, true);


### PR DESCRIPTION
Some small but important post-rollout fixes for issues with new code and regressions. Missing permissions check on llUnSit calls, StandUp applying to the root prim after use of avatar-as-a-prim features.