### PR TITLE
Fixed Mantis 3270 - Some iwRezPrim params applied to host (rezzer)

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -10140,10 +10140,16 @@ namespace InWorldz.Phlox.Engine
                         else
                             phantom = false;
 
-                        //no matter how many parts are selected, this physics change
-                        //is applied to the group, so dont apply in a loop
-                        m_host.ParentGroup.ScriptSetPhantomStatus(phantom);
-
+                        foreach (var o in links)
+                        {
+                            if (o is SceneObjectPart)
+                            {
+                                SceneObjectPart part = o as SceneObjectPart;
+                                //no matter how many parts are selected, this physics change
+                                //is applied to the group, so dont apply in a loop
+                                part.ParentGroup.ScriptSetPhantomStatus(phantom);
+                            }
+                        }
                         break;
 
                     case (int)ScriptBaseClass.PRIM_PHYSICS:
@@ -10157,9 +10163,16 @@ namespace InWorldz.Phlox.Engine
                         else
                             physics = false;
 
-                        //no matter how many parts are selected, this physics change
-                        //is applied to the group, so dont apply in a loop
-                        m_host.ParentGroup.ScriptSetPhysicsStatus(physics);
+                        foreach (var o in links)
+                        {
+                            if (o is SceneObjectPart)
+                            {
+                                SceneObjectPart part = o as SceneObjectPart;
+                                //no matter how many parts are selected, this physics change
+                                //is applied to the group, so dont apply in a loop
+                                part.ParentGroup.ScriptSetPhysicsStatus(physics);
+                            }
+                        }
                         break;
 
                     case (int)ScriptBaseClass.PRIM_TEMP_ON_REZ:


### PR DESCRIPTION
SetPrimParams applied PRIM_PHYSICS and PRIM_PHANTOM changes to the host (rezzer) object rather than the newly-created object.  See [Mantis #3270](http://bugs.inworldz.com/mantis/view.php?id=3270) for more.