### PR TITLE
IsAttachmentPointOnHud fixes

### DIFF
--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -861,11 +861,19 @@ namespace OpenSim.Region.Framework.Scenes
                 return;
             }
 
-            // it's a HUD and someone else's...
-            if (SceneObjectPart.IsAttachmentPointOnHUD(AttachmentPt) && (group.OwnerID != remoteClient.AgentId))
+            if ((group.OwnerID != remoteClient.AgentId))
             {
-                m_log.WarnFormat("[SCENE] Invalid wear HUD owned by {0} on {1} attachment point {2} object '{3}'.",
-                    group.UUID, remoteClient.AgentId, AttachmentPt, group.Name);
+                // Even for bots, the group.OwnerID will be set to the bot ID, so this is a safe check.
+                m_log.WarnFormat(
+                    "[SCENE] Invalid wear attachment owned by {0} on {1} object '{2}'.",
+                    group.UUID, remoteClient.AgentId, group.Name);
+                return;
+            }
+
+            if (!SceneObjectPart.IsValidAttachmentPoint(AttachmentPt))
+            {
+                m_log.WarnFormat("[SCENE] Invalid wear attachment owned by {0} attachment point {1} object '{2}'.",
+                    remoteClient.AgentId, AttachmentPt, group.Name);
                 return;
             }
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -281,8 +281,12 @@ namespace OpenSim.Region.Framework.Scenes
         public const byte MAX_HUD        = (byte)OpenMetaverse.AttachmentPoint.HUDBottomRight;  // 38
         public const byte MAX_ATTACHMENT = (byte)OpenMetaverse.AttachmentPoint.Root;            // 40
 
-        // Attachment points with the high bit set must be converted to 7-bit before this call.
+        // Attachment points with the high bit set must be converted to 7-bit before these calls.
         public static bool IsAttachmentPointOnHUD(uint attachPoint)
+        {
+            return (attachPoint >= MIN_HUD) && (attachPoint <= MAX_HUD);
+        }
+        public static bool IsValidAttachmentPoint(uint attachPoint)
         {
             return (attachPoint >= MIN_ATTACHMENT) && (attachPoint <= MAX_ATTACHMENT);
         }


### PR DESCRIPTION
- Fixed misnamed IsValidAttachmentPoint. Split into IsValidAttachmentPoint (corrected implementation) and IsValidAttachmentPoint (old misnamed implementation).
- Split IsAttachmentPointOnHUD check into separate checks: checking if we're trying to attach something owned by someone else (may fix ghost HUD issues), and use the correct IsValidAttachment Point check (not just HUDs).  It was already doing that, but after fixing the naming above, it was going to limit to HUDs which we don't really want/need to do.