### PR TITLE
Fixed sit target persistence to support both new and legacy zero values, plus...

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -8664,12 +8664,12 @@ namespace InWorldz.Phlox.Engine
         {
             Vector3 sitPos = new Vector3((float)offset.X, (float)offset.Y, (float)offset.Z);
             Quaternion sitRot = Rot2Quaternion(rot);
-            bool isEnabled = (sitPos != Vector3.Zero) || (sitRot != Quaternion.Identity);
+            bool isActive = (sitPos != Vector3.Zero) || (sitRot != Quaternion.Identity);
 
             var parts = GetLinkPrimsOnly(linknumber);
             foreach (SceneObjectPart part in parts)
             {
-                part.SetSitTarget(isEnabled, sitPos, sitRot, true);
+                part.SetSitTarget(isActive, sitPos, sitRot, true);
             }
         }
 
@@ -8690,7 +8690,7 @@ namespace InWorldz.Phlox.Engine
                 SitTargetInfo sitInfo = part.ParentGroup.SitTargetForPart(part.UUID);
                 if (IncludeSitTargetOnly)
                 {
-                    if (sitInfo.IsEnabled && sitInfo.HasSitter)
+                    if (sitInfo.IsActive && sitInfo.HasSitter)
                     {
                         seatedAvatar = sitInfo.Sitter.UUID;
                         break;
@@ -11680,7 +11680,7 @@ namespace InWorldz.Phlox.Engine
                                 SitTargetInfo sitInfo = part.ParentGroup.SitTargetForPart(part.UUID);
                                 if (sitInfo != null)
                                 {
-                                    res.Add((int)(sitInfo.IsEnabled ? 1 : 0));
+                                    res.Add((int)(sitInfo.IsActive ? 1 : 0));
                                     res.Add(new LSL_Vector(sitInfo.Offset));
                                     res.Add(new LSL_Rotation(sitInfo.Rotation));
                                     continue;

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -8664,12 +8664,12 @@ namespace InWorldz.Phlox.Engine
         {
             Vector3 sitPos = new Vector3((float)offset.X, (float)offset.Y, (float)offset.Z);
             Quaternion sitRot = Rot2Quaternion(rot);
-            bool enabled = (sitPos != Vector3.Zero) && (sitRot != Quaternion.Identity);
+            bool isEnabled = (sitPos != Vector3.Zero) && (sitRot != Quaternion.Identity);
 
             var parts = GetLinkPrimsOnly(linknumber);
             foreach (SceneObjectPart part in parts)
             {
-                part.SetSitTarget(sitPos, sitRot, enabled, true);
+                part.SetSitTarget(isEnabled, sitPos, sitRot, true);
             }
         }
 
@@ -8690,7 +8690,7 @@ namespace InWorldz.Phlox.Engine
                 SitTargetInfo sitInfo = part.ParentGroup.SitTargetForPart(part.UUID);
                 if (IncludeSitTargetOnly)
                 {
-                    if (sitInfo.IsSet && sitInfo.HasSitter)
+                    if (sitInfo.IsEnabled && sitInfo.HasSitter)
                     {
                         seatedAvatar = sitInfo.Sitter.UUID;
                         break;
@@ -11660,7 +11660,7 @@ namespace InWorldz.Phlox.Engine
                                 SitTargetInfo sitInfo = part.ParentGroup.SitTargetForPart(part.UUID);
                                 if (sitInfo != null)
                                 {
-                                    res.Add((int)(sitInfo.IsSet ? 1 : 0));
+                                    res.Add((int)(sitInfo.IsEnabled ? 1 : 0));
                                     res.Add(new LSL_Vector(sitInfo.Offset));
                                     res.Add(new LSL_Rotation(sitInfo.Rotation));
                                     continue;

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -8664,11 +8664,12 @@ namespace InWorldz.Phlox.Engine
         {
             Vector3 sitPos = new Vector3((float)offset.X, (float)offset.Y, (float)offset.Z);
             Quaternion sitRot = Rot2Quaternion(rot);
+            bool enabled = (sitPos != Vector3.Zero) && (sitRot != Quaternion.Identity);
 
             var parts = GetLinkPrimsOnly(linknumber);
             foreach (SceneObjectPart part in parts)
             {
-                part.SetSitTarget(sitPos, sitRot, true);
+                part.SetSitTarget(sitPos, sitRot, enabled, true);
             }
         }
 

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -9456,6 +9456,7 @@ namespace InWorldz.Phlox.Engine
                 int remain = rules.Length - idx;
                 int face;
                 LSL_Vector v;
+                LSL_Rotation r;
 
                 if (code == (int)ScriptBaseClass.PRIM_LINK_TARGET)
                 {
@@ -10375,6 +10376,25 @@ namespace InWorldz.Phlox.Engine
                                         SetRenderMaterialAlphaModeData(part, face, alpha_mode, alpha_mask_cutoff);
                                     }
                                 }
+                            }
+                        }
+                        break;
+                    case (int)ScriptBaseClass.PRIM_SIT_TARGET:
+                        // [ PRIM_SIT_TARGET, integer active, vector offset, rotation rot ] 
+                        if (remain < 3)
+                            return;
+                        bool isActive = rules.GetLSLIntegerItem(idx++) != 0;
+                        v = rules.GetVector3Item(idx++);
+                        r = rules.GetQuaternionItem(idx++);
+                        foreach (var o in links)
+                        {
+                            if (o is SceneObjectPart)
+                            {
+                                var part = o as SceneObjectPart;
+                                if (isActive)
+                                    part.SetSitTarget(isActive, v, r, true);
+                                else
+                                    part.RemoveSitTarget();
                             }
                         }
                         break;

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -8664,7 +8664,7 @@ namespace InWorldz.Phlox.Engine
         {
             Vector3 sitPos = new Vector3((float)offset.X, (float)offset.Y, (float)offset.Z);
             Quaternion sitRot = Rot2Quaternion(rot);
-            bool isEnabled = (sitPos != Vector3.Zero) && (sitRot != Quaternion.Identity);
+            bool isEnabled = (sitPos != Vector3.Zero) || (sitRot != Quaternion.Identity);
 
             var parts = GetLinkPrimsOnly(linknumber);
             foreach (SceneObjectPart part in parts)

--- a/InWorldz/InWorldz.Region.Data.Thoosa/Serialization/SceneObjectPartSnapshot.cs
+++ b/InWorldz/InWorldz.Region.Data.Thoosa/Serialization/SceneObjectPartSnapshot.cs
@@ -264,6 +264,9 @@ namespace InWorldz.Region.Data.Thoosa.Serialization
         [ProtoMember(63)]
         public KeyframeAnimationSnapshot KeyframeAnimation;
 
+        [ProtoMember(64)]
+        public ServerPrimFlags ServerFlags;
+
         static SceneObjectPartSnapshot()
         {
             ProtoBuf.Serializer.PrepareSerializer<SceneObjectPartSnapshot>();
@@ -342,6 +345,7 @@ namespace InWorldz.Region.Data.Thoosa.Serialization
                 ScriptAccessPin = part.ScriptAccessPin,
                 SerializedPhysicsData = part.SerializedPhysicsData,
                 ServerWeight = part.ServerWeight,
+                ServerFlags = (ServerPrimFlags)part.ServerFlags,
                 Shape = PrimShapeSnapshot.FromShape(part.Shape),
                 SitName = part.SitName,
                 SitTargetOrientation = sitInfo.Rotation,
@@ -449,6 +453,7 @@ namespace InWorldz.Region.Data.Thoosa.Serialization
                 Scale = this.Scale,
                 ScriptAccessPin = this.ScriptAccessPin,
                 SerializedPhysicsData = this.SerializedPhysicsData,
+                ServerFlags = (uint)this.ServerFlags,
                 ServerWeight = this.ServerWeight,
                 Shape = this.Shape.ToPrimitiveBaseShape(),
                 SitName = this.SitName,

--- a/InWorldz/InWorldz.Region.Data.Thoosa/Serialization/SceneObjectPartSnapshot.cs
+++ b/InWorldz/InWorldz.Region.Data.Thoosa/Serialization/SceneObjectPartSnapshot.cs
@@ -473,6 +473,9 @@ namespace InWorldz.Region.Data.Thoosa.Serialization
                 KeyframeAnimation = this.KeyframeAnimation == null ? null : this.KeyframeAnimation.ToKeyframeAnimation()
             };
 
+            // Do legacy to current update for sop.ServerFlags.
+            sop.PrepSitTargetFromStorage(sop.SitTargetPosition, sop.SitTargetOrientation);
+
             if (SerializedScriptStates != null)
             {
                 var states = new Dictionary<OpenMetaverse.UUID, byte[]>(SerializedScriptStates.Count);

--- a/InWorldz/InWorldz.Region.Data.Thoosa/Tests/Util.cs
+++ b/InWorldz/InWorldz.Region.Data.Thoosa/Tests/Util.cs
@@ -193,6 +193,7 @@ namespace InWorldz.Region.Data.Thoosa.Tests
             part.SavedAttachmentRot = Util.RandomQuat();
             part.ScriptAccessPin = 87654;
             part.SerializedPhysicsData = new byte[] { 0xA, 0xB, 0xC, 0xD, 0xE, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, };
+            part.ServerFlags = (int)ServerPrimFlags.SitTargetEnabled;    // see SetSitTarget below
             part.ServerWeight = 3.0f;
             part.StreamingCost = 2.0f;
             part.SitName = "Sitting";

--- a/InWorldz/InWorldz.Region.Data.Thoosa/Tests/Util.cs
+++ b/InWorldz/InWorldz.Region.Data.Thoosa/Tests/Util.cs
@@ -193,7 +193,7 @@ namespace InWorldz.Region.Data.Thoosa.Tests
             part.SavedAttachmentRot = Util.RandomQuat();
             part.ScriptAccessPin = 87654;
             part.SerializedPhysicsData = new byte[] { 0xA, 0xB, 0xC, 0xD, 0xE, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, };
-            part.ServerFlags = (int)ServerPrimFlags.SitTargetEnabled;    // see SetSitTarget below
+            part.ServerFlags = 0;
             part.ServerWeight = 3.0f;
             part.StreamingCost = 2.0f;
             part.SitName = "Sitting";
@@ -209,7 +209,7 @@ namespace InWorldz.Region.Data.Thoosa.Tests
             part.Velocity = Util.RandomVector();
             part.FromItemID = UUID.Random();
 
-            part.SetSitTarget(Util.RandomVector(), Util.RandomQuat(), true, false);
+            part.SetSitTarget(true, Util.RandomVector(), Util.RandomQuat(), false);
 
             return part;
         }

--- a/InWorldz/InWorldz.Region.Data.Thoosa/Tests/Util.cs
+++ b/InWorldz/InWorldz.Region.Data.Thoosa/Tests/Util.cs
@@ -209,7 +209,7 @@ namespace InWorldz.Region.Data.Thoosa.Tests
             part.Velocity = Util.RandomVector();
             part.FromItemID = UUID.Random();
 
-            part.SetSitTarget(Util.RandomVector(), Util.RandomQuat(), false);
+            part.SetSitTarget(Util.RandomVector(), Util.RandomQuat(), true, false);
 
             return part;
         }

--- a/OpenSim/Data/MySQL/MySQLRegionData.cs
+++ b/OpenSim/Data/MySQL/MySQLRegionData.cs
@@ -1760,18 +1760,22 @@ namespace OpenSim.Data.MySQL
                 Convert.ToSingle(row["RotationW"])
                 );
 
-            prim.SetSitTarget(new Vector3(
-                                Convert.ToSingle(row["SitTargetOffsetX"]),
-                                Convert.ToSingle(row["SitTargetOffsetY"]),
-                                Convert.ToSingle(row["SitTargetOffsetZ"])
-                                ),
-                             new Quaternion(
-                                Convert.ToSingle(row["SitTargetOrientX"]),
-                                Convert.ToSingle(row["SitTargetOrientY"]),
-                                Convert.ToSingle(row["SitTargetOrientZ"]),
-                                Convert.ToSingle(row["SitTargetOrientW"])
-                             ), 
-                             false);
+            // We need ServerFlags first, in order to set all the SitTarget data.
+            prim.ServerFlags = Convert.ToUInt32(row["ServerFlags"]);
+            // Now the sit target info itself.
+            bool sitTargetEnabled = (prim.ServerFlags & (uint) ServerPrimFlags.SitTargetEnabled) != 0;
+            Vector3 sitTargetPos = new Vector3(
+                Convert.ToSingle(row["SitTargetOffsetX"]),
+                Convert.ToSingle(row["SitTargetOffsetY"]),
+                Convert.ToSingle(row["SitTargetOffsetZ"])
+            );
+            Quaternion sitTargetRot = new Quaternion(
+                Convert.ToSingle(row["SitTargetOrientX"]),
+                Convert.ToSingle(row["SitTargetOrientY"]),
+                Convert.ToSingle(row["SitTargetOrientZ"]),
+                Convert.ToSingle(row["SitTargetOrientW"])
+            );
+            prim.SetSitTarget(sitTargetPos, sitTargetRot, sitTargetEnabled, false);
 
             prim.PayPrice[0] = Convert.ToInt32(row["PayPrice"]);
             prim.PayPrice[1] = Convert.ToInt32(row["PayButton1"]);
@@ -1875,8 +1879,6 @@ namespace OpenSim.Data.MySQL
                     }
                 }
             }
-
-            prim.ServerFlags = Convert.ToUInt32(row["ServerFlags"]);
 
             return prim;
         }

--- a/OpenSim/Data/MySQL/MySQLRegionData.cs
+++ b/OpenSim/Data/MySQL/MySQLRegionData.cs
@@ -1762,8 +1762,7 @@ namespace OpenSim.Data.MySQL
 
             // We need ServerFlags first, in order to set all the SitTarget data.
             prim.ServerFlags = Convert.ToUInt32(row["ServerFlags"]);
-            // Now the sit target info itself.
-            bool sitTargetEnabled = prim.SitTargetEnabled;  // don't lose this on SetSitTarget below
+
             Vector3 sitTargetPos = new Vector3(
                 Convert.ToSingle(row["SitTargetOffsetX"]),
                 Convert.ToSingle(row["SitTargetOffsetY"]),
@@ -1775,6 +1774,19 @@ namespace OpenSim.Data.MySQL
                 Convert.ToSingle(row["SitTargetOrientZ"]),
                 Convert.ToSingle(row["SitTargetOrientW"])
             );
+
+            // Now the sit target info itself.
+            bool sitTargetEnabled = ((prim.ServerFlags & (uint) ServerPrimFlags.SitTargetEnabled) != 0);
+            if (!sitTargetEnabled) // check if legacy data
+            {
+                {   // check if non-zero sit target in pos/rot
+                    if ((sitTargetPos != Vector3.Zero) || (sitTargetRot != Quaternion.Identity)) {
+                        sitTargetEnabled = true;
+                        prim.ServerFlags |= (uint)ServerPrimFlags.SitTargetEnabled;
+                    }
+                }
+            }
+            // Mark this one as updated to using this ServerFlags.
             prim.SetSitTarget(sitTargetEnabled, sitTargetPos, sitTargetRot, false);
 
             prim.PayPrice[0] = Convert.ToInt32(row["PayPrice"]);

--- a/OpenSim/Data/MySQL/MySQLRegionData.cs
+++ b/OpenSim/Data/MySQL/MySQLRegionData.cs
@@ -1779,6 +1779,7 @@ namespace OpenSim.Data.MySQL
             bool sitTargetEnabled = ((prim.ServerFlags & (uint) ServerPrimFlags.SitTargetEnabled) != 0);
             if (!sitTargetEnabled) // check if legacy data
             {
+                if ((prim.ServerFlags & (uint) ServerPrimFlags.SitTargetStateSaved) == 0) // not set
                 {   // check if non-zero sit target in pos/rot
                     if ((sitTargetPos != Vector3.Zero) || (sitTargetRot != Quaternion.Identity)) {
                         sitTargetEnabled = true;
@@ -1787,6 +1788,7 @@ namespace OpenSim.Data.MySQL
                 }
             }
             // Mark this one as updated to using this ServerFlags.
+            prim.ServerFlags |= (uint)ServerPrimFlags.SitTargetStateSaved;
             prim.SetSitTarget(sitTargetEnabled, sitTargetPos, sitTargetRot, false);
 
             prim.PayPrice[0] = Convert.ToInt32(row["PayPrice"]);

--- a/OpenSim/Data/MySQL/MySQLRegionData.cs
+++ b/OpenSim/Data/MySQL/MySQLRegionData.cs
@@ -1776,19 +1776,11 @@ namespace OpenSim.Data.MySQL
             );
 
             // Now the sit target info itself.
-            bool sitTargetEnabled = ((prim.ServerFlags & (uint) ServerPrimFlags.SitTargetEnabled) != 0);
-            if (!sitTargetEnabled) // check if legacy data
-            {
-                if ((prim.ServerFlags & (uint) ServerPrimFlags.SitTargetStateSaved) == 0) // not set
-                {   // check if non-zero sit target in pos/rot
-                    if ((sitTargetPos != Vector3.Zero) || (sitTargetRot != Quaternion.Identity)) {
-                        sitTargetEnabled = true;
-                        prim.ServerFlags |= (uint)ServerPrimFlags.SitTargetEnabled;
-                    }
-                }
-            }
-            // Mark this one as updated to using this ServerFlags.
-            prim.ServerFlags |= (uint)ServerPrimFlags.SitTargetStateSaved;
+
+            // This function must be called on asset load (inventory rez) or database load (rezzed)
+            // with SOP.ServerFlags initialized, which may be updated before return.
+            bool sitTargetEnabled = prim.PrepSitTargetFromStorage(sitTargetPos, sitTargetRot);
+            // Even though the prim is set, we need to call this to update the SceneObjectGroup.
             prim.SetSitTarget(sitTargetEnabled, sitTargetPos, sitTargetRot, false);
 
             prim.PayPrice[0] = Convert.ToInt32(row["PayPrice"]);

--- a/OpenSim/Data/MySQL/MySQLRegionData.cs
+++ b/OpenSim/Data/MySQL/MySQLRegionData.cs
@@ -1763,7 +1763,7 @@ namespace OpenSim.Data.MySQL
             // We need ServerFlags first, in order to set all the SitTarget data.
             prim.ServerFlags = Convert.ToUInt32(row["ServerFlags"]);
             // Now the sit target info itself.
-            bool sitTargetEnabled = (prim.ServerFlags & (uint) ServerPrimFlags.SitTargetEnabled) != 0;
+            bool sitTargetEnabled = prim.SitTargetEnabled;  // don't lose this on SetSitTarget below
             Vector3 sitTargetPos = new Vector3(
                 Convert.ToSingle(row["SitTargetOffsetX"]),
                 Convert.ToSingle(row["SitTargetOffsetY"]),
@@ -1775,7 +1775,7 @@ namespace OpenSim.Data.MySQL
                 Convert.ToSingle(row["SitTargetOrientZ"]),
                 Convert.ToSingle(row["SitTargetOrientW"])
             );
-            prim.SetSitTarget(sitTargetPos, sitTargetRot, sitTargetEnabled, false);
+            prim.SetSitTarget(sitTargetEnabled, sitTargetPos, sitTargetRot, false);
 
             prim.PayPrice[0] = Convert.ToInt32(row["PayPrice"]);
             prim.PayPrice[1] = Convert.ToInt32(row["PayButton1"]);

--- a/OpenSim/Data/MySQL/MySQLRegionData.cs
+++ b/OpenSim/Data/MySQL/MySQLRegionData.cs
@@ -491,6 +491,9 @@ namespace OpenSim.Data.MySQL
             ProviderRegistry.Instance.TryGet<ISerializationEngine>(out engine);
             cmd.Parameters.AddWithValue("KeyframeAnimation" + numString, 
                 engine.MiscObjectSerializer.SerializeKeyframeAnimationToBytes(prim.KeyframeAnimation));
+
+            // Server-use flags (per-prim persistence storage). Currently just enabled TRUE/FALSE for sit target.
+            cmd.Parameters.AddWithValue("ServerFlags" + numString, prim.ServerFlags);
         }
 
         private StringBuilder GenerateShapeValuesBlock(int number)
@@ -1872,6 +1875,8 @@ namespace OpenSim.Data.MySQL
                     }
                 }
             }
+
+            prim.ServerFlags = Convert.ToUInt32(row["ServerFlags"]);
 
             return prim;
         }

--- a/OpenSim/Data/MySQL/MySQLRegionData.cs
+++ b/OpenSim/Data/MySQL/MySQLRegionData.cs
@@ -1779,9 +1779,9 @@ namespace OpenSim.Data.MySQL
 
             // This function must be called on asset load (inventory rez) or database load (rezzed)
             // with SOP.ServerFlags initialized, which may be updated before return.
-            bool sitTargetEnabled = prim.PrepSitTargetFromStorage(sitTargetPos, sitTargetRot);
+            bool sitTargetActive = prim.PrepSitTargetFromStorage(sitTargetPos, sitTargetRot);
             // Even though the prim is set, we need to call this to update the SceneObjectGroup.
-            prim.SetSitTarget(sitTargetEnabled, sitTargetPos, sitTargetRot, false);
+            prim.SetSitTarget(sitTargetActive, sitTargetPos, sitTargetRot, false);
 
             prim.PayPrice[0] = Convert.ToInt32(row["PayPrice"]);
             prim.PayPrice[1] = Convert.ToInt32(row["PayButton1"]);

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1033,7 +1033,7 @@ namespace OpenSim.Region.Framework.Scenes
             m_sitTargets.Clear();   // new UUIDs have been assigned, need to refresh
             m_childParts.ForEachPart((SceneObjectPart part) => {
                 part.ResetInstance(isNewInstance, isScriptReset, itemId);
-                this.SetSitTarget(part, part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
+                this.SetSitTarget(part, part.SitTargetActive, part.SitTargetPosition, part.SitTargetOrientation, false);
             });
         }
 
@@ -1346,9 +1346,9 @@ namespace OpenSim.Region.Framework.Scenes
             });
         }
 
-        public void SetSitTarget(SceneObjectPart part, bool isEnabled, Vector3 pos, Quaternion rot, bool preserveSitter)
+        public void SetSitTarget(SceneObjectPart part, bool isActive, Vector3 pos, Quaternion rot, bool preserveSitter)
         {
-            SitTargetInfo sitInfo = new SitTargetInfo(part, isEnabled, pos, rot);
+            SitTargetInfo sitInfo = new SitTargetInfo(part, isActive, pos, rot);
             if (preserveSitter)
             {
                 SitTargetInfo oldInfo;
@@ -1572,7 +1572,7 @@ namespace OpenSim.Region.Framework.Scenes
             // then be aware it is a duplicate copy of the SOP/SOG that has UUID/LocalID
             // that matches the in-world copy. But also has its own sit target dictionary,
             // so even if the IDs match, the SOP references are different.
-            SetSitTarget(part, part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
+            SetSitTarget(part, part.SitTargetActive, part.SitTargetPosition, part.SitTargetOrientation, false);
 
             //Rebuild the bounding box
             ClearBoundingBoxCache();
@@ -1606,7 +1606,7 @@ namespace OpenSim.Region.Framework.Scenes
             //Rebuild the bounding box
             ClearBoundingBoxCache();
 
-            SetSitTarget(part, part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
+            SetSitTarget(part, part.SitTargetActive, part.SitTargetPosition, part.SitTargetOrientation, false);
 
             // Update the ServerWeight/LandImpact
             RecalcPrimWeights();
@@ -2575,7 +2575,7 @@ namespace OpenSim.Region.Framework.Scenes
                 m_childParts.RemovePart(part); // the old IDs are changing
                 part.ResetIDs(part.LinkNum); // Don't change link nums
                 m_childParts.AddPart(part); // update the part lists with new IDs
-                SetSitTarget(part, part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
+                SetSitTarget(part, part.SitTargetActive, part.SitTargetPosition, part.SitTargetOrientation, false);
             }
         }
 
@@ -2824,7 +2824,7 @@ namespace OpenSim.Region.Framework.Scenes
             otherGroupRoot.ClearUndoState();
             otherGroupRoot.AddFlag(PrimFlags.CreateSelected);
 
-            SetSitTarget(otherGroupRoot, otherGroupRoot.SitTargetEnabled, otherGroupRoot.SitTargetPosition, otherGroupRoot.SitTargetOrientation, false);
+            SetSitTarget(otherGroupRoot, otherGroupRoot.SitTargetActive, otherGroupRoot.SitTargetPosition, otherGroupRoot.SitTargetOrientation, false);
 
             // rest of parts
             int linkNum = 3;
@@ -2845,7 +2845,7 @@ namespace OpenSim.Region.Framework.Scenes
 
                 part.ClearUndoState();
 
-                SetSitTarget(part, part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
+                SetSitTarget(part, part.SitTargetActive, part.SitTargetPosition, part.SitTargetOrientation, false);
             });            
 
             otherGroup.m_childParts.Clear();
@@ -3027,7 +3027,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             part.ParentID = m_rootPart.LocalId;
             part.SetParentAndUpdatePhysics(this);
-            SetSitTarget(part, part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
+            SetSitTarget(part, part.SitTargetActive, part.SitTargetPosition, part.SitTargetOrientation, false);
         }
 
         public bool GetBlockGrab()

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -1033,7 +1033,7 @@ namespace OpenSim.Region.Framework.Scenes
             m_sitTargets.Clear();   // new UUIDs have been assigned, need to refresh
             m_childParts.ForEachPart((SceneObjectPart part) => {
                 part.ResetInstance(isNewInstance, isScriptReset, itemId);
-                this.SetSitTarget(part, part.SitTargetPosition, part.SitTargetOrientation, false);
+                this.SetSitTarget(part, part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
             });
         }
 
@@ -1346,9 +1346,9 @@ namespace OpenSim.Region.Framework.Scenes
             });
         }
 
-        public void SetSitTarget(SceneObjectPart part, Vector3 pos, Quaternion rot, bool preserveSitter)
+        public void SetSitTarget(SceneObjectPart part, bool isEnabled, Vector3 pos, Quaternion rot, bool preserveSitter)
         {
-            SitTargetInfo sitInfo = new SitTargetInfo(part, pos, rot);
+            SitTargetInfo sitInfo = new SitTargetInfo(part, isEnabled, pos, rot);
             if (preserveSitter)
             {
                 SitTargetInfo oldInfo;
@@ -1356,15 +1356,7 @@ namespace OpenSim.Region.Framework.Scenes
                     sitInfo.Sitter = oldInfo.Sitter;
             }
 
-            if (sitInfo.IsSet)
-            {
-                m_sitTargets[part.UUID] = sitInfo;
-            }
-            else
-            {
-                if (m_sitTargets.ContainsKey(part.UUID))
-                    m_sitTargets.Remove(part.UUID);
-            }
+            m_sitTargets[part.UUID] = sitInfo;
         }
 
         public void RemoveSitTarget(UUID partID)
@@ -1580,7 +1572,7 @@ namespace OpenSim.Region.Framework.Scenes
             // then be aware it is a duplicate copy of the SOP/SOG that has UUID/LocalID
             // that matches the in-world copy. But also has its own sit target dictionary,
             // so even if the IDs match, the SOP references are different.
-            SetSitTarget(part, part.SitTargetPosition, part.SitTargetOrientation, false);
+            SetSitTarget(part, part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
 
             //Rebuild the bounding box
             ClearBoundingBoxCache();
@@ -1614,7 +1606,7 @@ namespace OpenSim.Region.Framework.Scenes
             //Rebuild the bounding box
             ClearBoundingBoxCache();
 
-            SetSitTarget(part, part.SitTargetPosition, part.SitTargetOrientation, false);
+            SetSitTarget(part, part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
 
             // Update the ServerWeight/LandImpact
             RecalcPrimWeights();
@@ -2583,7 +2575,7 @@ namespace OpenSim.Region.Framework.Scenes
                 m_childParts.RemovePart(part); // the old IDs are changing
                 part.ResetIDs(part.LinkNum); // Don't change link nums
                 m_childParts.AddPart(part); // update the part lists with new IDs
-                SetSitTarget(part, part.SitTargetPosition, part.SitTargetOrientation, false);
+                SetSitTarget(part, part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
             }
         }
 
@@ -2832,7 +2824,7 @@ namespace OpenSim.Region.Framework.Scenes
             otherGroupRoot.ClearUndoState();
             otherGroupRoot.AddFlag(PrimFlags.CreateSelected);
 
-            SetSitTarget(otherGroupRoot, otherGroupRoot.SitTargetPosition, otherGroupRoot.SitTargetOrientation, false);
+            SetSitTarget(otherGroupRoot, otherGroupRoot.SitTargetEnabled, otherGroupRoot.SitTargetPosition, otherGroupRoot.SitTargetOrientation, false);
 
             // rest of parts
             int linkNum = 3;
@@ -2853,7 +2845,7 @@ namespace OpenSim.Region.Framework.Scenes
 
                 part.ClearUndoState();
 
-                SetSitTarget(part, part.SitTargetPosition, part.SitTargetOrientation, false);
+                SetSitTarget(part, part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
             });            
 
             otherGroup.m_childParts.Clear();
@@ -3035,7 +3027,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             part.ParentID = m_rootPart.LocalId;
             part.SetParentAndUpdatePhysics(this);
-            SetSitTarget(part, part.SitTargetPosition, part.SitTargetOrientation, false);
+            SetSitTarget(part, part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
         }
 
         public bool GetBlockGrab()

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -1754,12 +1754,21 @@ namespace OpenSim.Region.Framework.Scenes
             return (m_parentGroup.RootPart == this);    // matches?
         }
 
-        public void SetSitTarget(Vector3 pos, Quaternion rot, bool preserveSitter)
+        // Note that enabled=false is not the same as removing a sit target.
+        public void SetSitTarget(Vector3 pos, Quaternion rot, bool enabled, bool preserveSitter)
         {
             SitTargetPosition = pos;
             SitTargetOrientation = rot;
             if (ParentGroup != null)
                 ParentGroup.SetSitTarget(this, pos, rot, preserveSitter);
+        }
+        public void RemoveSitTarget()
+        {
+            SitTargetPosition = Vector3.Zero;
+            SitTargetOrientation = Quaternion.Identity;
+            ServerFlags &= ~(uint)ServerPrimFlags.SitTargetEnabled;
+            if (ParentGroup != null)
+                ParentGroup.RemoveSitTarget(this.UUID);
         }
 
         public static readonly uint LEGACY_BASEMASK = 0x7FFFFFF0;
@@ -2067,7 +2076,8 @@ namespace OpenSim.Region.Framework.Scenes
         // part.ParentGroup must be initialized for this.
         public void CopySitTarget(SceneObjectPart part)
         {
-            this.SetSitTarget(part.SitTargetPosition, part.SitTargetOrientation, false);
+            bool sitTargetEnabled = (part.ServerFlags & (uint) ServerPrimFlags.SitTargetEnabled) != 0;
+            this.SetSitTarget(part.SitTargetPosition, part.SitTargetOrientation, sitTargetEnabled, false);
         }
 
         /// <summary>

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -1797,6 +1797,29 @@ namespace OpenSim.Region.Framework.Scenes
                 ParentGroup.RemoveSitTarget(this.UUID);
         }
 
+        // This function must be called on asset load (inventory rez) or database load (rezzed)
+        // with SOP.ServerFlags initialized, which may be updated before return.
+        // Returns true if there is an active sit target after calculation.
+        public bool PrepSitTargetFromStorage(Vector3 sitTargetPos, Quaternion sitTargetRot)
+        {
+            // Now the sit target info itself.
+            bool sitTargetEnabled = ((this.ServerFlags & (uint) ServerPrimFlags.SitTargetEnabled) != 0);
+            if (!sitTargetEnabled) // check if legacy data
+            {
+                if ((this.ServerFlags & (uint) ServerPrimFlags.SitTargetStateSaved) == 0) // not set
+                {   // check if non-zero sit target in pos/rot
+                    if ((sitTargetPos != Vector3.Zero) || (sitTargetRot != Quaternion.Identity))
+                    {
+                        sitTargetEnabled = true;
+                        this.ServerFlags |= (uint)ServerPrimFlags.SitTargetEnabled;
+                    }
+                }
+            }
+            // Mark this one as updated to using this ServerFlags.
+            this.ServerFlags |= (uint)ServerPrimFlags.SitTargetStateSaved;
+            return sitTargetEnabled;
+        }
+
         public static readonly uint LEGACY_BASEMASK = 0x7FFFFFF0;
         public static bool IsLegacyBasemask(uint basemask)
         {

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -145,7 +145,12 @@ namespace OpenSim.Region.Framework.Scenes
         // PRIM_SIT_TARGET supports TRUE/FALSE,pos,rot 
         // even for ZERO_VECTOR,ZERO_ROTATION
         // so we need to store this too.
-        SitTargetEnabled = 1
+        SitTargetEnabled = 1,
+
+        // We need to know whether to use the legacy sit target persistence 
+        // or the one above, or existing content will break.
+        // If this bit is NOT set, ignore SitTargetEnabled 
+        // and use the legacy pos/rot != zero test.
     }
     #endregion Enumerations
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -151,6 +151,7 @@ namespace OpenSim.Region.Framework.Scenes
         // or the one above, or existing content will break.
         // If this bit is NOT set, ignore SitTargetEnabled 
         // and use the legacy pos/rot != zero test.
+        SitTargetStateSaved = 2
     }
     #endregion Enumerations
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -145,11 +145,11 @@ namespace OpenSim.Region.Framework.Scenes
         // PRIM_SIT_TARGET supports TRUE/FALSE,pos,rot 
         // even for ZERO_VECTOR,ZERO_ROTATION
         // so we need to store this too.
-        SitTargetEnabled = 1,
+        SitTargetActive = 1,
 
         // We need to know whether to use the legacy sit target persistence 
         // or the one above, or existing content will break.
-        // If this bit is NOT set, ignore SitTargetEnabled 
+        // If this bit is NOT set, ignore SitTargetActive
         // and use the legacy pos/rot != zero test.
         SitTargetStateSaved = 2
     }
@@ -1420,15 +1420,15 @@ namespace OpenSim.Region.Framework.Scenes
             set { _serverFlags = (ServerPrimFlags)value; }
         }
 
-        public bool SitTargetEnabled
+        public bool SitTargetActive
         {
-            get { return (_serverFlags & ServerPrimFlags.SitTargetEnabled) != 0; }
+            get { return (_serverFlags & ServerPrimFlags.SitTargetActive) != 0; }
             set
             {
                 if (value)  // enable or disable SitTargetEnabled flag
-                    _serverFlags |= ServerPrimFlags.SitTargetEnabled;
+                    _serverFlags |= ServerPrimFlags.SitTargetActive;
                 else
-                    _serverFlags &= ~ServerPrimFlags.SitTargetEnabled;
+                    _serverFlags &= ~ServerPrimFlags.SitTargetActive;
             }
         }
 
@@ -1773,16 +1773,16 @@ namespace OpenSim.Region.Framework.Scenes
         }
 
         // Note that enabled=false is not the same as removing a sit target.
-        public void SetSitTarget(bool isEnabled, Vector3 pos, Quaternion rot, bool preserveSitter)
+        public void SetSitTarget(bool isActive, Vector3 pos, Quaternion rot, bool preserveSitter)
         {
             // Take care of this prim.
             SitTargetPosition = pos;
             SitTargetOrientation = rot;
-            SitTargetEnabled = isEnabled;
+            SitTargetActive = isActive;
 
             // Now update the parent group.
             if (ParentGroup != null)
-                ParentGroup.SetSitTarget(this, isEnabled, pos, rot, preserveSitter);
+                ParentGroup.SetSitTarget(this, isActive, pos, rot, preserveSitter);
         }
 
         public void RemoveSitTarget()
@@ -1790,7 +1790,7 @@ namespace OpenSim.Region.Framework.Scenes
             // Take care of this prim.
             SitTargetPosition = Vector3.Zero;
             SitTargetOrientation = Quaternion.Identity;
-            SitTargetEnabled = false;
+            SitTargetActive = false;
 
             // Now update the parent group.
             if (ParentGroup != null)
@@ -1803,7 +1803,7 @@ namespace OpenSim.Region.Framework.Scenes
         public bool PrepSitTargetFromStorage(Vector3 sitTargetPos, Quaternion sitTargetRot)
         {
             // Now the sit target info itself.
-            bool sitTargetEnabled = ((this.ServerFlags & (uint) ServerPrimFlags.SitTargetEnabled) != 0);
+            bool sitTargetEnabled = ((this.ServerFlags & (uint) ServerPrimFlags.SitTargetActive) != 0);
             if (!sitTargetEnabled) // check if legacy data
             {
                 if ((this.ServerFlags & (uint) ServerPrimFlags.SitTargetStateSaved) == 0) // not set
@@ -1811,7 +1811,7 @@ namespace OpenSim.Region.Framework.Scenes
                     if ((sitTargetPos != Vector3.Zero) || (sitTargetRot != Quaternion.Identity))
                     {
                         sitTargetEnabled = true;
-                        this.ServerFlags |= (uint)ServerPrimFlags.SitTargetEnabled;
+                        this.ServerFlags |= (uint)ServerPrimFlags.SitTargetActive;
                     }
                 }
             }
@@ -2125,7 +2125,7 @@ namespace OpenSim.Region.Framework.Scenes
         // part.ParentGroup must be initialized for this.
         public void CopySitTarget(SceneObjectPart part)
         {
-            this.SetSitTarget(part.SitTargetEnabled, part.SitTargetPosition, part.SitTargetOrientation, false);
+            this.SetSitTarget(part.SitTargetActive, part.SitTargetPosition, part.SitTargetOrientation, false);
         }
 
         /// <summary>

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -137,6 +137,16 @@ namespace OpenSim.Region.Framework.Scenes
         SCULPT = 7
     }
 
+    [Flags]
+    public enum ServerPrimFlags : uint
+    {
+        None = 0,
+
+        // PRIM_SIT_TARGET supports TRUE/FALSE,pos,rot 
+        // even for ZERO_VECTOR,ZERO_ROTATION
+        // so we need to store this too.
+        SitTargetEnabled = 1
+    }
     #endregion Enumerations
 
     public class SceneObjectPart : IScriptHost, ISceneEntity
@@ -713,6 +723,7 @@ namespace OpenSim.Region.Framework.Scenes
         private Quaternion _prevAttRot = Quaternion.Identity;
         private Vector3 _standTargetPos = Vector3.Zero;
         private Quaternion _standTargetRot = Quaternion.Identity;
+        private ServerPrimFlags _serverFlags = 0;
 
         [XmlIgnore]
         public bool IsInTransaction
@@ -1396,6 +1407,12 @@ namespace OpenSim.Region.Framework.Scenes
         }
 
         public KeyframeAnimation KeyframeAnimation { get; set; }
+
+        public uint ServerFlags
+        {
+            get { return (uint)_serverFlags; }
+            set { _serverFlags = (ServerPrimFlags)value; }
+        }
 
         #endregion
 
@@ -2096,6 +2113,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             dupe.m_particleSystem = m_particleSystem;
             dupe.ObjectFlags = ObjectFlags;
+            dupe.ServerFlags = ServerFlags;
 
             dupe._ownershipCost = _ownershipCost;
             dupe._objectSaleType = _objectSaleType;

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -2390,7 +2390,7 @@ namespace OpenSim.Region.Framework.Scenes
                                 // Otherwise, we have a lot to do, it's a real stand up operation.
                                 // if there is a part with a sit target
 
-                                if (sitInfo.IsSet)
+                                if (sitInfo.IsEnabled)
                                 {   // prim not found, or has a sit target (just use that offset)
                                     info.Position = AbsolutePosition;   // don't change it from where we are now, but update with the current absolute position
                                 }
@@ -2478,7 +2478,7 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 // Is a sit target available?
                 SitTargetInfo sitInfo = part.ParentGroup.SitTargetForPart(part.UUID);
-                if (sitInfo.IsSet && !sitInfo.HasSitter)
+                if (sitInfo.IsEnabled && !sitInfo.HasSitter)
                 {
                     //switch the target to this prim
                     return part;
@@ -2553,7 +2553,7 @@ namespace OpenSim.Region.Framework.Scenes
                 // This adjustment gives the viewer the position it expects.
                 vPos.Z -= m_appearance.HipOffset;
 
-                if (sitInfo.IsSet)
+                if (sitInfo.IsEnabled)
                 {
                     avSitPos += sitInfo.Offset;
                     if (ADJUST_SIT_TARGET)

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -2390,7 +2390,7 @@ namespace OpenSim.Region.Framework.Scenes
                                 // Otherwise, we have a lot to do, it's a real stand up operation.
                                 // if there is a part with a sit target
 
-                                if (sitInfo.IsEnabled)
+                                if (sitInfo.IsActive)
                                 {   // prim not found, or has a sit target (just use that offset)
                                     info.Position = AbsolutePosition;   // don't change it from where we are now, but update with the current absolute position
                                 }
@@ -2478,7 +2478,7 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 // Is a sit target available?
                 SitTargetInfo sitInfo = part.ParentGroup.SitTargetForPart(part.UUID);
-                if (sitInfo.IsEnabled && !sitInfo.HasSitter)
+                if (sitInfo.IsActive && !sitInfo.HasSitter)
                 {
                     //switch the target to this prim
                     return part;
@@ -2553,7 +2553,7 @@ namespace OpenSim.Region.Framework.Scenes
                 // This adjustment gives the viewer the position it expects.
                 vPos.Z -= m_appearance.HipOffset;
 
-                if (sitInfo.IsEnabled)
+                if (sitInfo.IsActive)
                 {
                     avSitPos += sitInfo.Offset;
                     if (ADJUST_SIT_TARGET)

--- a/OpenSim/Region/Framework/Scenes/SitTargetInfo.cs
+++ b/OpenSim/Region/Framework/Scenes/SitTargetInfo.cs
@@ -46,7 +46,7 @@ namespace OpenSim.Region.Framework.Scenes
 {
     public class SitTargetInfo
     {
-        private bool m_isEnabled = false;
+        private bool m_isActive = false;
         private Vector3 m_offset = Vector3.Zero;
         private Quaternion m_rotation = Quaternion.Identity;
         private SceneObjectPart m_part = null;
@@ -66,9 +66,9 @@ namespace OpenSim.Region.Framework.Scenes
             get { return m_rotation; }
         }
 
-        public bool IsEnabled
+        public bool IsActive
         {
-            get { return m_isEnabled; }
+            get { return m_isActive; }
         }
 
         public ScenePresence Sitter
@@ -99,14 +99,14 @@ namespace OpenSim.Region.Framework.Scenes
         {
             m_offset = Vector3.Zero;
             m_rotation = Quaternion.Identity;
-            m_isEnabled = false;
+            m_isActive = false;
             m_part = null;
             m_sitter = null;
         }
 
         public SitTargetInfo(SceneObjectPart part, bool isEnabled, Vector3 pos, Quaternion rot)
         {
-            m_isEnabled = isEnabled;
+            m_isActive = isEnabled;
             m_offset = pos;
             m_rotation = rot;
             m_part = part;
@@ -121,7 +121,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         public void CopyTo(SitTargetInfo sitInfo)
         {
-            sitInfo.m_isEnabled = this.m_isEnabled;
+            sitInfo.m_isActive = this.m_isActive;
             sitInfo.m_offset = this.m_offset;
             sitInfo.m_rotation = this.m_rotation;
             sitInfo.m_part = this.m_part;

--- a/OpenSim/Region/Framework/Scenes/SitTargetInfo.cs
+++ b/OpenSim/Region/Framework/Scenes/SitTargetInfo.cs
@@ -46,6 +46,7 @@ namespace OpenSim.Region.Framework.Scenes
 {
     public class SitTargetInfo
     {
+        private bool m_isEnabled = false;
         private Vector3 m_offset = Vector3.Zero;
         private Quaternion m_rotation = Quaternion.Identity;
         private SceneObjectPart m_part = null;
@@ -65,6 +66,11 @@ namespace OpenSim.Region.Framework.Scenes
             get { return m_rotation; }
         }
 
+        public bool IsEnabled
+        {
+            get { return m_isEnabled; }
+        }
+
         public ScenePresence Sitter
         {
             get { return m_sitter; }
@@ -77,9 +83,9 @@ namespace OpenSim.Region.Framework.Scenes
             set { m_part = value; }
         }
 
-        public bool IsSet
+        public bool IsZero
         {
-            get { return (m_part != null) && (m_offset != Vector3.Zero) || (m_rotation != Quaternion.Identity);  }
+            get { return (m_part == null) || (m_offset == Vector3.Zero) || (m_rotation == Quaternion.Identity);  }
         }
 
         public bool HasSitter
@@ -93,12 +99,14 @@ namespace OpenSim.Region.Framework.Scenes
         {
             m_offset = Vector3.Zero;
             m_rotation = Quaternion.Identity;
+            m_isEnabled = false;
             m_part = null;
             m_sitter = null;
         }
 
-        public SitTargetInfo(SceneObjectPart part, Vector3 pos, Quaternion rot)
+        public SitTargetInfo(SceneObjectPart part, bool isEnabled, Vector3 pos, Quaternion rot)
         {
+            m_isEnabled = isEnabled;
             m_offset = pos;
             m_rotation = rot;
             m_part = part;
@@ -113,6 +121,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         public void CopyTo(SitTargetInfo sitInfo)
         {
+            sitInfo.m_isEnabled = this.m_isEnabled;
             sitInfo.m_offset = this.m_offset;
             sitInfo.m_rotation = this.m_rotation;
             sitInfo.m_part = this.m_part;

--- a/OpenSim/Region/Framework/Scenes/SitTargetInfo.cs
+++ b/OpenSim/Region/Framework/Scenes/SitTargetInfo.cs
@@ -85,7 +85,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         public bool IsZero
         {
-            get { return (m_part == null) || (m_offset == Vector3.Zero) || (m_rotation == Quaternion.Identity);  }
+            get { return (m_offset == Vector3.Zero) && (m_rotation == Quaternion.Identity);  }
         }
 
         public bool HasSitter

--- a/OpenSim/Region/FrameworkTests/SceneUtil.cs
+++ b/OpenSim/Region/FrameworkTests/SceneUtil.cs
@@ -99,6 +99,7 @@ namespace OpenSim.Region.FrameworkTests
             part.SavedAttachmentRot = SceneUtil.RandomQuat();
             part.ScriptAccessPin = 87654;
             part.SerializedPhysicsData = new byte[] { 0xA, 0xB, 0xC, 0xD, 0xE, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, };
+            part.ServerFlags = (int)ServerPrimFlags.SitTargetEnabled;    // see SetSitTarget below
             part.ServerWeight = 3.0f;
             part.StreamingCost = 2.0f;
             part.SitName = "Sitting";

--- a/OpenSim/Region/FrameworkTests/SceneUtil.cs
+++ b/OpenSim/Region/FrameworkTests/SceneUtil.cs
@@ -99,7 +99,7 @@ namespace OpenSim.Region.FrameworkTests
             part.SavedAttachmentRot = SceneUtil.RandomQuat();
             part.ScriptAccessPin = 87654;
             part.SerializedPhysicsData = new byte[] { 0xA, 0xB, 0xC, 0xD, 0xE, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, };
-            part.ServerFlags = (int)ServerPrimFlags.SitTargetEnabled;    // see SetSitTarget below
+            part.ServerFlags = 0;
             part.ServerWeight = 3.0f;
             part.StreamingCost = 2.0f;
             part.SitName = "Sitting";
@@ -115,7 +115,7 @@ namespace OpenSim.Region.FrameworkTests
             part.Velocity = SceneUtil.RandomVector();
             part.FromItemID = UUID.Random();
 
-            part.SetSitTarget(SceneUtil.RandomVector(), SceneUtil.RandomQuat(), true, false);
+            part.SetSitTarget(true, SceneUtil.RandomVector(), SceneUtil.RandomQuat(), false);
 
             return part;
         }

--- a/OpenSim/Region/FrameworkTests/SceneUtil.cs
+++ b/OpenSim/Region/FrameworkTests/SceneUtil.cs
@@ -115,7 +115,7 @@ namespace OpenSim.Region.FrameworkTests
             part.Velocity = SceneUtil.RandomVector();
             part.FromItemID = UUID.Random();
 
-            part.SetSitTarget(SceneUtil.RandomVector(), SceneUtil.RandomQuat(), false);
+            part.SetSitTarget(SceneUtil.RandomVector(), SceneUtil.RandomQuat(), true, false);
 
             return part;
         }


### PR DESCRIPTION
also implemented a _setter_ for `PRIM_SIT_TARGET` (now supports `llSetPrimitiveParams` family of functions).  Previously on the _getter_ was supported.

Background: `PRIM_SIT_TARGET` supports `TRUE/FALSE,pos,rot` even for `ZERO_VECTOR,ZERO_ROTATION` so we need to persist this boolean state data too.  This is done with an update to the `prims` table in the region database:
```
ALTER TABLE `inworldz_rdb`.`prims` 
ADD COLUMN `ServerFlags` INT(11) NOT NULL DEFAULT '0' AFTER `KeyframeAnimation`;
```