### PR TITLE
Attempted fix for mantis #3274

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -14694,7 +14694,7 @@ namespace InWorldz.Phlox.Engine
                     }
                 }
 
-                int textLength = notecardData.Length;
+                int textLength = Encoding.UTF8.GetByteCount(notecardData.ToString());
                 string sNotecardData = "Linden text version 2\n{\nLLEmbeddedItems version 1\n{\ncount 0\n}\nText length "
                     + textLength.ToString() + "\n" + notecardData.ToString() + "}\n";
 


### PR DESCRIPTION
This is an attempted fix for iwMakeNotecard that was reported in mantis #3274, where notecards created with one or more unicode characters would have the characters at the end of the notecard truncated.  EG: if the notecard body is "£100, £200", then the written notecard would be "£100, £2".

The cause of the problem was that iwMakeNotecard was using the _character length_ of the notecard body, when it should have been using its _byte length_ (in utf8 encoding).

I have not tested this as there were a number of compile errors, but it should work in theory.  If anyone has a working setup where Halcyon builds without error, please test for me.