### PR TITLE
Made a simple change to be able to mark the default assets as loaded.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,7 @@ bin/trustednetworks.txt
 bin/addin-db-001/
 bin/addin-db-002/
 bin/ScriptEngines/Phlox/states/script_states.db3
+bin/assets/AssetSets.xml.loaded
 
 # Other files that need to be created per-installation
 bin/Halcyon.ini

--- a/OpenSim/Framework/Communications/Cache/WHIPAssetClient.cs
+++ b/OpenSim/Framework/Communications/Cache/WHIPAssetClient.cs
@@ -30,6 +30,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using OpenSim.Framework;
 using log4net;
@@ -113,9 +114,26 @@ namespace InWorldz.Whip.Client
         public virtual void LoadDefaultAssets(string pAssetSetsXml)
         {
             _log.Info("[ASSET SERVER]: Setting up asset database");
-            _loadingDefaultAssets = true;
-            assetLoader.ForEachDefaultXmlAsset(pAssetSetsXml, StoreAsset);
-            _loadingDefaultAssets = false;
+            var signpostMarkerFilename = $"{pAssetSetsXml}.loaded";
+
+            if (File.Exists(signpostMarkerFilename))
+            {
+                _log.Info("[ASSET SERVER]: Asset database marked as already set up. Not reloading default assets.");
+            }
+            else
+            {
+                _loadingDefaultAssets = true;
+                assetLoader.ForEachDefaultXmlAsset(pAssetSetsXml, StoreAsset);
+                _loadingDefaultAssets = false;
+                try
+                {
+                    File.CreateText(signpostMarkerFilename).Close();
+                }
+                catch(Exception e)
+                {
+                    _log.Error($"Unable to create file '{signpostMarkerFilename}' to mark default assets as having been already loaded.", e);
+                }
+            }
         }
 
         private List<string[]> ParseReadWriteWhipURL(string url)

--- a/bin/assets/README.txt
+++ b/bin/assets/README.txt
@@ -1,7 +1,7 @@
 README
 
-OpenSim comes with a default asset set contained in the OpenSimAssetSet
-directory.  You can also load up your own asset set to OpenSim on startup by
+Halcyon comes with a default asset set contained in the OpenSimAssetSet
+directory.  You can also load up your own asset set to Halcyon on startup by
 making a file entry in AssetSets.xml.  This file should point towards an XML
 file which details the assets in your asset set.  The 
 OpenSimAssetSet/OpenSimAssetSet.xml is a good template for the information 
@@ -10,3 +10,7 @@ required.
 If you want your assets to show up in the standard inventory library for an
 avatar, you will also need to add separate entries to the xml files in the
 bin/inventory configuration directory.
+
+If you've run the region before you'll need to remove the
+AssetSets.xml.loaded file in order to get the server to load the changes up
+to the asset server.


### PR DESCRIPTION
This should dramatically speed up relaunch times.  If you are operating an existing grid and don't want the default assets being loaded, simply create a new file in the assets folder named AssetSets.xml.loaded

Below you can find the list of ideas for solving this annoyance.  This gives some background into why this solution was chosen.
The last idea is the best one, but is a LOT more complex of a solution.  Someday maybe.

== XML->HashUUID->AssetServer
* hash xml file into Hash-style UUID with a special name for possible later cleanup ops and store on asset server.
* If store fails (duplicate) then don't reload the data.

Issues:
* Requires writing a hasher that does the hash-style UUIDs.  Complex.
* Adds MORE ASSETS to the asset server.  Yuck. 

== Move the files to an installed folder
* Really only need to move the Assets.xml file
* Simple move file change.

Issues:
* Git now thinks the file's been removed and wants you to commit the change. (critical problem)
* Requires the server to have write on the folder, which it might not.

== Rename the Assets.xml file
* Simple rename file change.

Issues:
* Git now thinks the file's been removed and wants you to commit the change. (critical problem)
* Requires the server to have write on the folder, which it might not.

== Use a signpost file (current favorite)
* Simple does-file-exist check is only addition to region source.
* Signpost can be added to .gitignore

Issues:
* Requires the server to have write on the folder, which it might not.  Not too big of an issue: the server will just be slow unles the sysadmin manually puts in the signpost file.
* If sysadmin changes any of the default assets he has to 

== Make default asset loading not the region's problem
* Region gets something that doesn't belong to it taken away.
* A special tool would be created for loading in default assets.
* Documentation about the change.

Issues:
* Most complex change.
