### PR TITLE
Replaced some GetSceneObjectPart calls with a new GetSitTargetPart.

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -4371,8 +4371,8 @@ namespace InWorldz.Phlox.Engine
                     }
                     else
                     {
-                        ScenePresence.PositionInfo info = presence.GetPosInfo();
-                        if(info.Parent != null && info.Parent.ObjectOwner == m_host.OwnerID)
+                        SceneObjectPart parent = presence.GetSitTargetPart();
+                        if(parent != null && parent.ObjectOwner == m_host.OwnerID)
                         {
                             implicitPerms = ScriptBaseClass.PERMISSION_TRIGGER_ANIMATION;
                         }
@@ -5857,18 +5857,10 @@ namespace InWorldz.Phlox.Engine
 
                 // Find pushee position
                 // Pushee Linked?
-                ScenePresence.PositionInfo info = pusheeav.GetPosInfo();
-                if (info.Parent != null)
+                SceneObjectPart parentobj = pusheeav.GetSitTargetPart();
+                if (parentobj != null)
                 {
-                    SceneObjectPart parentobj = info.Parent;
-                    if (parentobj != null)
-                    {
-                        PusheePos = parentobj.AbsolutePosition;
-                    }
-                    else
-                    {
-                        PusheePos = pusheeav.AbsolutePosition;
-                    }
+                    PusheePos = parentobj.AbsolutePosition;
                 }
                 else
                 {
@@ -7133,8 +7125,8 @@ namespace InWorldz.Phlox.Engine
                 flags |= ScriptBaseClass.AGENT_WALKING;
             }
 
-            ScenePresence.PositionInfo info = agent.GetPosInfo();
-            if (info.Parent != null)
+            SceneObjectPart parent = agent.GetSitTargetPart();
+            if (parent != null)
             {
                 flags |= ScriptBaseClass.AGENT_ON_OBJECT;
                 flags |= ScriptBaseClass.AGENT_SITTING;
@@ -7891,8 +7883,8 @@ namespace InWorldz.Phlox.Engine
 
                 if (av != null)
                 {
-                    SceneObjectPart part = FindAvatarOnObject(key);
-                    if (part.ParentGroup == m_host.ParentGroup)
+                    SceneObjectPart part = av.GetSitTargetPart();
+                    if ((part != null) && (part.ParentGroup == m_host.ParentGroup))
                     {
                         // if the avatar is sitting on this object, then
                         // we can unsit them.  We don't want random scripts unsitting random people
@@ -8592,13 +8584,6 @@ namespace InWorldz.Phlox.Engine
         public void llSitTarget(LSL_Vector offset, LSL_Rotation rot)
         {
             llLinkSitTarget(m_host.LinkNum, offset, rot);
-        }
-
-        private SceneObjectPart FindAvatarOnObject(UUID agentId)
-        {
-            ScenePresence sp = m_host.ParentGroup.Scene.GetScenePresence(agentId);
-            ScenePresence.PositionInfo posInfo = (sp == null) ? null : sp.GetPosInfo();
-            return (posInfo == null) ? null : posInfo.Parent;
         }
 
         private string AvatarOnSitTarget(int linknumber, bool IncludeSitTargetOnly)

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1114,6 +1114,15 @@ namespace OpenSim.Region.Framework.Scenes
 
 #region Status Methods
 
+        public SceneObjectPart GetSitTargetPart()
+        {
+            SceneObjectPart part = null;
+            if (m_requestedSitTargetUUID != UUID.Zero)
+                part = m_scene.GetSceneObjectPart(m_requestedSitTargetUUID);
+
+            return part;
+        }
+
         /// <summary>
         /// This turns a child agent, into a root agent
         /// This is called when an agent teleports into a region, or if an
@@ -1122,9 +1131,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         public SceneObjectPart MakeRootAgent(Vector3 pos)
         {
-            SceneObjectPart part = null;
-            if (m_requestedSitTargetUUID != UUID.Zero)
-                part = m_scene.GetSceneObjectPart(m_requestedSitTargetUUID);
+            SceneObjectPart part = GetSitTargetPart();
 
             DumpDebug("MakeRootAgent", "n/a");
             m_log.DebugFormat(
@@ -2152,7 +2159,7 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 if (m_sitAtAutoTarget)
                 {
-                    SceneObjectPart part = m_scene.GetSceneObjectPart(m_requestedSitTargetUUID);
+                    SceneObjectPart part = GetSitTargetPart();
                     if (part != null)
                     {
                         lock (m_posInfo)


### PR DESCRIPTION
This is the rest of the cleanup from https://github.com/InWorldz/halcyon/commit/37ebcd69130bdae0f6b9dbafcb027748c1a18b19 that was not essential to the 0.9.28 release. It should have no effect on the region behavior, but it is technically more correct to check against the correct prim after avatar-as-a-prim reparents the avatar on the root prim.  We need to remember to do script checks etc on the original sit target part, e.g. for runtime permissions, not the root prim.

Replaced GetSceneObjectPart(m_requestedSitTargetUUID) calls with a new GetSitTargetPart() for better self-documenting code. In some cases you want the seated avatar's visual parent (e.g. for updates), but in some cases (LSL scripting) you often want the original sat-upon prim (e.g. for runtime permissions checks for scripts).  This is an attempt to differentiate more obviously in the code between the two different usage patterns.  The most obvious place where this would mattered was in LSLSystemAPI.cs GetImplicitPermissions() which could cause implicit permissions to apply only to scripts in the root prim, however in that case the prim owner is checked, which should be the same for the child part and the root prim.  The other place was in llPushObject where the position would have been incorrect for the seated avatar, but that wouldn't matter in llPushObject for a seated avatar.