### PR TITLE
Fixed shallow copy (reference copying) in SOG.Copy

### DIFF
--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -209,7 +209,13 @@ namespace OpenSim.Region.Framework.Scenes
                     return String.Empty;
                 return RootPart.Name;
             }
-            set { RootPart.Name = value; }
+            set {
+                RootPart.Name = value;
+                // Also update the object name to keep it in sync with the root part name.
+                // This mostly only affects debugging since the Name getter override above
+                // pulls the name from the root part.
+                this.Name = value;
+            }
         }
 
         // when a prim enters a new region, this is the number of avatars that must be seated (waited for) before the prim can exit the region

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -2062,7 +2062,18 @@ namespace OpenSim.Region.Framework.Scenes
             SceneObjectGroup dupe = (SceneObjectGroup)MemberwiseClone();
             dupe.m_InTransition = 0;
             dupe.m_isBackedUp = false;
+
+            // The MemberwiseClone() above is a shallow copy. All of the object references from the old SOG need new instances.
             dupe.m_childParts = new GroupPartsCollection();
+            dupe.m_childAvatars = new AvatarPartsCollection();
+            dupe.m_sitTargets = new Dictionary<UUID, SitTargetInfo>();
+            dupe.m_targets = new List<ScriptPosTarget>(MAX_TARGETS);
+            dupe.m_rotTargets = new List<ScriptRotTarget>(MAX_TARGETS);
+            dupe.m_targetsLock = new object();
+            dupe._bbLock = new object();
+
+            dupe.m_targets.InsertRange(0, m_targets);
+            dupe.m_rotTargets.InsertRange(0, m_rotTargets);
 
             dupe.CopyRootPart(m_rootPart, OwnerID, GroupID, userExposed, serializePhysicsState);
 


### PR DESCRIPTION
Several SOG members are references to other objects and the MemberwiseClone() copies the _reference_. So changes to things like sit target lists, or LSL scripted targets, bounding box, etc in one copy of a SOG affected all copies of that SOG that were shift-copied. This resulted in Mike's report of sit targets being cleared in the original _after_ a shift-copy, and is probably responsible for some of the LSL target-related bugs, as well as other object "quantum entanglement" reports.

Reviewed SceneObjectGroup and EntityBase for other possible cases of this shallow copy problem pattern. Didn't find any further cases but did notice that the SOG.Name field (defined in EntityBase but overridden with the RootPart.Name in SOG.Name) wasn't kept in sync on changes. So a second commit also means that changes to the SOG.Name will now also update the object name to keep it in sync with the root part name. This mostly only affects debugging and other symbolic dumps since the Name getter override in SOG pulls the name from the root part.  But this keeps the objects consistent just in case.