### PR TITLE
Implemented llReturnObjectsByOwner and llReturnObjectsByID

### DIFF
--- a/InWorldz/InWorldz.Testing/MockClientAPI.cs
+++ b/InWorldz/InWorldz.Testing/MockClientAPI.cs
@@ -81,6 +81,10 @@ namespace InWorldz.Testing
         {
             return 0;
         }
+        public ulong? GetGroupPowersOrNull(OpenMetaverse.UUID groupID)
+        {
+            return null;
+        }
 
         public bool IsGroupMember(OpenMetaverse.UUID GroupID)
         {

--- a/OpenSim/Framework/IClientAPI.cs
+++ b/OpenSim/Framework/IClientAPI.cs
@@ -122,7 +122,7 @@ namespace OpenSim.Framework
     // really don't want to be passing packets in these events, so this is very temporary.
     public delegate void GenericCall4(Packet packet, IClientAPI remoteClient);
 
-    public delegate void DeRezObjects(
+    public delegate int DeRezObjects(
         IClientAPI remoteClient, ICollection<uint> objects, UUID groupId, DeRezAction action, UUID destinationID);
 
     public delegate void GenericCall5(IClientAPI remoteClient, bool status);
@@ -610,6 +610,7 @@ namespace OpenSim.Framework
         ulong ActiveGroupPowers { get; }
 
         ulong GetGroupPowers(UUID groupID);
+        ulong? GetGroupPowersOrNull(UUID groupID);
 
         bool IsGroupMember(UUID GroupID);
 

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -419,7 +419,8 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             return false;
         }
 
-        public ulong GetGroupPowers(UUID groupID)
+        // Returns null if not in the group at all.
+        public ulong? GetGroupPowersOrNull(UUID groupID)
         {
             if (m_groupPowers != null)
             {
@@ -433,7 +434,11 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 }
             }
 
-            return 0;
+            return null;
+        }
+        public ulong GetGroupPowers(UUID groupID)
+        {
+            return GetGroupPowersOrNull(groupID) ?? 0;
         }
 
         public void SetGroupPowers(IEnumerable<AgentGroupData> groupPowers)

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
@@ -411,6 +411,7 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
         }
 
         public ulong GetGroupPowers(OpenMetaverse.UUID groupID) { return 0; }
+        public ulong? GetGroupPowersOrNull(OpenMetaverse.UUID groupID) { return null; }
 
         public bool IsGroupMember(OpenMetaverse.UUID GroupID) { return false; }
 

--- a/OpenSim/Region/CoreModules/World/Land/LandChannel.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandChannel.cs
@@ -205,6 +205,26 @@ namespace OpenSim.Region.CoreModules.World.Land
             }
         }
 
+        public int ScriptedReturnObjectsInParcel(UUID actionAgentID, UUID targetAgentID, LandData parcel, bool sameOwner)
+        {
+            if (m_landManagementModule != null)
+            {
+                return m_landManagementModule.ScriptedReturnObjectsInParcel(actionAgentID, targetAgentID, parcel, sameOwner);
+            }
+
+            return -1;
+        }
+
+        public int ScriptedReturnObjectsInParcelByIDs(UUID actionAgentID, List<UUID> targetIDs, int parcelLocalID)
+        {
+            if (m_landManagementModule != null)
+            {
+                return m_landManagementModule.ScriptedReturnObjectsInParcelByIDs(actionAgentID, targetIDs, parcelLocalID);
+            }
+
+            return -1;
+        }
+
         public void setParcelObjectMaxOverride(overrideParcelMaxPrimCountDelegate overrideDel)
         {
             if (m_landManagementModule != null)

--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -1540,6 +1540,47 @@ namespace OpenSim.Region.CoreModules.World.Land
             selectedParcel.returnLandObjects(returnType, agentIDs, taskIDs, remoteClient);
         }
 
+        // Pass parcel==null for all parcels in the region, or parcel != null for a specific parcel
+        // or all parcels owned by the same owner.
+        public int ScriptedReturnObjectsInParcel(UUID actionAgentID, UUID targetAgentID, LandData patternParcel, bool sameOwner)
+        {
+            int count = 0;
+
+            // Applies to all parcels in the region
+            foreach (ILandObject landObject in AllParcels())
+            {
+                bool includeParcel = (patternParcel == null);  // all parcels
+                if (patternParcel != null)  // a more specific criteria
+                {
+                    if (patternParcel.LocalID == landObject.landData.LocalID)
+                        includeParcel = true;
+                    else
+                    if (sameOwner && (patternParcel.OwnerID == landObject.landData.OwnerID))
+                        includeParcel = true;
+                }
+
+                if (includeParcel)
+                {
+                    int rc = landObject.scriptedReturnLandObjectsByOwner(actionAgentID, targetAgentID);
+                    // if we get an error, stop. If we've returned items, return the count, otherwise error code.
+                    if (rc < 0) // error
+                        return (count > 0) ? count : rc;
+                    count += rc;
+                }
+            }
+
+            return count;
+        }
+
+        public int ScriptedReturnObjectsInParcelByIDs(UUID actionAgentID, List<UUID> targetIDs, int parcelLocalID)
+        {
+            if (!m_landList.ContainsKey(parcelLocalID))
+                return 0;
+
+            ILandObject parcel = m_landList[parcelLocalID];
+            return parcel.scriptedReturnLandObjectsByIDs(actionAgentID, targetIDs);
+        }
+
         public void NoLandDataFromStorage()
         {
             ResetSimLandObjects();

--- a/OpenSim/Region/Framework/Interfaces/ILandChannel.cs
+++ b/OpenSim/Region/Framework/Interfaces/ILandChannel.cs
@@ -72,6 +72,8 @@ namespace OpenSim.Region.Framework.Interfaces
         void UpdateLandObject(int localID, LandData data);
         void UpdateLandPrimCounts();
         void ReturnObjectsInParcel(int localID, uint returnType, UUID[] agentIDs, UUID[] taskIDs, IClientAPI remoteClient);
+        int ScriptedReturnObjectsInParcel(UUID actionAgentID, UUID targetAgentID, LandData parcel, bool sameOwner);
+        int ScriptedReturnObjectsInParcelByIDs(UUID actionAgentID, List<UUID> targetIDs, int parcelLocalID);
         void setParcelObjectMaxOverride(overrideParcelMaxPrimCountDelegate overrideDel);
         void setSimulatorObjectMaxOverride(overrideSimulatorMaxPrimCountDelegate overrideDel);
         void SetParcelOtherCleanTime(IClientAPI remoteClient, int localID, int otherCleanTime);

--- a/OpenSim/Region/Framework/Interfaces/ILandObject.cs
+++ b/OpenSim/Region/Framework/Interfaces/ILandObject.cs
@@ -75,6 +75,8 @@ namespace OpenSim.Region.Framework.Interfaces
         void sendLandObjectOwners(IClientAPI remote_client);
         void returnObject(SceneObjectGroup obj);
         void returnLandObjects(uint type, UUID[] owners, UUID[] tasks, IClientAPI remote_client);
+        int scriptedReturnLandObjectsByOwner(UUID scriptOwnerID, UUID targetOwnerID);
+        int scriptedReturnLandObjectsByIDs(UUID scriptOwnerID, List<UUID> IDs);
         void InspectParcelForAutoReturn();
         void resetLandPrimCounts();
         void addPrimToCount(SceneObjectGroup obj);

--- a/OpenSim/Region/Framework/Scenes/Scene.Permissions.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Permissions.cs
@@ -80,7 +80,7 @@ namespace OpenSim.Region.Framework.Scenes
     public delegate bool CopyUserInventoryHandler(UUID itemID, UUID userID);
     public delegate bool DeleteUserInventoryHandler(UUID itemID, UUID userID);
     public delegate bool TeleportHandler(UUID userID, Scene scene);
-    public delegate bool UseObjectReturnHandler(ILandObject landData, uint type, IClientAPI client, List<SceneObjectGroup> retlist, Scene scene);
+    public delegate bool UseObjectReturnHandler(ILandObject parcel, uint type, IClientAPI client, UUID scriptOwnerID, List<SceneObjectGroup> retlist, Scene scene);
     public delegate bool ControlPrimMediaHandler(UUID userID, UUID primID, int face);
     public delegate bool InteractWithPrimMediaHandler(UUID userID, UUID primID, int face);
 
@@ -923,7 +923,7 @@ namespace OpenSim.Region.Framework.Scenes
             return true;
         }
 
-        public bool CanUseObjectReturn(ILandObject landData, uint type , IClientAPI client, List<SceneObjectGroup> retlist)
+        public bool CanUseObjectReturn(ILandObject parcel, uint type, IClientAPI client, UUID scriptOwnerID, List<SceneObjectGroup> retlist)
         {
             UseObjectReturnHandler handler = OnUseObjectReturn;
             if (handler != null)
@@ -931,7 +931,7 @@ namespace OpenSim.Region.Framework.Scenes
                 Delegate[] list = handler.GetInvocationList();
                 foreach (UseObjectReturnHandler h in list)
                 {
-                    if (h(landData, type, client, retlist, m_scene) == false)
+                    if (h(parcel, type, client, scriptOwnerID, retlist, m_scene) == false)
                         return false;
                 }
             }


### PR DESCRIPTION
Also clarified and simplified cases where a group was checked and NOT being a member was treated as 0 (member in Everyone role) by using a nullable type for group powers.  Factored caching of group powers, and otherwise also favor use of LLCV client cached powers if available when not cached.

This is an initial version that works as most people would expect. It does **not** yet support group-based returns as described in the second sentence of the [documentation](http://wiki.secondlife.com/wiki/LlReturnObjectsByOwner):

> If the script is owned by an agent, PERMISSION_RETURN_OBJECTS may be granted by the owner. If the script is _owned by a group_, this permission may be granted by _an agent belonging to the group's "Owners" role_.

That will be added in a followup PR later.