### PR TITLE
Mantis 3279 - Prevent linking objects while attached.

### DIFF
--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -1967,6 +1967,12 @@ namespace OpenSim.Region.Framework.Scenes
                 if ((parentGroup.RootPart.OwnerMask & (uint)PermissionMask.Modify) != (uint)PermissionMask.Modify)
                     return;
 
+                if (parentGroup.IsAttachment)
+                {
+                    client.SendAlertMessage("Cannot link objects while attached: nothing to link.");
+                    return;
+                }
+
                 foreach (uint id in childPrimIds)
                 {
                     SceneObjectGroup group = this.GetGroupByPrim(id);
@@ -1976,6 +1982,11 @@ namespace OpenSim.Region.Framework.Scenes
                         return;
                     if ((group.RootPart.OwnerMask & (uint)PermissionMask.Modify) != (uint)PermissionMask.Modify)
                         return;
+                    if (group.IsAttachment)
+                    {
+                        client.SendAlertMessage("Cannot link objects while attached: nothing to link.");
+                        return;
+                    }
 
                     if (group.RootPart.LocalId != parentPrimId)
                     {


### PR DESCRIPTION
Also report slightly more informative message than SL's "nothing to link", but include that text.