### PR TITLE
Fixed confusion over script (runtime perms) answer handling.

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -4496,8 +4496,9 @@ namespace InWorldz.Phlox.Engine
             }
             PermsChange(item, UUID.Zero, 0);
 
-            if (m_waitingForScriptAnswer != presence)
+            if (m_waitingForScriptAnswer != presence.ControllingClient)
             {
+                ClearWaitingForScriptAnswer(m_waitingForScriptAnswer);
                 presence.ControllingClient.OnScriptAnswer += handleScriptAnswer;
                 presence.ControllingClient.OnConnectionClosed += handleConnectionClosed;
                 m_waitingForScriptAnswer = presence.ControllingClient;


### PR DESCRIPTION
- `client.OnScriptAnswer` was not cleared if a new avatar was targeted for perms check.
- the test for existing was comparing an `LLCV` to an `SP` (`IClientAPI`) for equality.
- the second problem may have resulted in trying to add the same `OnScriptAnswer` and `OnConnectionClosed` handlers repeatedly, every time a runtime permissions prompt was issued.