### PR TITLE
Mantis 3239 - Fix seated border checks

### DIFF
--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -454,8 +454,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                         if (parcelAvatarIsEntering.DenyParcelAccess(avatar.UUID, out reason))
                         {
                             EntityBase.PositionInfo avatarPos = avatar.GetPosInfo();
-                            if (avatarPos.Parent == null)   // not seated
-                                RemoveAvatarFromParcel(avatar);
+                            RemoveAvatarFromParcel(avatar);
                             SendNoEntryNotice(avatar, reason);
                             return;
                         }

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -2459,11 +2459,8 @@ namespace OpenSim.Region.Framework.Scenes
                             SetHeight(m_avHeight);
                         }
 
-                        if (!fromCrossing)
-                        {
-                            m_animPersistUntil = 0;    // abort any timed animation
-                            TrySetMovementAnimation("STAND");
-                        }
+                        m_animPersistUntil = 0;    // abort any timed animation
+                        TrySetMovementAnimation("STAND");
                     }
                 }
             }


### PR DESCRIPTION
Fixes Mantis 3239, ability for users to enter parcel seated.  Problem case was sitting on an object owned by someone else.  Fixes both cases of riding the object, and sitting on one across parcel borders. Also cleanup to remove a conditional check for a condition that was always true anyway.