### PR TITLE
Changes to match SL's banned parcel implementation

### DIFF
--- a/OpenSim/Framework/Constants.cs
+++ b/OpenSim/Framework/Constants.cs
@@ -54,6 +54,9 @@ namespace OpenSim.Framework
 
         public const string DefaultTexture = "89556747-24cb-43ed-920b-47caed15465f";
 
+        // Avatar "bounce" when descending into a no-entry parcel (e.g. banned)
+        public const float AVATAR_BOUNCE = 10.0f;
+
         // Summary:
         //     Used by EstateOwnerMessage packets
         public enum EstateAccessDeltaCommands

--- a/OpenSim/Region/CoreModules/World/Land/LandChannel.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandChannel.cs
@@ -39,7 +39,8 @@ namespace OpenSim.Region.CoreModules.World.Land
 
         //Land types set with flags in ParcelOverlay.
         //Only one of these can be used.
-        public const float BAN_LINE_SAFETY_HEIGHT = 100;
+        public const float BAN_LINE_SAFETY_HEIGHT = 5000;   // min height over land if explicitly banned
+        public const float NON_PUBLIC_SAFETY_HEIGHT = 50;   // min height over land for non-public parcels
         public const byte LAND_FLAG_PROPERTY_BORDER_SOUTH = 128; //Equals 10000000
         public const byte LAND_FLAG_PROPERTY_BORDER_WEST = 64; //Equals 01000000
 
@@ -162,11 +163,11 @@ namespace OpenSim.Region.CoreModules.World.Land
             return false;
         }
 
-        public float GetBanHeight()
+        public float GetBanHeight(bool isBanned)
         {
             if (m_landManagementModule != null)
             {
-                return m_landManagementModule.BanHeight;
+                return isBanned ? m_landManagementModule.BanHeight : m_landManagementModule.NonPublicHeight;
             }
 
             return 0.0f;

--- a/OpenSim/Region/CoreModules/World/Land/LandObject.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandObject.cs
@@ -546,7 +546,6 @@ namespace OpenSim.Region.CoreModules.World.Land
             return true;
         }
 
-        private readonly float AVATAR_BOUNCE = 10.0f;
         public void RemoveAvatarFromParcel(UUID userID)
         {
             ScenePresence sp = m_scene.GetScenePresence(userID);
@@ -580,11 +579,11 @@ namespace OpenSim.Region.CoreModules.World.Land
             }
 
             ILandObject parcel = m_scene.LandChannel.GetLandObject(pos.X, pos.Y);
-            if ((parcel != null) && parcel.DenyParcelAccess(sp.UUID, out reason2))
+            float minZ;
+            if ((parcel != null) && m_scene.TestBelowHeightLimit(sp.UUID, pos, parcel, out minZ, out reason2))
             {
-                float minZ = LandChannel.BAN_LINE_SAFETY_HEIGHT + AVATAR_BOUNCE;
                 if (pos.Z < minZ)
-                    pos.Z = minZ;
+                    pos.Z = minZ + Constants.AVATAR_BOUNCE;
             }
 
             // Now force the non-sitting avatar to a position above the parcel

--- a/OpenSim/Region/Framework/Interfaces/ILandChannel.cs
+++ b/OpenSim/Region/Framework/Interfaces/ILandChannel.cs
@@ -76,7 +76,7 @@ namespace OpenSim.Region.Framework.Interfaces
         void setSimulatorObjectMaxOverride(overrideSimulatorMaxPrimCountDelegate overrideDel);
         void SetParcelOtherCleanTime(IClientAPI remoteClient, int localID, int otherCleanTime);
         void RefreshParcelInfo(IClientAPI remoteClient, bool force);
-        float GetBanHeight();
+        float GetBanHeight(bool isBanned);
         void RemoveAvatarFromParcel(UUID userID);
 
         // Region support for Plus parcel web updates

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -641,7 +641,8 @@ namespace OpenSim.Region.Framework.Scenes
                 if (NewParcel == null)
                     return; // Just don't allow it to change to something invalid
 
-                if ((NewParcel != null) && (val.Z < m_scene.LandChannel.GetBanHeight()))
+                // Optimization: Precheck with more restrictive general ban height before checking if the avatar is banned.
+                if ((NewParcel != null) && (val.Z < m_scene.LandChannel.GetBanHeight(false)))
                 {
                     // Possibly entering a restricted parcel.
                     ParcelPropertiesStatus reason;
@@ -651,7 +652,8 @@ namespace OpenSim.Region.Framework.Scenes
                         // First, let's check each rider to see if we need to eject them.
                         this.ForEachSittingAvatar(delegate (ScenePresence sitter)
                         {
-                            if (NewParcel.DenyParcelAccess(sitter.UUID, out reason))
+                            float minZ;
+                            if (m_scene.TestBelowHeightLimit(sitter.UUID, val, NewParcel, out minZ, out reason))
                             {
                                 Util.FireAndForget((o) =>
                                 {


### PR DESCRIPTION
As outlined in ![Mantis 3250](http://bugs.inworldz.com/mantis/view.php?id=3250):
- minimum height over a parcel _where avatar is in ban list_ now 5000m + terrain height (much higher)
- minimum height over _a parcel with public access disabled_ is now 50m + terrain height (generally lower)

It used to be a fixed 100m for both of those cases.  This also required splitting the constant value into two different values, and adding code to determine which case applied.