### PR TITLE
Slow apply physics

### DIFF
--- a/OpenSim/Framework/Util.cs
+++ b/OpenSim/Framework/Util.cs
@@ -2500,7 +2500,19 @@ namespace OpenSim.Framework
 
                 m_log.Info(m_context + ": " + elapsed.ToString());
             }
-            
+        }
+
+        public static void ReportIfSlow(string prefix, int millis, System.Action action)
+        {
+            Util.SlowTimeReporter slowCheck = new Util.SlowTimeReporter(prefix, new TimeSpan(0, 0, 0, 0, millis));
+            try
+            {
+                action();
+            }
+            finally
+            {
+                slowCheck.Complete();
+            }
         }
     }
 }

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1781,23 +1781,42 @@ namespace OpenSim.Region.Framework.Scenes
         /// <param name="m_physicalPrim"></param>
         public void ApplyPhysics(bool allowPhysicalPrims, bool fromStorage)
         {
+            // Some diagnostic thresholds for reporting slow/inefficient operations.
+            const int SLOW_CALC_THRESHOLD = 1000;   // > this in ms considered slow calc
+            const int PHYS_PRIMS_THRESHOLD = 16; // > this reports many physical prims
+
             if (!m_rootPart.PhysicsSummary.NeedsPhysicsShape)
                 return;
 
             if (m_childParts.Count > 1)
             {
                 List<BulkShapeData> allParts = new List<BulkShapeData>();
-                allParts.Add(m_rootPart.GenerateBulkShapeData());
-
-                m_childParts.ForEachPart((SceneObjectPart part) => {
-                    if (part.LocalId != m_rootPart.LocalId)
+                int count = 1;
+                Vector3 pos = this.AbsolutePosition;
+                string prefix = String.Format("[SCENE]: Slow GenerateBulkShapeData for '{0}' at {1}/{2}/{3} ", this.Name, (int)pos.X, (int)pos.Y, (int)pos.Z);
+                Util.ReportIfSlow(prefix+"(object)", SLOW_CALC_THRESHOLD, () => 
+                {
+                    Util.ReportIfSlow(prefix+"(root)", SLOW_CALC_THRESHOLD, () => 
                     {
-                        if (part.RequiresPhysicalShape)
+                        allParts.Add(m_rootPart.GenerateBulkShapeData());
+                    });
+
+                    m_childParts.ForEachPart((SceneObjectPart part) => {
+                        if (part.LocalId != m_rootPart.LocalId)
                         {
-                            allParts.Add(part.GenerateBulkShapeData());
+                            if (part.RequiresPhysicalShape)
+                            {
+                                count++;
+                                Util.ReportIfSlow(prefix+"(#"+part.LinkNum.ToString()+")", SLOW_CALC_THRESHOLD, () =>
+                                {
+                                    allParts.Add(part.GenerateBulkShapeData());
+                                });
+                            }
                         }
-                    }
+                    });
                 });
+                if (count > PHYS_PRIMS_THRESHOLD)
+                    m_log.WarnFormat("[SCENE]: ApplyPhysics object included {0} physical prims.", count);
 
                 m_scene.PhysicsScene.BulkAddPrimShapes(allParts, m_rootPart.GeneratePhysicsAddPrimShapeFlags(allowPhysicalPrims, fromStorage));
 


### PR DESCRIPTION
Diagnostics to report slow/inefficient operations in `ApplyPhysics` to attempt to get to the bottom of the high CPU usage on crossings.