### PR TITLE
Fixed a possible null reference on money transfers

### DIFF
--- a/OpenSim/Region/CoreModules/Avatar/Currency/AvatarCurrency.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Currency/AvatarCurrency.cs
@@ -645,6 +645,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Currency
             if (sourceAvatarClient == null)
             {
                 m_log.Debug("[CURRENCY]: Source Avatar not found!");
+                return;
             }
 
             if (transType == (int)MoneyTransactionType.PayObject)


### PR DESCRIPTION
Just a small fix.  If the sender leaves the region or disconnects before it is processed.