### PR TITLE
AgentPreferences CAP implementation and related features

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -7256,12 +7256,18 @@ namespace InWorldz.Phlox.Engine
 
         public string llGetAgentLanguage(string id)
         {
-            // This should only return a value if the avatar is in the same region
-            //ckrinke 1-30-09 : This needs to parse the XMLRPC language field supplied
-            //by the client at login. Currently returning only en-us until our I18N
-            //effort gains momentum
-            
-            return "en-us";
+            UUID agent = new UUID();
+            if (!UUID.TryParse(id, out agent)) return String.Empty;
+
+            ScenePresence presence = World.GetScenePresence(agent);
+            if (presence == null) return String.Empty;
+            if (presence.IsChildAgent) return String.Empty;
+
+            AgentPreferencesData prefs = presence.AgentPrefs;
+            if (prefs == null) return String.Empty;
+            if (!prefs.LanguageIsPublic) return String.Empty;
+
+            return prefs.Language;
         }
 
         public void llAdjustSoundVolume(float volume)

--- a/InWorldz/InWorldz.Testing/MockClientAPI.cs
+++ b/InWorldz/InWorldz.Testing/MockClientAPI.cs
@@ -33,6 +33,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using OpenMetaverse;
 using OpenSim.Framework;
 using OpenMetaverse.StructuredData;
 
@@ -607,7 +608,7 @@ namespace InWorldz.Testing
             
         }
 
-        public void SendAppearance(AvatarAppearance app)
+        public void SendAppearance(AvatarAppearance app, Vector3 hover)
         {
             
         }

--- a/OpenSim/Framework/AgentPreferencesData.cs
+++ b/OpenSim/Framework/AgentPreferencesData.cs
@@ -56,6 +56,21 @@ namespace OpenSim.Framework
             this.FromOSDMap(map);
         }
 
+        public AgentPreferencesData(AgentPreferencesData data)
+        {
+            if (data != null)
+            {
+                this.HoverHeight = data.HoverHeight;
+                this.AccessPrefs = data.AccessPrefs;
+                this.Language = data.Language;
+                this.LanguageIsPublic = data.LanguageIsPublic;
+                this.PermEveryone = data.PermEveryone;
+                this.PermGroup = data.PermGroup;
+                this.PermNextOwner = data.PermNextOwner;
+                this.PrincipalID = data.PrincipalID;
+            }
+        }
+
         public OSDMap ToOSDMap()
         {
             OSDMap result = new OSDMap();

--- a/OpenSim/Framework/AgentPreferencesData.cs
+++ b/OpenSim/Framework/AgentPreferencesData.cs
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) InWorldz Halcyon Developers
+ * Copyright (c) Contributors, http://opensimulator.org/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the OpenSim Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE DEVELOPERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System.Collections.Generic;
+using OpenMetaverse;
+using OpenMetaverse.StructuredData;
+
+namespace OpenSim.Framework
+{
+    /// <summary>
+    /// Known information about a particular user preferences
+    /// </summary>
+    public class AgentPreferencesData
+    {
+        public UUID PrincipalID = UUID.Zero;
+        public string AccessPrefs = "M";
+        //public int GodLevel; // *TODO: Implement GodLevel (Unused by the viewer, afaict - 6/11/2015)
+        public double HoverHeight = 0.0;
+        public string Language = "en-us";
+        public bool LanguageIsPublic = true;
+        // DefaultObjectPermMasks
+        public int PermEveryone = 0;
+        public int PermGroup = 0;
+        public int PermNextOwner = 0; // Illegal value by design
+
+        public AgentPreferencesData()
+        {
+        }
+
+        public AgentPreferencesData(OSDMap map)
+        {
+            this.FromOSDMap(map);
+        }
+
+        public OSDMap ToOSDMap()
+        {
+            OSDMap result = new OSDMap();
+            result["PrincipalID"] = PrincipalID;
+            result["AccessPrefs"] = AccessPrefs;
+            result["HoverHeight"] = HoverHeight;
+            result["Language"] = Language;
+            result["LanguageIsPublic"] = LanguageIsPublic;
+            result["PermEveryone"] = PermEveryone;
+            result["PermGroup"] = PermGroup;
+            result["PermNextOwner"] = PermNextOwner;
+            return result;
+        }
+
+        public void FromOSDMap(OSDMap map)
+        {
+            if (map.ContainsKey("PrincipalID"))
+                UUID.TryParse(map["PrincipalID"].ToString(), out PrincipalID);
+            if (map.ContainsKey("AccessPrefs"))
+                AccessPrefs = map["AccessPrefs"].ToString();
+            if (map.ContainsKey("HoverHeight"))
+                HoverHeight = double.Parse(map["HoverHeight"].ToString());
+            if (map.ContainsKey("Language"))
+                Language = map["Language"].ToString();
+            if (map.ContainsKey("LanguageIsPublic"))
+                LanguageIsPublic = bool.Parse(map["LanguageIsPublic"].ToString());
+            if (map.ContainsKey("PermEveryone"))
+                PermEveryone = int.Parse(map["PermEveryone"].ToString());
+            if (map.ContainsKey("PermGroup"))
+                PermGroup = int.Parse(map["PermGroup"].ToString());
+            if (map.ContainsKey("PermNextOwner"))
+                PermNextOwner = int.Parse(map["PermNextOwner"].ToString());            
+        }
+    }
+}

--- a/OpenSim/Framework/AgentPreferencesData.cs
+++ b/OpenSim/Framework/AgentPreferencesData.cs
@@ -43,9 +43,9 @@ namespace OpenSim.Framework
         public string Language = "en-us";
         public bool LanguageIsPublic = true;
         // DefaultObjectPermMasks
-        public int PermEveryone = 0;
-        public int PermGroup = 0;
-        public int PermNextOwner = 0; // Illegal value by design
+        public uint PermEveryone = 0;
+        public uint PermGroup = 0;
+        public uint PermNextOwner = 0; // Illegal value by design
 
         public AgentPreferencesData()
         {
@@ -98,11 +98,11 @@ namespace OpenSim.Framework
             if (map.ContainsKey("LanguageIsPublic"))
                 LanguageIsPublic = bool.Parse(map["LanguageIsPublic"].ToString());
             if (map.ContainsKey("PermEveryone"))
-                PermEveryone = int.Parse(map["PermEveryone"].ToString());
+                PermEveryone = uint.Parse(map["PermEveryone"].ToString());
             if (map.ContainsKey("PermGroup"))
-                PermGroup = int.Parse(map["PermGroup"].ToString());
+                PermGroup = uint.Parse(map["PermGroup"].ToString());
             if (map.ContainsKey("PermNextOwner"))
-                PermNextOwner = int.Parse(map["PermNextOwner"].ToString());            
+                PermNextOwner = uint.Parse(map["PermNextOwner"].ToString());            
         }
     }
 }

--- a/OpenSim/Framework/AvatarAppearance.cs
+++ b/OpenSim/Framework/AvatarAppearance.cs
@@ -42,8 +42,7 @@ namespace OpenSim.Framework
     {
         private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        public readonly static int VISUALPARAM_COUNT_1X = 218;   // 1.x viewers, i.e. before avatar physics layers
-        public readonly static int VISUALPARAM_COUNT = 251;
+        public readonly static int VISUALPARAM_COUNT = 253;
 
         public readonly static byte VISUALPARAM_DEFAULT = 100;   // what to use for a default value? 0=alien, 150=fat scientist
 
@@ -62,6 +61,7 @@ namespace OpenSim.Framework
         protected Dictionary<int, List<AvatarAttachment>> m_attachments;
         protected float m_avatarHeight = 0;
         protected float m_hipOffset = 0;
+        protected float m_hoverHeight = 0.0f;
 
         public bool IsBotAppearance { get; set; }
 
@@ -98,6 +98,12 @@ namespace OpenSim.Framework
         public virtual float HipOffset
         {
             get { return m_hipOffset; }
+        }
+
+        public virtual float HoverHeight
+        {
+            get { return m_hoverHeight; }
+            set { m_hoverHeight = value; }
         }
 
         public static byte[] GetDefaultVisualParams()
@@ -1018,7 +1024,828 @@ namespace OpenSim.Framework
                 m_log.ErrorFormat("[AVATAR APPEARANCE]: unpack failed badly: {0}{1}", e.Message, e.StackTrace);
             }
         }
+        #endregion
 
+        #region VPElement
+
+        /// <summary>
+        /// Viewer Params Array Element for AgentSetAppearance
+        /// Generated from LibOMV's Visual Params list
+        /// </summary>
+        public enum VPElement : int
+        {
+            /// <summary>
+            /// Brow Size - Small 0--+255 Large
+            /// </summary>
+            SHAPE_BIG_BROW = 0,
+            /// <summary>
+            /// Nose Size - Small 0--+255 Large
+            /// </summary>
+            SHAPE_NOSE_BIG_OUT = 1,
+            /// <summary>
+            /// Nostril Width - Narrow 0--+255 Broad
+            /// </summary>
+            SHAPE_BROAD_NOSTRILS = 2,
+            /// <summary>
+            /// Chin Cleft - Round 0--+255 Cleft
+            /// </summary>
+            SHAPE_CLEFT_CHIN = 3,
+            /// <summary>
+            /// Nose Tip Shape - Pointy 0--+255 Bulbous
+            /// </summary>
+            SHAPE_BULBOUS_NOSE_TIP = 4,
+            /// <summary>
+            /// Chin Angle - Chin Out 0--+255 Chin In
+            /// </summary>
+            SHAPE_WEAK_CHIN = 5,
+            /// <summary>
+            /// Chin-Neck - Tight Chin 0--+255 Double Chin
+            /// </summary>
+            SHAPE_DOUBLE_CHIN = 6,
+            /// <summary>
+            /// Lower Cheeks - Well-Fed 0--+255 Sunken
+            /// </summary>
+            SHAPE_SUNKEN_CHEEKS = 7,
+            /// <summary>
+            /// Upper Bridge - Low 0--+255 High
+            /// </summary>
+            SHAPE_NOBLE_NOSE_BRIDGE = 8,
+            /// <summary>
+            ///  - Less 0--+255 More
+            /// </summary>
+            SHAPE_JOWLS = 9,
+            /// <summary>
+            /// Upper Chin Cleft - Round 0--+255 Cleft
+            /// </summary>
+            SHAPE_CLEFT_CHIN_UPPER = 10,
+            /// <summary>
+            /// Cheek Bones - Low 0--+255 High
+            /// </summary>
+            SHAPE_HIGH_CHEEK_BONES = 11,
+            /// <summary>
+            /// Ear Angle - In 0--+255 Out
+            /// </summary>
+            SHAPE_EARS_OUT = 12,
+            /// <summary>
+            /// Eyebrow Points - Smooth 0--+255 Pointy
+            /// </summary>
+            HAIR_POINTY_EYEBROWS = 13,
+            /// <summary>
+            /// Jaw Shape - Pointy 0--+255 Square
+            /// </summary>
+            SHAPE_SQUARE_JAW = 14,
+            /// <summary>
+            /// Upper Cheeks - Thin 0--+255 Puffy
+            /// </summary>
+            SHAPE_PUFFY_UPPER_CHEEKS = 15,
+            /// <summary>
+            /// Nose Tip Angle - Downturned 0--+255 Upturned
+            /// </summary>
+            SHAPE_UPTURNED_NOSE_TIP = 16,
+            /// <summary>
+            /// Nose Thickness - Thin Nose 0--+255 Bulbous Nose
+            /// </summary>
+            SHAPE_BULBOUS_NOSE = 17,
+            /// <summary>
+            /// Upper Eyelid Fold - Uncreased 0--+255 Creased
+            /// </summary>
+            SHAPE_UPPER_EYELID_FOLD = 18,
+            /// <summary>
+            /// Attached Earlobes - Unattached 0--+255 Attached
+            /// </summary>
+            SHAPE_ATTACHED_EARLOBES = 19,
+            /// <summary>
+            /// Eye Bags - Smooth 0--+255 Baggy
+            /// </summary>
+            SHAPE_BAGGY_EYES = 20,
+            /// <summary>
+            /// Eye Opening - Narrow 0--+255 Wide
+            /// </summary>
+            SHAPE_WIDE_EYES = 21,
+            /// <summary>
+            /// Lip Cleft - Narrow 0--+255 Wide
+            /// </summary>
+            SHAPE_WIDE_LIP_CLEFT = 22,
+            /// <summary>
+            /// Bridge Width - Narrow 0--+255 Wide
+            /// </summary>
+            SHAPE_WIDE_NOSE_BRIDGE = 23,
+            /// <summary>
+            /// Eyebrow Arc - Flat 0--+255 Arced
+            /// </summary>
+            HAIR_ARCED_EYEBROWS = 24,
+            /// <summary>
+            /// Height - Short 0--+255 Tall
+            /// </summary>
+            SHAPE_HEIGHT = 25,
+            /// <summary>
+            /// Body Thickness - Body Thin 0--+255 Body Thick
+            /// </summary>
+            SHAPE_THICKNESS = 26,
+            /// <summary>
+            /// Ear Size - Small 0--+255 Large
+            /// </summary>
+            SHAPE_BIG_EARS = 27,
+            /// <summary>
+            /// Shoulders - Narrow 0--+255 Broad
+            /// </summary>
+            SHAPE_SHOULDERS = 28,
+            /// <summary>
+            /// Hip Width - Narrow 0--+255 Wide
+            /// </summary>
+            SHAPE_HIP_WIDTH = 29,
+            /// <summary>
+            ///  - Short Torso 0--+255 Long Torso
+            /// </summary>
+            SHAPE_TORSO_LENGTH = 30,
+            SHAPE_MALE = 31,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            GLOVES_GLOVE_LENGTH = 32,
+            /// <summary>
+            ///  - Darker 0--+255 Lighter
+            /// </summary>
+            EYES_EYE_LIGHTNESS = 33,
+            /// <summary>
+            ///  - Natural 0--+255 Unnatural
+            /// </summary>
+            EYES_EYE_COLOR = 34,
+            /// <summary>
+            ///  - Small 0--+255 Large
+            /// </summary>
+            SHAPE_BREAST_SIZE = 35,
+            /// <summary>
+            ///  - None 0--+255 Wild
+            /// </summary>
+            SKIN_RAINBOW_COLOR = 36,
+            /// <summary>
+            /// Ruddiness - Pale 0--+255 Ruddy
+            /// </summary>
+            SKIN_RED_SKIN = 37,
+            /// <summary>
+            ///  - Light 0--+255 Dark
+            /// </summary>
+            SKIN_PIGMENT = 38,
+            HAIR_RAINBOW_COLOR_39 = 39,
+            /// <summary>
+            ///  - No Red 0--+255 Very Red
+            /// </summary>
+            HAIR_RED_HAIR = 40,
+            /// <summary>
+            ///  - Black 0--+255 Blonde
+            /// </summary>
+            HAIR_BLONDE_HAIR = 41,
+            /// <summary>
+            ///  - No White 0--+255 All White
+            /// </summary>
+            HAIR_WHITE_HAIR = 42,
+            /// <summary>
+            ///  - Less Rosy 0--+255 More Rosy
+            /// </summary>
+            SKIN_ROSY_COMPLEXION = 43,
+            /// <summary>
+            ///  - Darker 0--+255 Pinker
+            /// </summary>
+            SKIN_LIP_PINKNESS = 44,
+            /// <summary>
+            ///  - Thin Eyebrows 0--+255 Bushy Eyebrows
+            /// </summary>
+            HAIR_EYEBROW_SIZE = 45,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            HAIR_FRONT_FRINGE = 46,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            HAIR_SIDE_FRINGE = 47,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            HAIR_BACK_FRINGE = 48,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            HAIR_HAIR_FRONT = 49,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            HAIR_HAIR_SIDES = 50,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            HAIR_HAIR_BACK = 51,
+            /// <summary>
+            ///  - Sweep Forward 0--+255 Sweep Back
+            /// </summary>
+            HAIR_HAIR_SWEEP = 52,
+            /// <summary>
+            ///  - Left 0--+255 Right
+            /// </summary>
+            HAIR_HAIR_TILT = 53,
+            /// <summary>
+            /// Middle Part - No Part 0--+255 Part
+            /// </summary>
+            HAIR_HAIR_PART_MIDDLE = 54,
+            /// <summary>
+            /// Right Part - No Part 0--+255 Part
+            /// </summary>
+            HAIR_HAIR_PART_RIGHT = 55,
+            /// <summary>
+            /// Left Part - No Part 0--+255 Part
+            /// </summary>
+            HAIR_HAIR_PART_LEFT = 56,
+            /// <summary>
+            /// Full Hair Sides - Mowhawk 0--+255 Full Sides
+            /// </summary>
+            HAIR_HAIR_SIDES_FULL = 57,
+            /// <summary>
+            ///  - Less 0--+255 More
+            /// </summary>
+            SKIN_BODY_DEFINITION = 58,
+            /// <summary>
+            /// Lip Width - Narrow Lips 0--+255 Wide Lips
+            /// </summary>
+            SHAPE_LIP_WIDTH = 59,
+            /// <summary>
+            ///  - Small 0--+255 Big
+            /// </summary>
+            SHAPE_BELLY_SIZE = 60,
+            /// <summary>
+            ///  - Less 0--+255 More
+            /// </summary>
+            SKIN_FACIAL_DEFINITION = 61,
+            /// <summary>
+            ///  - Less 0--+255 More
+            /// </summary>
+            SKIN_WRINKLES = 62,
+            /// <summary>
+            ///  - Less 0--+255 More
+            /// </summary>
+            SKIN_FRECKLES = 63,
+            /// <summary>
+            ///  - Short Sideburns 0--+255 Mutton Chops
+            /// </summary>
+            HAIR_SIDEBURNS = 64,
+            /// <summary>
+            ///  - Chaplin 0--+255 Handlebars
+            /// </summary>
+            HAIR_MOUSTACHE = 65,
+            /// <summary>
+            ///  - Less soul 0--+255 More soul
+            /// </summary>
+            HAIR_SOULPATCH = 66,
+            /// <summary>
+            ///  - Less Curtains 0--+255 More Curtains
+            /// </summary>
+            HAIR_CHIN_CURTAINS = 67,
+            /// <summary>
+            /// Rumpled Hair - Smooth Hair 0--+255 Rumpled Hair
+            /// </summary>
+            HAIR_HAIR_RUMPLED = 68,
+            /// <summary>
+            /// Big Hair Front - Less 0--+255 More
+            /// </summary>
+            HAIR_HAIR_BIG_FRONT = 69,
+            /// <summary>
+            /// Big Hair Top - Less 0--+255 More
+            /// </summary>
+            HAIR_HAIR_BIG_TOP = 70,
+            /// <summary>
+            /// Big Hair Back - Less 0--+255 More
+            /// </summary>
+            HAIR_HAIR_BIG_BACK = 71,
+            /// <summary>
+            /// Spiked Hair - No Spikes 0--+255 Big Spikes
+            /// </summary>
+            HAIR_HAIR_SPIKED = 72,
+            /// <summary>
+            /// Chin Depth - Shallow 0--+255 Deep
+            /// </summary>
+            SHAPE_DEEP_CHIN = 73,
+            /// <summary>
+            /// Part Bangs - No Part 0--+255 Part Bangs
+            /// </summary>
+            HAIR_BANGS_PART_MIDDLE = 74,
+            /// <summary>
+            /// Head Shape - More Square 0--+255 More Round
+            /// </summary>
+            SHAPE_HEAD_SHAPE = 75,
+            /// <summary>
+            /// Eye Spacing - Close Set Eyes 0--+255 Far Set Eyes
+            /// </summary>
+            SHAPE_EYE_SPACING = 76,
+            /// <summary>
+            ///  - Low Heels 0--+255 High Heels
+            /// </summary>
+            SHOES_HEEL_HEIGHT = 77,
+            /// <summary>
+            ///  - Low Platforms 0--+255 High Platforms
+            /// </summary>
+            SHOES_PLATFORM_HEIGHT = 78,
+            /// <summary>
+            ///  - Thin Lips 0--+255 Fat Lips
+            /// </summary>
+            SHAPE_LIP_THICKNESS = 79,
+            /// <summary>
+            /// Mouth Position - High 0--+255 Low
+            /// </summary>
+            SHAPE_MOUTH_HEIGHT = 80,
+            /// <summary>
+            /// Breast Buoyancy - Less Gravity 0--+255 More Gravity
+            /// </summary>
+            SHAPE_BREAST_GRAVITY = 81,
+            /// <summary>
+            /// Platform Width - Narrow 0--+255 Wide
+            /// </summary>
+            SHOES_SHOE_PLATFORM_WIDTH = 82,
+            /// <summary>
+            ///  - Pointy Heels 0--+255 Thick Heels
+            /// </summary>
+            SHOES_HEEL_SHAPE = 83,
+            /// <summary>
+            ///  - Pointy 0--+255 Square
+            /// </summary>
+            SHOES_TOE_SHAPE = 84,
+            /// <summary>
+            /// Foot Size - Small 0--+255 Big
+            /// </summary>
+            SHAPE_FOOT_SIZE = 85,
+            /// <summary>
+            /// Nose Width - Narrow 0--+255 Wide
+            /// </summary>
+            SHAPE_WIDE_NOSE = 86,
+            /// <summary>
+            /// Eyelash Length - Short 0--+255 Long
+            /// </summary>
+            SHAPE_EYELASHES_LONG = 87,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            UNDERSHIRT_SLEEVE_LENGTH = 88,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            UNDERSHIRT_BOTTOM = 89,
+            /// <summary>
+            ///  - Low 0--+255 High
+            /// </summary>
+            UNDERSHIRT_COLLAR_FRONT = 90,
+            JACKET_SLEEVE_LENGTH_91 = 91,
+            JACKET_COLLAR_FRONT_92 = 92,
+            /// <summary>
+            /// Jacket Length - Short 0--+255 Long
+            /// </summary>
+            JACKET_BOTTOM_LENGTH_LOWER = 93,
+            /// <summary>
+            /// Open Front - Open 0--+255 Closed
+            /// </summary>
+            JACKET_OPEN_JACKET = 94,
+            /// <summary>
+            ///  - Short 0--+255 Tall
+            /// </summary>
+            SHOES_SHOE_HEIGHT = 95,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            SOCKS_SOCKS_LENGTH = 96,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            UNDERPANTS_PANTS_LENGTH = 97,
+            /// <summary>
+            ///  - Low 0--+255 High
+            /// </summary>
+            UNDERPANTS_PANTS_WAIST = 98,
+            /// <summary>
+            /// Cuff Flare - Tight Cuffs 0--+255 Flared Cuffs
+            /// </summary>
+            PANTS_LEG_PANTFLAIR = 99,
+            /// <summary>
+            ///  - More Vertical 0--+255 More Sloped
+            /// </summary>
+            SHAPE_FOREHEAD_ANGLE = 100,
+            /// <summary>
+            ///  - Less Body Fat 0--+255 More Body Fat
+            /// </summary>
+            SHAPE_BODY_FAT = 101,
+            /// <summary>
+            /// Pants Crotch - High and Tight 0--+255 Low and Loose
+            /// </summary>
+            PANTS_LOW_CROTCH = 102,
+            /// <summary>
+            /// Egg Head - Chin Heavy 0--+255 Forehead Heavy
+            /// </summary>
+            SHAPE_EGG_HEAD = 103,
+            /// <summary>
+            /// Head Stretch - Squash Head 0--+255 Stretch Head
+            /// </summary>
+            SHAPE_SQUASH_STRETCH_HEAD = 104,
+            /// <summary>
+            /// Torso Muscles - Less Muscular 0--+255 More Muscular
+            /// </summary>
+            SHAPE_TORSO_MUSCLES = 105,
+            /// <summary>
+            /// Outer Eye Corner - Corner Down 0--+255 Corner Up
+            /// </summary>
+            SHAPE_EYELID_CORNER_UP = 106,
+            /// <summary>
+            ///  - Less Muscular 0--+255 More Muscular
+            /// </summary>
+            SHAPE_LEG_MUSCLES = 107,
+            /// <summary>
+            /// Lip Fullness - Less Full 0--+255 More Full
+            /// </summary>
+            SHAPE_TALL_LIPS = 108,
+            /// <summary>
+            /// Toe Thickness - Flat Toe 0--+255 Thick Toe
+            /// </summary>
+            SHOES_SHOE_TOE_THICK = 109,
+            /// <summary>
+            /// Crooked Nose - Nose Left 0--+255 Nose Right
+            /// </summary>
+            SHAPE_CROOKED_NOSE = 110,
+            /// <summary>
+            ///  - Corner Down 0--+255 Corner Up
+            /// </summary>
+            SHAPE_MOUTH_CORNER = 111,
+            /// <summary>
+            ///  - Shear Right Up 0--+255 Shear Left Up
+            /// </summary>
+            SHAPE_FACE_SHEAR = 112,
+            /// <summary>
+            /// Shift Mouth - Shift Left 0--+255 Shift Right
+            /// </summary>
+            SHAPE_SHIFT_MOUTH = 113,
+            /// <summary>
+            /// Eye Pop - Pop Right Eye 0--+255 Pop Left Eye
+            /// </summary>
+            SHAPE_POP_EYE = 114,
+            /// <summary>
+            /// Jaw Jut - Overbite 0--+255 Underbite
+            /// </summary>
+            SHAPE_JAW_JUT = 115,
+            /// <summary>
+            /// Shear Back - Full Back 0--+255 Sheared Back
+            /// </summary>
+            HAIR_HAIR_SHEAR_BACK = 116,
+            /// <summary>
+            ///  - Small Hands 0--+255 Large Hands
+            /// </summary>
+            SHAPE_HAND_SIZE = 117,
+            /// <summary>
+            /// Love Handles - Less Love 0--+255 More Love
+            /// </summary>
+            SHAPE_LOVE_HANDLES = 118,
+            SHAPE_TORSO_MUSCLES_119 = 119,
+            /// <summary>
+            /// Head Size - Small Head 0--+255 Big Head
+            /// </summary>
+            SHAPE_HEAD_SIZE = 120,
+            /// <summary>
+            ///  - Skinny Neck 0--+255 Thick Neck
+            /// </summary>
+            SHAPE_NECK_THICKNESS = 121,
+            /// <summary>
+            /// Breast Cleavage - Separate 0--+255 Join
+            /// </summary>
+            SHAPE_BREAST_FEMALE_CLEAVAGE = 122,
+            /// <summary>
+            /// Pectorals - Big Pectorals 0--+255 Sunken Chest
+            /// </summary>
+            SHAPE_CHEST_MALE_NO_PECS = 123,
+            /// <summary>
+            /// Eye Size - Beady Eyes 0--+255 Anime Eyes
+            /// </summary>
+            SHAPE_EYE_SIZE = 124,
+            /// <summary>
+            ///  - Short Legs 0--+255 Long Legs
+            /// </summary>
+            SHAPE_LEG_LENGTH = 125,
+            /// <summary>
+            ///  - Short Arms 0--+255 Long arms
+            /// </summary>
+            SHAPE_ARM_LENGTH = 126,
+            /// <summary>
+            ///  - Pink 0--+255 Black
+            /// </summary>
+            SKIN_LIPSTICK_COLOR = 127,
+            /// <summary>
+            ///  - No Lipstick 0--+255 More Lipstick
+            /// </summary>
+            SKIN_LIPSTICK = 128,
+            /// <summary>
+            ///  - No Lipgloss 0--+255 Glossy
+            /// </summary>
+            SKIN_LIPGLOSS = 129,
+            /// <summary>
+            ///  - No Eyeliner 0--+255 Full Eyeliner
+            /// </summary>
+            SKIN_EYELINER = 130,
+            /// <summary>
+            ///  - No Blush 0--+255 More Blush
+            /// </summary>
+            SKIN_BLUSH = 131,
+            /// <summary>
+            ///  - Pink 0--+255 Orange
+            /// </summary>
+            SKIN_BLUSH_COLOR = 132,
+            /// <summary>
+            ///  - Clear 0--+255 Opaque
+            /// </summary>
+            SKIN_OUT_SHDW_OPACITY = 133,
+            /// <summary>
+            ///  - No Eyeshadow 0--+255 More Eyeshadow
+            /// </summary>
+            SKIN_OUTER_SHADOW = 134,
+            /// <summary>
+            ///  - Light 0--+255 Dark
+            /// </summary>
+            SKIN_OUT_SHDW_COLOR = 135,
+            /// <summary>
+            ///  - No Eyeshadow 0--+255 More Eyeshadow
+            /// </summary>
+            SKIN_INNER_SHADOW = 136,
+            /// <summary>
+            ///  - No Polish 0--+255 Painted Nails
+            /// </summary>
+            SKIN_NAIL_POLISH = 137,
+            /// <summary>
+            ///  - Clear 0--+255 Opaque
+            /// </summary>
+            SKIN_BLUSH_OPACITY = 138,
+            /// <summary>
+            ///  - Light 0--+255 Dark
+            /// </summary>
+            SKIN_IN_SHDW_COLOR = 139,
+            /// <summary>
+            ///  - Clear 0--+255 Opaque
+            /// </summary>
+            SKIN_IN_SHDW_OPACITY = 140,
+            /// <summary>
+            ///  - Dark Green 0--+255 Black
+            /// </summary>
+            SKIN_EYELINER_COLOR = 141,
+            /// <summary>
+            ///  - Pink 0--+255 Black
+            /// </summary>
+            SKIN_NAIL_POLISH_COLOR = 142,
+            /// <summary>
+            ///  - Sparse 0--+255 Dense
+            /// </summary>
+            HAIR_EYEBROW_DENSITY = 143,
+            /// <summary>
+            ///  - 5 O'Clock Shadow 0--+255 Bushy Hair
+            /// </summary>
+            HAIR_HAIR_THICKNESS = 144,
+            /// <summary>
+            /// Saddle Bags - Less Saddle 0--+255 More Saddle
+            /// </summary>
+            SHAPE_SADDLEBAGS = 145,
+            /// <summary>
+            /// Taper Back - Wide Back 0--+255 Narrow Back
+            /// </summary>
+            HAIR_HAIR_TAPER_BACK = 146,
+            /// <summary>
+            /// Taper Front - Wide Front 0--+255 Narrow Front
+            /// </summary>
+            HAIR_HAIR_TAPER_FRONT = 147,
+            /// <summary>
+            ///  - Short Neck 0--+255 Long Neck
+            /// </summary>
+            SHAPE_NECK_LENGTH = 148,
+            /// <summary>
+            /// Eyebrow Height - Higher 0--+255 Lower
+            /// </summary>
+            HAIR_LOWER_EYEBROWS = 149,
+            /// <summary>
+            /// Lower Bridge - Low 0--+255 High
+            /// </summary>
+            SHAPE_LOWER_BRIDGE_NOSE = 150,
+            /// <summary>
+            /// Nostril Division - High 0--+255 Low
+            /// </summary>
+            SHAPE_LOW_SEPTUM_NOSE = 151,
+            /// <summary>
+            /// Jaw Angle - Low Jaw 0--+255 High Jaw
+            /// </summary>
+            SHAPE_JAW_ANGLE = 152,
+            /// <summary>
+            /// Shear Front - Full Front 0--+255 Sheared Front
+            /// </summary>
+            HAIR_HAIR_SHEAR_FRONT = 153,
+            /// <summary>
+            ///  - Less Volume 0--+255 More Volume
+            /// </summary>
+            HAIR_HAIR_VOLUME = 154,
+            /// <summary>
+            /// Lip Cleft Depth - Shallow 0--+255 Deep
+            /// </summary>
+            SHAPE_LIP_CLEFT_DEEP = 155,
+            /// <summary>
+            /// Puffy Eyelids - Flat 0--+255 Puffy
+            /// </summary>
+            SHAPE_PUFFY_LOWER_LIDS = 156,
+            /// <summary>
+            ///  - Sunken Eyes 0--+255 Bugged Eyes
+            /// </summary>
+            SHAPE_EYE_DEPTH = 157,
+            /// <summary>
+            ///  - Flat Head 0--+255 Long Head
+            /// </summary>
+            SHAPE_HEAD_LENGTH = 158,
+            /// <summary>
+            ///  - Less Freckles 0--+255 More Freckles
+            /// </summary>
+            SKIN_BODY_FRECKLES = 159,
+            /// <summary>
+            ///  - Low 0--+255 High
+            /// </summary>
+            UNDERSHIRT_COLLAR_BACK = 160,
+            JACKET_COLLAR_BACK_161 = 161,
+            SHIRT_COLLAR_BACK_162 = 162,
+            /// <summary>
+            ///  - Short Pigtails 0--+255 Long Pigtails
+            /// </summary>
+            HAIR_PIGTAILS = 163,
+            /// <summary>
+            ///  - Short Ponytail 0--+255 Long Ponytail
+            /// </summary>
+            HAIR_PONYTAIL = 164,
+            /// <summary>
+            /// Butt Size - Flat Butt 0--+255 Big Butt
+            /// </summary>
+            SHAPE_BUTT_SIZE = 165,
+            /// <summary>
+            /// Ear Tips - Flat 0--+255 Pointy
+            /// </summary>
+            SHAPE_POINTY_EARS = 166,
+            /// <summary>
+            /// Lip Ratio - More Upper Lip 0--+255 More Lower Lip
+            /// </summary>
+            SHAPE_LIP_RATIO = 167,
+            SHIRT_SLEEVE_LENGTH_168 = 168,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            SHIRT_SHIRT_BOTTOM = 169,
+            SHIRT_COLLAR_FRONT_170 = 170,
+            SHIRT_SHIRT_RED = 171,
+            SHIRT_SHIRT_GREEN = 172,
+            SHIRT_SHIRT_BLUE = 173,
+            PANTS_PANTS_RED = 174,
+            PANTS_PANTS_GREEN = 175,
+            PANTS_PANTS_BLUE = 176,
+            SHOES_SHOES_RED = 177,
+            SHOES_SHOES_GREEN = 178,
+            /// <summary>
+            ///  - Low 0--+255 High
+            /// </summary>
+            PANTS_WAIST_HEIGHT = 179,
+            PANTS_PANTS_LENGTH_180 = 180,
+            /// <summary>
+            /// Pants Fit - Tight Pants 0--+255 Loose Pants
+            /// </summary>
+            PANTS_LOOSE_LOWER_CLOTHING = 181,
+            SHOES_SHOES_BLUE = 182,
+            SOCKS_SOCKS_RED = 183,
+            SOCKS_SOCKS_GREEN = 184,
+            SOCKS_SOCKS_BLUE = 185,
+            UNDERSHIRT_UNDERSHIRT_RED = 186,
+            UNDERSHIRT_UNDERSHIRT_GREEN = 187,
+            UNDERSHIRT_UNDERSHIRT_BLUE = 188,
+            UNDERPANTS_UNDERPANTS_RED = 189,
+            UNDERPANTS_UNDERPANTS_GREEN = 190,
+            UNDERPANTS_UNDERPANTS_BLUE = 191,
+            GLOVES_GLOVES_RED = 192,
+            /// <summary>
+            /// Shirt Fit - Tight Shirt 0--+255 Loose Shirt
+            /// </summary>
+            SHIRT_LOOSE_UPPER_CLOTHING = 193,
+            GLOVES_GLOVES_GREEN = 194,
+            GLOVES_GLOVES_BLUE = 195,
+            JACKET_JACKET_RED = 196,
+            JACKET_JACKET_GREEN = 197,
+            JACKET_JACKET_BLUE = 198,
+            /// <summary>
+            /// Sleeve Looseness - Tight Sleeves 0--+255 Loose Sleeves
+            /// </summary>
+            SHIRT_SHIRTSLEEVE_FLAIR = 199,
+            /// <summary>
+            /// Knee Angle - Knock Kneed 0--+255 Bow Legged
+            /// </summary>
+            SHAPE_BOWED_LEGS = 200,
+            /// <summary>
+            ///  - Short hips 0--+255 Long Hips
+            /// </summary>
+            SHAPE_HIP_LENGTH = 201,
+            /// <summary>
+            ///  - Fingerless 0--+255 Fingers
+            /// </summary>
+            GLOVES_GLOVE_FINGERS = 202,
+            /// <summary>
+            /// bustle skirt - no bustle 0--+255 more bustle
+            /// </summary>
+            SKIRT_SKIRT_BUSTLE = 203,
+            /// <summary>
+            ///  - Short 0--+255 Long
+            /// </summary>
+            SKIRT_SKIRT_LENGTH = 204,
+            /// <summary>
+            ///  - Open Front 0--+255 Closed Front
+            /// </summary>
+            SKIRT_SLIT_FRONT = 205,
+            /// <summary>
+            ///  - Open Back 0--+255 Closed Back
+            /// </summary>
+            SKIRT_SLIT_BACK = 206,
+            /// <summary>
+            ///  - Open Left 0--+255 Closed Left
+            /// </summary>
+            SKIRT_SLIT_LEFT = 207,
+            /// <summary>
+            ///  - Open Right 0--+255 Closed Right
+            /// </summary>
+            SKIRT_SLIT_RIGHT = 208,
+            /// <summary>
+            /// Skirt Fit - Tight Skirt 0--+255 Poofy Skirt
+            /// </summary>
+            SKIRT_SKIRT_LOOSENESS = 209,
+            SHIRT_SHIRT_WRINKLES = 210,
+            PANTS_PANTS_WRINKLES = 211,
+            /// <summary>
+            /// Jacket Wrinkles - No Wrinkles 0--+255 Wrinkles
+            /// </summary>
+            JACKET_JACKET_WRINKLES = 212,
+            /// <summary>
+            /// Package - Coin Purse 0--+255 Duffle Bag
+            /// </summary>
+            SHAPE_MALE_PACKAGE = 213,
+            /// <summary>
+            /// Inner Eye Corner - Corner Down 0--+255 Corner Up
+            /// </summary>
+            SHAPE_EYELID_INNER_CORNER_UP = 214,
+            SKIRT_SKIRT_RED = 215,
+            SKIRT_SKIRT_GREEN = 216,
+            SKIRT_SKIRT_BLUE = 217, 
+
+            /// <summary>
+            /// Avatar Physics section.  These are 0 type visual params which get transmitted.
+            /// </summary>
+
+            /// <summary>
+            /// Breast Part 1 
+            /// </summary>
+            BREAST_PHYSICS_MASS = 218,
+            BREAST_PHYSICS_GRAVITY = 219,
+            BREAST_PHYSICS_DRAG = 220,
+            BREAST_PHYSICS_UPDOWN_MAX_EFFECT = 221,
+            BREAST_PHYSICS_UPDOWN_SPRING = 222,
+            BREAST_PHYSICS_UPDOWN_GAIN = 223,
+            BREAST_PHYSICS_UPDOWN_DAMPING = 224,
+            BREAST_PHYSICS_INOUT_MAX_EFFECT = 225,
+            BREAST_PHYSICS_INOUT_SPRING = 226,
+            BREAST_PHYSICS_INOUT_GAIN = 227,
+            BREAST_PHYSICS_INOUT_DAMPING = 228,
+            /// <summary>
+            /// Belly
+            /// </summary>
+            BELLY_PHYISCS_MASS = 229,
+            BELLY_PHYSICS_GRAVITY = 230,
+            BELLY_PHYSICS_DRAG = 231,
+            BELLY_PHYISCS_UPDOWN_MAX_EFFECT = 232,
+            BELLY_PHYSICS_UPDOWN_SPRING = 233,
+            BELLY_PHYSICS_UPDOWN_GAIN = 234,
+            BELLY_PHYSICS_UPDOWN_DAMPING = 235,
+
+            /// <summary>
+            /// Butt
+            /// </summary>
+            BUTT_PHYSICS_MASS = 236,
+            BUTT_PHYSICS_GRAVITY = 237,
+            BUTT_PHYSICS_DRAG = 238,
+            BUTT_PHYSICS_UPDOWN_MAX_EFFECT = 239,
+            BUTT_PHYSICS_UPDOWN_SPRING = 240,
+            BUTT_PHYSICS_UPDOWN_GAIN = 241,
+            BUTT_PHYSICS_UPDOWN_DAMPING = 242,
+            BUTT_PHYSICS_LEFTRIGHT_MAX_EFFECT = 243,
+            BUTT_PHYSICS_LEFTRIGHT_SPRING = 244,
+            BUTT_PHYSICS_LEFTRIGHT_GAIN = 245,
+            BUTT_PHYSICS_LEFTRIGHT_DAMPING = 246,
+            /// <summary>
+            /// Breast Part 2
+            /// </summary>
+            BREAST_PHYSICS_LEFTRIGHT_MAX_EFFECT = 247,
+            BREAST_PHYSICS_LEFTRIGHT_SPRING= 248,
+            BREAST_PHYSICS_LEFTRIGHT_GAIN = 249,
+            BREAST_PHYSICS_LEFTRIGHT_DAMPING = 250,
+
+            // Ubit: 07/96/2013 new parameters 
+            _APPEARANCEMESSAGE_VERSION = 251,    //ID 11000
+
+            SHAPE_HOVER = 252,    //ID 11001
+        }
         #endregion
     }
 }

--- a/OpenSim/Framework/AvatarAppearance.cs
+++ b/OpenSim/Framework/AvatarAppearance.cs
@@ -61,7 +61,6 @@ namespace OpenSim.Framework
         protected Dictionary<int, List<AvatarAttachment>> m_attachments;
         protected float m_avatarHeight = 0;
         protected float m_hipOffset = 0;
-        protected float m_hoverHeight = 0.0f;
 
         public bool IsBotAppearance { get; set; }
 
@@ -98,12 +97,6 @@ namespace OpenSim.Framework
         public virtual float HipOffset
         {
             get { return m_hipOffset; }
-        }
-
-        public virtual float HoverHeight
-        {
-            get { return m_hoverHeight; }
-            set { m_hoverHeight = value; }
         }
 
         public static byte[] GetDefaultVisualParams()

--- a/OpenSim/Framework/ChildAgentDataUpdate.cs
+++ b/OpenSim/Framework/ChildAgentDataUpdate.cs
@@ -299,6 +299,9 @@ namespace OpenSim.Framework
         // Appearance
         public AvatarAppearance Appearance;
 
+        // AgentPreferences from viewer
+        public AgentPreferencesData AgentPrefs;
+
         public string CallbackURI;
 
         public UUID SatOnGroup;
@@ -371,16 +374,15 @@ namespace OpenSim.Framework
                     anims.Add(aanim.PackUpdateMessage());
                 args["animations"] = anims;
             }
-            
-            if ((Appearance != null) && (Appearance.Texture != null))
-                args["texture_entry"] = OSD.FromBinary(Appearance.Texture.GetBytes());
 
-            if ((Appearance != null) && (Appearance.VisualParams != null) && (Appearance.VisualParams.Length > 0))
-                args["visual_params"] = OSD.FromBinary(Appearance.VisualParams);
-
-            // We might not pass this in all cases...
             if (Appearance != null)
             {
+                // We might not pass this in all cases...
+                if (Appearance.Texture != null)
+                    args["texture_entry"] = OSD.FromBinary(Appearance.Texture.GetBytes());
+                if ((Appearance.VisualParams != null) && (Appearance.VisualParams.Length > 0))
+                    args["visual_params"] = OSD.FromBinary(Appearance.VisualParams);
+
                 OSDArray wears = new OSDArray(AvatarWearable.MAX_WEARABLES * 2);
                 for (int i = 0; i < AvatarWearable.MAX_WEARABLES; i++)
                 {
@@ -390,6 +392,19 @@ namespace OpenSim.Framework
                 }
 
                 args["wearables"] = wears;
+            }
+
+            // AgentPreferences from viewer
+            if (AgentPrefs != null)
+            {
+                args["hover_height"] = AgentPrefs.HoverHeight;
+                args["access_prefs"] = AgentPrefs.AccessPrefs;
+                args["perm_everyone"] = AgentPrefs.PermEveryone;
+                args["perm_group"] = AgentPrefs.PermGroup;
+                args["perm_next_owner"] = AgentPrefs.PermNextOwner;
+                args["language"] = AgentPrefs.Language;
+                args["language_is_public"] = AgentPrefs.LanguageIsPublic;
+                args["principal_id"] = m_id;
             }
 
             if (!String.IsNullOrEmpty(CallbackURI))
@@ -579,6 +594,41 @@ namespace OpenSim.Framework
                     // The following is compatible with OSD.FromVector3(vec), since Vector3.TryParse is not.
                     SatOnPrimOffset = args["sit_offset"].AsVector3();
                 }
+            }
+
+            // Initialize AgentPrefs from viewer
+            AgentPrefs = new AgentPreferencesData();
+            if (args.ContainsKey("hover_height"))
+            {
+                AgentPrefs.HoverHeight = args["hover_height"];
+            }
+            if (args.ContainsKey("access_prefs"))
+            {
+                AgentPrefs.AccessPrefs = args["access_prefs"];
+            }
+            if (args.ContainsKey("perm_everyone"))
+            {
+                AgentPrefs.PermEveryone = args["perm_everyone"];
+            }
+            if (args.ContainsKey("perm_group"))
+            {
+                AgentPrefs.PermGroup = args["perm_group"];
+            }
+            if (args.ContainsKey("perm_next_owner"))
+            {
+                AgentPrefs.PermNextOwner = args["perm_next_owner"];
+            }
+            if (args.ContainsKey("language"))
+            {
+                AgentPrefs.Language = args["language"];
+            }
+            if (args.ContainsKey("language_is_public"))
+            {
+                AgentPrefs.LanguageIsPublic = args["language_is_public"];
+            }
+            if (args.ContainsKey("principal_id"))
+            {
+                AgentPrefs.PrincipalID = args["principal_id"];
             }
         }
 

--- a/OpenSim/Framework/Communications/Messages/AgentPutMessage.cs
+++ b/OpenSim/Framework/Communications/Messages/AgentPutMessage.cs
@@ -165,6 +165,9 @@ namespace OpenSim.Framework.Communications.Messages
         [ProtoMember(38)]
         public bool AvatarAsAPrim;
 
+        [ProtoMember(39)]
+        public PackedAgentPrefs AgentPrefs;
+
         static AgentPutMessage()
         {
             ProtoBuf.Serializer.PrepareSerializer<AgentPutMessage>();
@@ -177,6 +180,7 @@ namespace OpenSim.Framework.Communications.Messages
                 ActiveGroupID = data.ActiveGroupID.Guid,
                 AgentAccess = data.AgentAccess,
                 AgentId = data.AgentID.Guid,
+                AgentPrefs = PackedAgentPrefs.FromAgentPrefs(data.AgentPrefs),
                 AlwaysRun = data.AlwaysRun,
                 Anims = PackedAnimation.FromAnimations(data.Anims),
                 Appearance = PackedAppearance.FromAppearance(data.Appearance),
@@ -226,6 +230,7 @@ namespace OpenSim.Framework.Communications.Messages
                 ActiveGroupID = new UUID(this.ActiveGroupID),
                 AgentAccess = this.AgentAccess,
                 AgentID = agentId,
+                AgentPrefs = (this.AgentPrefs != null) ? this.AgentPrefs.ToAgentPrefs(agentId) : new AgentPreferencesData(),
                 AlwaysRun = this.AlwaysRun,
                 Anims = PackedAnimation.ToAnimations(this.Anims),
                 Appearance = this.Appearance.ToAppearance(agentId),

--- a/OpenSim/Framework/Communications/Messages/PackedAgentPrefs.cs
+++ b/OpenSim/Framework/Communications/Messages/PackedAgentPrefs.cs
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2015, InWorldz Halcyon Developers
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ * 
+ *   * Neither the name of halcyon nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ProtoBuf;
+using OpenSim.Framework;
+
+namespace OpenSim.Framework.Communications.Messages
+{
+    /// <summary>
+    /// Network-ready message to pack up an avatars appearance to send over the wire
+    /// </summary>
+    [ProtoContract]
+    public class PackedAgentPrefs
+    {
+        [ProtoMember(1)]
+        public double Hover;            // e.g. 0.0
+
+        [ProtoMember(2)]
+        public bool LanguageIsPublic;   // e.g. true
+
+        [ProtoMember(3)]
+        public string Language;         // e.g. "en" or "en-us"
+
+        [ProtoMember(4)]
+        public string AccessPrefs;      // e.g. "M"
+
+        // Default permissions for object creates
+        [ProtoMember(5)]
+        public int PermEveryone;
+        [ProtoMember(6)]
+        public int PermGroup;
+        [ProtoMember(7)]
+        public int PermNextOwner;
+
+
+        internal static PackedAgentPrefs FromAgentPrefs(AgentPreferencesData agentPreferences)
+        {
+            PackedAgentPrefs prefs = new PackedAgentPrefs
+            {
+                AccessPrefs = agentPreferences.AccessPrefs,
+                Hover = agentPreferences.HoverHeight,
+                Language = agentPreferences.Language,
+                LanguageIsPublic = agentPreferences.LanguageIsPublic,
+                // DefaultObjectPermMasks
+                PermEveryone = agentPreferences.PermEveryone,
+                PermGroup = agentPreferences.PermGroup,
+                PermNextOwner = agentPreferences.PermNextOwner
+            };
+
+            return prefs;
+        }
+
+        internal AgentPreferencesData ToAgentPrefs(OpenMetaverse.UUID owner)
+        {
+            AgentPreferencesData agentPreferences =
+                new AgentPreferencesData
+                {
+                    AccessPrefs = this.AccessPrefs,
+                    HoverHeight = this.Hover,
+                    Language = this.Language,
+                    LanguageIsPublic = this.LanguageIsPublic,
+                    // DefaultObjectPermMasks
+                    PermEveryone = this.PermEveryone,
+                    PermGroup = this.PermGroup,
+                    PermNextOwner = this.PermNextOwner
+                };
+
+            return agentPreferences;
+        }
+    }
+}

--- a/OpenSim/Framework/Communications/Messages/PackedAgentPrefs.cs
+++ b/OpenSim/Framework/Communications/Messages/PackedAgentPrefs.cs
@@ -57,11 +57,11 @@ namespace OpenSim.Framework.Communications.Messages
 
         // Default permissions for object creates
         [ProtoMember(5)]
-        public int PermEveryone;
+        public uint PermEveryone;
         [ProtoMember(6)]
-        public int PermGroup;
+        public uint PermGroup;
         [ProtoMember(7)]
-        public int PermNextOwner;
+        public uint PermNextOwner;
 
 
         internal static PackedAgentPrefs FromAgentPrefs(AgentPreferencesData agentPreferences)

--- a/OpenSim/Framework/IClientAPI.cs
+++ b/OpenSim/Framework/IClientAPI.cs
@@ -944,10 +944,9 @@ namespace OpenSim.Framework
         /// <summary>
         /// Send information about the given agent's appearance to another client.
         /// </summary>
-        /// <param name="agentID">The id of the agent associated with the appearance</param>
-        /// <param name="visualParams"></param>
-        /// <param name="textureEntry"></param>        
-        void SendAppearance(AvatarAppearance app);
+        /// <param name="app">Appearance to send</param>
+        /// <param name="hover">A vector representing the AgentPreferences hover height.</param>
+        void SendAppearance(AvatarAppearance app, Vector3 hover);
 
         void SendStartPingCheck(byte seq);
 

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -3074,7 +3074,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             OutPacket(aw, ThrottleOutPacketType.Task);
         }
 
-        public void SendAppearance(AvatarAppearance app)
+        public void SendAppearance(AvatarAppearance app, Vector3 hover)
         {
             // UUID agentID, byte[] visualParams, byte[] textureEntry)
             // m_appearance.Owner, m_appearance.VisualParams, m_appearance.Texture.GetBytes()
@@ -3113,7 +3113,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
 
             avp.AppearanceHover = new AvatarAppearancePacket.AppearanceHoverBlock[1];
             avp.AppearanceHover[0] = new AvatarAppearancePacket.AppearanceHoverBlock();
-            avp.AppearanceHover[0].HoverHeight = new Vector3(0.0f, 0.0f, app.HoverHeight);
+            avp.AppearanceHover[0].HoverHeight = hover;
 
             avp.Sender.IsTrial = false;
             avp.Sender.ID = app.Owner;

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -3047,15 +3047,6 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 limit = AvatarWearable.MAX_WEARABLES;
             return System.Math.Min(limit, actual);
         }
-        // This one is required, otherwise the viewer may not draw the avatar at all (cloud).
-        public int MaxVisualParams()
-        {
-            if (_clientVersion.Contains("InWorldz Release 1.") || _clientVersion.Contains("Imprudence"))
-                return AvatarAppearance.VISUALPARAM_COUNT_1X;    // 15 out of 16, 1.x does not support physics layers
-            
-            // Assume anything else can handle everything we support.
-            return AvatarAppearance.VISUALPARAM_COUNT;
-        }
 
         public void SendWearables(AvatarWearable[] wearables, int serial)
         {
@@ -3096,12 +3087,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             }
 
             AvatarAppearancePacket avp = (AvatarAppearancePacket)PacketPool.Instance.GetPacket(PacketType.AvatarAppearance);
-            // TODO: don't create new blocks if recycling an old packet
-            int clientParamsLength = MaxVisualParams();
-
-            if (clientParamsLength > app.VisualParams.Length)
-                clientParamsLength = app.VisualParams.Length;
-
+            int clientParamsLength = app.VisualParams.Length;
             avp.VisualParam = new AvatarAppearancePacket.VisualParamBlock[clientParamsLength];
             avp.ObjectData.TextureEntry = app.Texture.GetBytes();
 
@@ -3125,7 +3111,9 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                     }
                 };
 
-            // TODO Add AvatarHoverPacket block here 
+            avp.AppearanceHover = new AvatarAppearancePacket.AppearanceHoverBlock[1];
+            avp.AppearanceHover[0] = new AvatarAppearancePacket.AppearanceHoverBlock();
+            avp.AppearanceHover[0].HoverHeight = new Vector3(0.0f, 0.0f, app.HoverHeight);
 
             avp.Sender.IsTrial = false;
             avp.Sender.ID = app.Owner;

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
@@ -920,7 +920,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
         {
         }
 
-        public void SendAppearance(AvatarAppearance app)
+        public void SendAppearance(AvatarAppearance app, Vector3 hover)
         {
         }
 

--- a/OpenSim/Region/CoreModules/Capabilities/AgentPreferencesModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/AgentPreferencesModule.cs
@@ -168,9 +168,9 @@ namespace OpenSim.Region.CoreModules.Capabilities
             if (req.ContainsKey("default_object_perm_masks"))
             {
                 OSDMap permsMap = (OSDMap)req["default_object_perm_masks"];
-                data.PermEveryone = permsMap["Everyone"].AsInteger();
-                data.PermGroup = permsMap["Group"].AsInteger();
-                data.PermNextOwner = permsMap["NextOwner"].AsInteger();
+                data.PermEveryone = permsMap["Everyone"].AsUInteger();
+                data.PermGroup = permsMap["Group"].AsUInteger();
+                data.PermNextOwner = permsMap["NextOwner"].AsUInteger();
             }
             if (req.ContainsKey("hover_height"))
             {

--- a/OpenSim/Region/CoreModules/Capabilities/AgentPreferencesModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/AgentPreferencesModule.cs
@@ -103,7 +103,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
             {
                 ScenePresence sp = m_scene.GetScenePresence(agent);
                 if (sp != null)
-                    data = sp.AgentPrefs;
+                    data = new AgentPreferencesData(sp.AgentPrefs);
             }
 
             if (data == null)

--- a/OpenSim/Region/CoreModules/Capabilities/AgentPreferencesModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/AgentPreferencesModule.cs
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) InWorldz Halcyon Developers
+ * Copyright (c) Contributors, http://opensimulator.org/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the OpenSimulator Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE DEVELOPERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using log4net;
+using Nini.Config;
+using Mono.Addins;
+using OpenMetaverse;
+using OpenMetaverse.StructuredData;
+using OpenSim.Framework;
+using OpenSim.Framework.Servers.HttpServer;
+using OpenSim.Region.Framework.Interfaces;
+using OpenSim.Region.Framework.Scenes;
+using OpenSim.Services.Interfaces;
+
+using OSD = OpenMetaverse.StructuredData.OSD;
+using Caps = OpenSim.Framework.Communications.Capabilities.Caps;
+
+namespace OpenSim.Region.CoreModules.Capabilities
+{
+    [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule")]
+    public class AgentPreferencesModule : ISharedRegionModule
+    {
+        private static readonly ILog m_log
+            = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        private Scene m_scene;
+
+        #region ISharedRegionModule Members
+
+        public void Initialize(IConfigSource source)
+        {
+
+        }
+
+        public void AddRegion(Scene s)
+        {
+            m_scene = s;
+        }
+
+        public void RemoveRegion(Scene s)
+        {
+            m_scene.EventManager.OnRegisterCaps -= RegisterCaps;
+        }
+
+        public void RegionLoaded(Scene s)
+        {
+            m_scene.EventManager.OnRegisterCaps += RegisterCaps;
+        }
+
+        public void PostInitialize()
+        {
+        }
+
+        public void Close()
+        { 
+        }
+
+        public string Name
+        {
+            get { return "AgentPreferencesModule"; }
+        }
+
+        public Type ReplaceableInterface
+        {
+            get { return null; }
+        }
+
+        #endregion
+
+        #region AgentPrefs Storage
+
+        private Dictionary<UUID,AgentPreferencesData> m_agentPrefs = new Dictionary<UUID, AgentPreferencesData>();
+
+        private AgentPreferencesData FetchAgentPrefs(UUID agent)
+        {
+            AgentPreferencesData data = null;
+            if (agent != UUID.Zero)
+            {
+                // data = m_scene.AgentPreferencesService.GetAgentPreferences(agent);
+                if (m_agentPrefs.ContainsKey(agent))
+                    data = m_agentPrefs[agent];
+            }
+
+            if (data == null)
+                data = new AgentPreferencesData();
+            
+            return data;
+        }
+
+        private void StoreAgentPrefs(UUID agent, AgentPreferencesData data)
+        {
+            m_agentPrefs[agent] = data;            
+        }
+
+        #endregion
+
+        #region Region module
+
+        public void RegisterCaps(UUID agentID, Caps caps)
+        {
+            UUID capId = UUID.Random();
+            caps.RegisterHandler("AgentPreferences",
+                new RestStreamHandler("POST", "/CAPS/" + capId,
+                    delegate(string request, string path, string param,
+                        OSHttpRequest httpRequest, OSHttpResponse httpResponse)
+                    {
+                        return UpdateAgentPreferences(request, path, param, agentID);
+                    }));
+            caps.RegisterHandler("UpdateAgentLanguage",
+                new RestStreamHandler("POST", "/CAPS/" + capId,
+                    delegate(string request, string path, string param,
+                        OSHttpRequest httpRequest, OSHttpResponse httpResponse)
+                    {
+                        return UpdateAgentPreferences(request, path, param, agentID);
+                    }));
+            caps.RegisterHandler("UpdateAgentInformation",
+                new RestStreamHandler("POST", "/CAPS/" + capId,
+                    delegate(string request, string path, string param,
+                        OSHttpRequest httpRequest, OSHttpResponse httpResponse)
+                    {
+                        return UpdateAgentPreferences(request, path, param, agentID);
+                    }));
+        }
+
+        public string UpdateAgentPreferences(string request, string path, string param, UUID agent)
+        {
+            OSDMap resp = new OSDMap();
+            // The viewer doesn't do much with the return value, so for now, if there is no preference service,
+            // we'll return a null llsd block for debugging purposes. This may change if someone knows what the
+            // correct server response would be here.
+
+            // if (m_scene.AgentPreferencesService == null) return OSDParser.SerializeLLSDXmlString(resp);
+
+            m_log.DebugFormat("[AgentPrefs]: UpdateAgentPreferences for {0}", agent.ToString());
+            OSDMap req = (OSDMap)OSDParser.DeserializeLLSDXml(request);
+
+            AgentPreferencesData data = FetchAgentPrefs(agent);
+
+            if (req.ContainsKey("access_prefs"))
+            {
+                OSDMap accessPrefs = (OSDMap)req["access_prefs"];  // We could check with ContainsKey...
+                data.AccessPrefs = accessPrefs["max"].AsString();
+            }
+            if (req.ContainsKey("default_object_perm_masks"))
+            {
+                OSDMap permsMap = (OSDMap)req["default_object_perm_masks"];
+                data.PermEveryone = permsMap["Everyone"].AsInteger();
+                data.PermGroup = permsMap["Group"].AsInteger();
+                data.PermNextOwner = permsMap["NextOwner"].AsInteger();
+            }
+            if (req.ContainsKey("hover_height"))
+            {
+                float hover = (float)req["hover_height"].AsReal();
+                if (hover != (float)data.HoverHeight) // has it changed?
+                {
+                    ScenePresence sp = m_scene.GetScenePresence(agent);
+                    if ((sp != null) && (sp.Appearance != null))
+                        sp.Appearance.HoverHeight = hover;
+                }
+                data.HoverHeight = hover;
+            }
+            if (req.ContainsKey("language"))
+            {
+                data.Language = req["language"].AsString();
+            }
+            if (req.ContainsKey("language_is_public"))
+            {
+                data.LanguageIsPublic = req["language_is_public"].AsBoolean();
+            }
+
+            // m_scene.AgentPreferencesService.StoreAgentPreferences(data);
+            StoreAgentPrefs(agent, data);
+
+            OSDMap respAccessPrefs = new OSDMap();
+            respAccessPrefs["max"] = data.AccessPrefs;
+            resp["access_prefs"] = respAccessPrefs;
+            OSDMap respDefaultPerms = new OSDMap();
+            respDefaultPerms["Everyone"] = data.PermEveryone;
+            respDefaultPerms["Group"] = data.PermGroup;
+            respDefaultPerms["NextOwner"] = data.PermNextOwner;
+            resp["default_object_perm_masks"] = respDefaultPerms;
+            resp["god_level"] = 0; // *TODO: Add this
+            resp["hover_height"] = data.HoverHeight;
+            resp["language"] = data.Language;
+            resp["language_is_public"] = data.LanguageIsPublic;
+
+            return OSDParser.SerializeLLSDXmlString(resp);
+        }
+
+        #endregion Region module
+    }
+}

--- a/OpenSim/Region/CoreModules/Capabilities/ObjectAddModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/ObjectAddModule.cs
@@ -319,7 +319,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                 // rez ON the ground, not IN the ground
                 pos.Z += 0.25F;
 
-                obj = m_scene.AddNewPrim(avatar.UUID, group_id, pos, rotation, pbs, false);
+                obj = m_scene.AddNewPrim(avatar.UUID, group_id, pos, rotation, pbs, false, true);
             }
 
 

--- a/OpenSim/Region/CoreModules/Capabilities/SimulatorFeaturesModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/SimulatorFeaturesModule.cs
@@ -168,6 +168,7 @@ namespace OpenSim.Region.CoreModules.Capabilities
                 m_features["RenderMaterialsCapability"] = m_RenderMaterialsCapability;
                 m_features["MaxMaterialsPerTransaction"] = m_MaxMaterialsPerTransaction;
                 m_features["DynamicPathfindingEnabled"] = m_DynamicPathfindingEnabled;
+                m_features["AvatarHoverHeightEnabled"] = true;
     
                 OSDMap typesMap = new OSDMap();
                 typesMap["convex"] = true;

--- a/OpenSim/Region/CoreModules/World/Vegetation/VegetationModule.cs
+++ b/OpenSim/Region/CoreModules/World/Vegetation/VegetationModule.cs
@@ -66,7 +66,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Vegetation
             treeShape.Scale = scale;
             treeShape.State = (byte)treeType;
             
-            return m_scene.AddNewPrim(uuid, groupID, position, rotation, treeShape, false);
+            return m_scene.AddNewPrim(uuid, groupID, position, rotation, treeShape, false, true);
         }
         
         public SceneObjectGroup CreateEntity(

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2352,7 +2352,7 @@ namespace OpenSim.Region.Framework.Scenes
                 {
                     if (CheckLandImpact(parcel, landImpact, out reason))
                     {
-                        AddNewPrim(ownerID, groupID, pos, rot, shape, true);
+                        AddNewPrim(ownerID, groupID, pos, rot, shape, true, true);
                         return;
                     }
                     if (reason == "region")
@@ -2376,8 +2376,33 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
+        public void ApplyDefaultPerms(SceneObjectPart part)
+        {
+            // Try to apply the avatar's preferred default permissions from AgentPrefs.
+            ScenePresence sp = GetScenePresence(part.OwnerID);
+            if (sp == null) return;
+            AgentPreferencesData prefs = sp.AgentPrefs;
+            if (prefs == null) return;
+
+            part.NextOwnerMask = prefs.PermNextOwner & part.BaseMask;
+            part.GroupMask = prefs.PermGroup & part.BaseMask;
+            part.EveryoneMask = prefs.PermEveryone & part.BaseMask;
+
+            // Check if trying to set the Export flag.
+            if ((prefs.PermEveryone & (uint)PermissionMask.Export) != 0)
+            {
+                // Attempting to set export flag.
+                if ((part.OwnerMask & (uint)PermissionMask.Export) == 0 || (part.BaseMask & (uint)PermissionMask.Export) == 0 || (part.NextOwnerMask & (uint)PermissionMask.All) != (uint)PermissionMask.All)
+                    part.EveryoneMask &= ~(uint)PermissionMask.Export;
+            }
+
+            // If the owner has not provided full rights (MCT) for NextOwner, clear the Export flag.
+            if ((part.NextOwnerMask &(uint)PermissionMask.All) != (uint)PermissionMask.All)
+                part.EveryoneMask &= ~(uint)PermissionMask.Export;
+        }
+
         public virtual SceneObjectGroup AddNewPrim(
-            UUID ownerID, UUID groupID, Vector3 pos, Quaternion rot, PrimitiveBaseShape shape, bool rezSelected)
+            UUID ownerID, UUID groupID, Vector3 pos, Quaternion rot, PrimitiveBaseShape shape, bool rezSelected, bool sessionPerms)
         {
             //m_log.DebugFormat(
             //    "[SCENE]: Scene.AddNewPrim() pcode {0} called for {1} in {2}", shape.PCode, ownerID, RegionInfo.RegionName);
@@ -2388,6 +2413,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             // Otherwise, use this default creation code;
             SceneObjectGroup sceneObject = new SceneObjectGroup(ownerID, pos, rot, shape, rezSelected);
+            if (sessionPerms) ApplyDefaultPerms(sceneObject.RootPart);
             sceneObject.SetGroup(groupID, null);
             AddNewSceneObject(sceneObject, true);
 

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1,35 +1,4 @@
 /*
- * Copyright (c) 2015, InWorldz Halcyon Developers
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- *   * Redistributions of source code must retain the above copyright notice, this
- *     list of conditions and the following disclaimer.
- * 
- *   * Redistributions in binary form must reproduce the above copyright notice,
- *     this list of conditions and the following disclaimer in the documentation
- *     and/or other materials provided with the distribution.
- * 
- *   * Neither the name of halcyon nor the names of its
- *     contributors may be used to endorse or promote products derived from
- *     this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
-
-/*
  * Copyright (c) InWorldz Halcyon Developers
  * Copyright (c) Contributors, http://opensimulator.org/
  *
@@ -67,7 +36,6 @@ using OpenSim.Framework.Client;
 using OpenSim.Framework.Communications.Cache;
 using OpenSim.Framework.Geom;
 using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes.Types;
 using OpenSim.Region.Physics.Manager;
 using OpenSim.Region.Framework.Scenes.Serialization;
 using System.Threading.Tasks;
@@ -274,12 +242,11 @@ namespace OpenSim.Region.Framework.Scenes
             get { return m_agentPrefs; }
             set
             {
-                bool updatedHover = (this.Appearance.HoverHeight != (float)value.HoverHeight);
+                bool updatedHover = (m_agentPrefs == null) ? true : (m_agentPrefs.HoverHeight != (float)value.HoverHeight);
                 m_agentPrefs = value;
                 if (updatedHover)
                 {
-                    // keep Appearance and other viewers in sync
-                    this.Appearance.HoverHeight = (float)value.HoverHeight;
+                    // keep other viewers in sync
                     SendAppearanceToAllOtherAgents();
                 }
             }
@@ -3495,15 +3462,16 @@ namespace OpenSim.Region.Framework.Scenes
         }
 
         /// <summary>
-        /// Send appearance data to an agent that isn't this one.
+        /// Send MY appearance data to ANOTHER different avatar (that isn't this one).
         /// </summary>
-        /// <param name="avatar"></param>
-        public void SendAppearanceToOtherAgent(ScenePresence avatar)
+        /// <param name="otherAvatar"></param>
+        public void SendAppearanceToOtherAgent(ScenePresence otherAvatar)
         {
             //m_log.WarnFormat("[SP]: Sending avatar appearance for {0} to {1}. Face[0]: {2}, Owner: {3}", this.Name, avatar.Name,
             //    m_appearance.Texture.FaceTextures[0] != null ? m_appearance.Texture.FaceTextures[0].TextureID.ToString() : "null", m_appearance.Owner);
 
-            avatar.ControllingClient.SendAppearance(m_appearance);
+            float hover = (this.AgentPrefs != null) ? (float)this.AgentPrefs.HoverHeight : 0.0f;
+            otherAvatar.ControllingClient.SendAppearance(m_appearance, new Vector3(0.0f, 0.0f, (float)hover));
         }
 
         private void InitialAttachmentRez()
@@ -4165,6 +4133,7 @@ namespace OpenSim.Region.Framework.Scenes
                 cAgent.GodLevel = (byte) 0;
 
             cAgent.Appearance = new AvatarAppearance(m_appearance);
+            cAgent.AgentPrefs = new AgentPreferencesData(m_agentPrefs);
 
             // Animations
             try
@@ -4263,6 +4232,7 @@ namespace OpenSim.Region.Framework.Scenes
                 m_godlevel = cAgent.GodLevel;
 
             m_appearance = new AvatarAppearance(cAgent.Appearance);
+            m_agentPrefs = new AgentPreferencesData(cAgent.AgentPrefs);
 
             // Animations
             try

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -267,6 +267,24 @@ namespace OpenSim.Region.Framework.Scenes
             set { m_appearance = value; }
         }
 
+        public AgentPreferencesData m_agentPrefs;
+
+        public AgentPreferencesData AgentPrefs
+        {
+            get { return m_agentPrefs; }
+            set
+            {
+                bool updatedHover = (this.Appearance.HoverHeight != (float)value.HoverHeight);
+                m_agentPrefs = value;
+                if (updatedHover)
+                {
+                    // keep Appearance and other viewers in sync
+                    this.Appearance.HoverHeight = (float)value.HoverHeight;
+                    SendAppearanceToAllOtherAgents();
+                }
+            }
+        }
+
         protected List<SceneObjectGroup> m_attachments = new List<SceneObjectGroup>();
 
         protected List<UUID> m_groupsRegisteredForCollisionEvents = new List<UUID>();


### PR DESCRIPTION
- added supports the `AgentPreferences` CAP
- supports providing `AgentPreferences` values to the destination region on region crossings and teleports.
- changed `VisualParams` to always store and return whatever the viewer sent (rather than variable 212/251/253 bytes).
- added support for the **avatar hover height** slider (independent of the v2-style hover height on _shapes_)
- enabled `AvatarHoverHeight` in `SimulatorFeatures`
- sends updates to all avatars on hover changes
- implemented **default object permissions** for object creation based on `AgentPreferences`. This may also fix [Mantis 828](http://bugs.inworldz.com/mantis/view.php?id=828).
- implemented [llGetAgentLanguage](http://wiki.secondlife.com/wiki/LlGetAgentLanguage). Fixes [Mantis 2667](http://bugs.inworldz.com/mantis/view.php?id=2667).