### PR TITLE
Sit target persistence + PRIM_SIT_TARGET gets

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -11630,6 +11630,29 @@ namespace InWorldz.Phlox.Engine
                             }
                         }
                         break;
+
+                    case (int)ScriptBaseClass.PRIM_SIT_TARGET:
+                        foreach (object o in parts)
+                        {
+                            if (o is SceneObjectPart)
+                            {
+                                SceneObjectPart part = (o as SceneObjectPart);
+                                SitTargetInfo sitInfo = part.ParentGroup.SitTargetForPart(part.UUID);
+                                if (sitInfo != null)
+                                {
+                                    res.Add((int)(sitInfo.IsSet ? 1 : 0));
+                                    res.Add(new LSL_Vector(sitInfo.Offset));
+                                    res.Add(new LSL_Rotation(sitInfo.Rotation));
+                                    continue;
+                                }
+                            }
+
+                            // No sit target info, or it's a ScenePresence.
+                            res.Add((int)0);
+                            res.Add(new LSL_Vector(Vector3.Zero));
+                            res.Add(new LSL_Rotation(Quaternion.Identity));
+                        }
+                        break;
                 }
             }
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1033,6 +1033,7 @@ namespace OpenSim.Region.Framework.Scenes
             m_sitTargets.Clear();   // new UUIDs have been assigned, need to refresh
             m_childParts.ForEachPart((SceneObjectPart part) => {
                 part.ResetInstance(isNewInstance, isScriptReset, itemId);
+                this.SetSitTarget(part, part.SitTargetPosition, part.SitTargetOrientation, false);
             });
         }
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -2043,6 +2043,13 @@ namespace OpenSim.Region.Framework.Scenes
             return outdata;
         }
 
+        // part.ParentGroup must be initialized for this.
+        public void CopySitTarget(SceneObjectPart part)
+        {
+            SitTargetInfo sitInfo = part.ParentGroup.SitTargetForPart(part.UUID);
+            this.SetSitTarget(sitInfo.Offset, sitInfo.Rotation, false);
+        }
+
         /// <summary>
         /// Duplicates this part.
         /// </summary>
@@ -3588,23 +3595,18 @@ namespace OpenSim.Region.Framework.Scenes
         }
 
         /// <summary>
-        ///
+        /// Returns true if the parent has changed.
         /// </summary>
-        public void SetParent(SceneObjectGroup parent, bool isDuplicate)
+        public bool SetParent(SceneObjectGroup parent)
         {
             bool hasChanged = (m_parentGroup != parent);
             m_parentGroup = parent;
-
-            // If this is being called from CopyPart, as part of the persistence backup, 
-            // then it is a duplicate copy of the SOP/SOG that has UUID/LocalID that 
-            // matches the in-world copy, so don't change the in-world SOG/SOP.
-            if (hasChanged && !isDuplicate)
-                parent.SetSitTarget(this, SitTargetPosition, SitTargetOrientation, false);
+            return hasChanged;
         }
 
         public void SetParentAndUpdatePhysics(SceneObjectGroup parent)
         {
-            this.SetParent(parent, false);
+            this.SetParent(parent);
 
             PhysicsActor physActor = PhysActor;
             if (physActor != null)

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -2046,8 +2046,7 @@ namespace OpenSim.Region.Framework.Scenes
         // part.ParentGroup must be initialized for this.
         public void CopySitTarget(SceneObjectPart part)
         {
-            SitTargetInfo sitInfo = part.ParentGroup.SitTargetForPart(part.UUID);
-            this.SetSitTarget(sitInfo.Offset, sitInfo.Rotation, false);
+            this.SetSitTarget(part.SitTargetPosition, part.SitTargetOrientation, false);
         }
 
         /// <summary>

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
@@ -346,6 +346,10 @@ namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
         public const int PRIM_SPECULAR = 36;
         public const int PRIM_NORMAL = 37;
         public const int PRIM_ALPHA_MODE = 38;
+        public const int PRIM_ALLOW_UNSIT = 39;
+        public const int PRIM_SCRIPTED_SIT_ONLY = 40;
+        public const int PRIM_SIT_TARGET = 41;
+
         // large out of normal range value unlikely to conflict with future LL values
         /// \xrefitem lslconst "IW_PRIM_ALPHA" ""
         /// <tt>[ IW_PRIM_ALPHA, integer face, float alpha ]</tt>\n\n


### PR DESCRIPTION
This update fixes the reported problems with persisting and maintaining sit targets after various operations including region restarts, crossings, link/unlink, shift-copy, etc.  It also adds support for PRIM_SIT_TARGET in llGetLinkPrimitiveParams (only). This allows dumping of current sit targets, for MUCH easier sit target testing.