### PR TITLE
Fixed missing Initialize call for loading load asset XML files.

### DIFF
--- a/InWorldz/InWorldz.Data.Assets.Stratus/StratusAssetClient.cs
+++ b/InWorldz/InWorldz.Data.Assets.Stratus/StratusAssetClient.cs
@@ -120,6 +120,7 @@ namespace InWorldz.Data.Assets.Stratus
                 if (Config.Settings.Instance.LegacySupport)
                 {
                     _whipAssetClient = new Whip.Client.AssetClient(Config.Settings.Instance.WhipURL);
+                    _whipAssetClient.Initialize(settings);
 
                     if (Config.Settings.Instance.CFSupport)
                     {


### PR DESCRIPTION
If config isn't passed in, _settings is null and LoadDefaultAssets() is not called to load the XML files from the assets subfolder.  I believe this is why the "missing" asset counters are so high.