### PR TITLE
A new call to llSitTarget must preserve any seated avatar!

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -8577,7 +8577,7 @@ namespace InWorldz.Phlox.Engine
             var parts = GetLinkPrimsOnly(linknumber);
             foreach (SceneObjectPart part in parts)
             {
-                part.SetSitTarget(sitPos, sitRot);
+                part.SetSitTarget(sitPos, sitRot, true);
             }
         }
 

--- a/InWorldz/InWorldz.Region.Data.Thoosa/Tests/Util.cs
+++ b/InWorldz/InWorldz.Region.Data.Thoosa/Tests/Util.cs
@@ -208,7 +208,7 @@ namespace InWorldz.Region.Data.Thoosa.Tests
             part.Velocity = Util.RandomVector();
             part.FromItemID = UUID.Random();
 
-            part.SetSitTarget(Util.RandomVector(), Util.RandomQuat());
+            part.SetSitTarget(Util.RandomVector(), Util.RandomQuat(), false);
 
             return part;
         }

--- a/OpenSim/Data/MySQL/MySQLRegionData.cs
+++ b/OpenSim/Data/MySQL/MySQLRegionData.cs
@@ -1767,7 +1767,8 @@ namespace OpenSim.Data.MySQL
                                 Convert.ToSingle(row["SitTargetOrientY"]),
                                 Convert.ToSingle(row["SitTargetOrientZ"]),
                                 Convert.ToSingle(row["SitTargetOrientW"])
-                             ));
+                             ), 
+                             false);
 
             prim.PayPrice[0] = Convert.ToInt32(row["PayPrice"]);
             prim.PayPrice[1] = Convert.ToInt32(row["PayButton1"]);

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1337,9 +1337,16 @@ namespace OpenSim.Region.Framework.Scenes
             });
         }
 
-        public void SetSitTarget(SceneObjectPart part, Vector3 pos, Quaternion rot)
+        public void SetSitTarget(SceneObjectPart part, Vector3 pos, Quaternion rot, bool preserveSitter)
         {
             SitTargetInfo sitInfo = new SitTargetInfo(part, pos, rot);
+            if (preserveSitter)
+            {
+                SitTargetInfo oldInfo;
+                if (m_sitTargets.TryGetValue(part.UUID, out oldInfo))
+                    sitInfo.Sitter = oldInfo.Sitter;
+            }
+
             if (sitInfo.IsSet)
             {
                 m_sitTargets[part.UUID] = sitInfo;
@@ -2537,7 +2544,7 @@ namespace OpenSim.Region.Framework.Scenes
                 m_childParts.RemovePart(part); // the old IDs are changing
                 part.ResetIDs(part.LinkNum); // Don't change link nums
                 m_childParts.AddPart(part); // update the part lists with new IDs
-                SetSitTarget(part, part.SitTargetPosition, part.SitTargetOrientation);
+                SetSitTarget(part, part.SitTargetPosition, part.SitTargetOrientation, false);
             }
         }
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -1719,12 +1719,12 @@ namespace OpenSim.Region.Framework.Scenes
             return (m_parentGroup.RootPart == this);    // matches?
         }
 
-        public void SetSitTarget(Vector3 pos, Quaternion rot)
+        public void SetSitTarget(Vector3 pos, Quaternion rot, bool preserveSitter)
         {
             SitTargetPosition = pos;
             SitTargetOrientation = rot;
             if (ParentGroup != null)
-                ParentGroup.SetSitTarget(this, pos, rot);
+                ParentGroup.SetSitTarget(this, pos, rot, preserveSitter);
         }
 
         public static readonly uint LEGACY_BASEMASK = 0x7FFFFFF0;
@@ -3585,7 +3585,7 @@ namespace OpenSim.Region.Framework.Scenes
             // then it is a duplicate copy of the SOP/SOG that has UUID/LocalID that 
             // matches the in-world copy, so don't change the in-world SOG/SOP.
             if (hasChanged && !isDuplicate)
-                parent.SetSitTarget(this, SitTargetPosition, SitTargetOrientation);
+                parent.SetSitTarget(this, SitTargetPosition, SitTargetOrientation, false);
         }
 
         public void SetParentAndUpdatePhysics(SceneObjectGroup parent)

--- a/OpenSim/Region/FrameworkTests/SceneUtil.cs
+++ b/OpenSim/Region/FrameworkTests/SceneUtil.cs
@@ -114,7 +114,7 @@ namespace OpenSim.Region.FrameworkTests
             part.Velocity = SceneUtil.RandomVector();
             part.FromItemID = UUID.Random();
 
-            part.SetSitTarget(SceneUtil.RandomVector(), SceneUtil.RandomQuat());
+            part.SetSitTarget(SceneUtil.RandomVector(), SceneUtil.RandomQuat(), false);
 
             return part;
         }


### PR DESCRIPTION
Oops.  A new sit target _offset_ doesn't really mean a new sit target _object_, with _no sitter_.  Fixes report by Trouble Morgan in the forum: http://inworldz.com/forums/viewtopic.php?p=211615#p211615