### PR TITLE
Estate manager bans

### DIFF
--- a/OpenSim/Region/CoreModules/World/Estate/EstateManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Estate/EstateManagementModule.cs
@@ -258,12 +258,15 @@ namespace OpenSim.Region.CoreModules.World.Estate
         {
             if (AgentId == UUID.Zero)
                 return EstateResult.InvalidReq; // not found
-            if (AgentId == m_scene.RegionInfo.EstateSettings.EstateOwner)
-                return EstateResult.InvalidReq; // never process EO
-            if (m_scene.IsEstateOwnerPartner(AgentId))
-                return EstateResult.InvalidReq; // never process EO
-            if (AgentId == m_scene.RegionInfo.MasterAvatarAssignedUUID)
-                return EstateResult.InvalidReq; // never process owner
+            if (isBan)
+            {
+                if (m_scene.IsEstateManager(AgentId))
+                    return EstateResult.InvalidReq; // never process EO
+                if (m_scene.IsEstateOwnerPartner(AgentId))
+                    return EstateResult.InvalidReq; // never process EO
+                if (AgentId == m_scene.RegionInfo.MasterAvatarAssignedUUID)
+                    return EstateResult.InvalidReq; // never process owner
+            }
 
             EstateBan[] banlistcheck = m_scene.RegionInfo.EstateSettings.EstateBans;
 

--- a/OpenSim/Region/CoreModules/World/Land/LandObject.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandObject.cs
@@ -419,7 +419,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                 return true; // never deny the master avatar
             if (avatar == m_scene.RegionInfo.EstateSettings.EstateOwner)
                 return true; // never deny the estate owner
-            if (m_scene.IsEstateOwner(avatar))
+            if (m_scene.IsEstateManager(avatar))    // includes Estate Owner
                 return true;
             if (m_scene.IsEstateOwnerPartner(avatar))
                 return true;


### PR DESCRIPTION
- Do not enforce _parcel_ bans for Estate Managers. Fixes ![Mantis 3249](http://bugs.inworldz.com/mantis/view.php?id=3249) as discussed earlier.

- Also prevent Estate Managers from being banned from that _estate_, and allow removal of bans. Two changes:
    * Do not allow EM to be added to the ban list.
    * Do not prevent special cases from being *removed* from the ban list (EO, EM or master avatar). This fix also allows cleanup in the event that the EO/EM changes after the ban list is in place.