### PR TITLE
Fixed a typo that prevented group membership cache from being used

### DIFF
--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
@@ -846,7 +846,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
         {
             // Use the known in-memory group membership data if available before going to db.
             if (remoteClient != null)
-                remoteClient.IsGroupMember(groupID);
+                return remoteClient.IsGroupMember(groupID);
 
             return m_groupData.IsAgentInGroup(groupID, remoteClient.AgentId);
         }


### PR DESCRIPTION
omg what the heck. Missing return to actually hand back the cached value rather than falling through to the db query.

(!!!)