### PR TITLE
Salt those new passwords!

### DIFF
--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -1143,7 +1143,7 @@ namespace OpenSim.Framework.Communications
         /// <returns>The UUID of the created user profile.  On failure, returns UUID.Zero</returns>
         public virtual UUID AddUser(string firstName, string lastName, string password, string email, uint regX, uint regY, UUID uuid)
         {
-            string salt = Util.RandomString(64);
+            string salt = Util.RandomString(32);
             string md5PasswdHash = Util.Md5Hash(Util.Md5Hash(password) + ":" + salt);
 
             UserProfileData userProf = GetUserProfile(firstName, lastName);
@@ -1335,7 +1335,7 @@ namespace OpenSim.Framework.Communications
         /// <returns>true if the update was successful, false otherwise</returns>
         public virtual bool ResetUserPassword(string firstName, string lastName, string newPassword)
         {
-            string salt = Util.RandomString(64);
+            string salt = Util.RandomString(32);
             string md5PasswdHash = Util.Md5Hash(Util.Md5Hash(newPassword) + ":" + salt);
 
             UserProfileData profile = GetUserProfile(firstName, lastName);

--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -1141,10 +1141,10 @@ namespace OpenSim.Framework.Communications
         /// <param name="regY">location Y</param>
         /// <param name="uuid">UUID of avatar.</param>
         /// <returns>The UUID of the created user profile.  On failure, returns UUID.Zero</returns>
-        public virtual UUID AddUser(
-            string firstName, string lastName, string password, string email, uint regX, uint regY, UUID uuid)
+        public virtual UUID AddUser(string firstName, string lastName, string password, string email, uint regX, uint regY, UUID uuid)
         {
-            string md5PasswdHash = Util.Md5Hash(Util.Md5Hash(password) + ":" + String.Empty);
+            string salt = Util.RandomString(64);
+            string md5PasswdHash = Util.Md5Hash(Util.Md5Hash(password) + ":" + salt);
 
             UserProfileData userProf = GetUserProfile(firstName, lastName);
             if (userProf != null)
@@ -1159,7 +1159,7 @@ namespace OpenSim.Framework.Communications
             user.FirstName = firstName;
             user.SurName = lastName;
             user.PasswordHash = md5PasswdHash;
-            user.PasswordSalt = String.Empty;
+            user.PasswordSalt = salt;
             user.Created = Util.UnixTimeSinceEpoch();
             user.HomeLookAt = new Vector3(100, 100, 100);
             user.HomeRegionX = regX;
@@ -1335,7 +1335,8 @@ namespace OpenSim.Framework.Communications
         /// <returns>true if the update was successful, false otherwise</returns>
         public virtual bool ResetUserPassword(string firstName, string lastName, string newPassword)
         {
-            string md5PasswdHash = Util.Md5Hash(Util.Md5Hash(newPassword) + ":" + String.Empty);
+            string salt = Util.RandomString(64);
+            string md5PasswdHash = Util.Md5Hash(Util.Md5Hash(newPassword) + ":" + salt);
 
             UserProfileData profile = GetUserProfile(firstName, lastName);
 
@@ -1346,7 +1347,7 @@ namespace OpenSim.Framework.Communications
             }
 
             profile.PasswordHash = md5PasswdHash;
-            profile.PasswordSalt = String.Empty;
+            profile.PasswordSalt = salt;
 
             UpdateUserProfile(profile);
 

--- a/OpenSim/Framework/Util.cs
+++ b/OpenSim/Framework/Util.cs
@@ -329,6 +329,16 @@ namespace OpenSim.Framework
             get { return randomClass; }
         }
 
+        public static string RandomString(uint length, string alphabet = "abcdefghijklmnopqrstuvwyxzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+        {
+            var chars = new char[length];
+            for (var i = 0u; i < length; i++)
+            {
+                chars[i] = alphabet[RandomClass.Next(alphabet.Length)];
+            }
+            return new string(chars);
+        }
+
         public static ulong UIntsToLong(uint X, uint Y)
         {
             return Utils.UIntsToLong(X, Y);


### PR DESCRIPTION
Previously new accounts created using the built-in AddUser function left the salt blank, as did the password reset command.
This now actually builds a real salt.  The alphabet could be extended, but that should be sufficient.
