### PR TITLE
Fixed llReturnObject functions to match the complex semantics documented by LL

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -4605,36 +4605,6 @@ namespace InWorldz.Phlox.Engine
             ClearWaitingForScriptAnswer(client);
         }
 
-        /**************************
-        // Coded before I realized it was not actually needed.
-        public bool IsAgentGroupOwner(UUID agentID, UUID groupID)
-        {
-            if (groupID == UUID.Zero)
-                return false;
-
-            ScenePresence sp = World.GetScenePresence(agentID);
-            if (sp != null) {
-                IClientAPI remoteClient = sp.ControllingClient;
-                if (remoteClient != null)
-                    return IsAgentGroupOwner(remoteClient, groupID);
-            }
-
-            // Otherwise, do it the hard way.
-            IGroupsModule groupsModule = m_ScriptEngine.World.RequestModuleInterface<IGroupsModule>();
-
-            GroupRecord groupRec = groupsModule.GetGroupRecord(groupID);
-            if (groupRec == null) return false;
-
-            List<GroupRolesData> agentRoles = groupsModule.GroupRoleDataRequest(null, groupID);
-            foreach (GroupRolesData role in agentRoles)
-            {
-                if (role.RoleID == groupRec.OwnerRoleID)
-                    return true;
-            }
-            return false;
-        }
-        **************************/
-
         public bool IsAgentGroupOwner(IClientAPI remoteClient, UUID groupID)
         {
             if (groupID == UUID.Zero)

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -18444,7 +18444,7 @@ namespace InWorldz.Phlox.Engine
                     default:
                         return ScriptBaseClass.ERR_MALFORMED_PARAMS;
                 }
-                return World.LandChannel.ScriptedReturnObjectsInParcel(item.OwnerID, targetAgentID, patternParcel, sameOwner);
+                return World.LandChannel.ScriptedReturnObjectsInParcelByOwner(item.OwnerID, targetAgentID, patternParcel, sameOwner);
             }
             catch (Exception e)
             {

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -18317,118 +18317,50 @@ namespace InWorldz.Phlox.Engine
             return ret;
         }
 
-        // This is a fast check for the case where there's an agent present and we've loaded group info.
-        public bool IsAgentGroupOwner(IClientAPI remoteClient, UUID groupID)
-        {
-            if (groupID == UUID.Zero)
-                return false;
-
-            // Use the known in-memory group membership data if available before going to db.
-            if (remoteClient == null)
-                return false; // we don't know who to check
-
-            // This isn't quite the same as being in the Owners role, but close enough in 
-            // order to avoid multiple complex queries in order to check Role membership.
-            return remoteClient.GetGroupPowers(groupID) == (ulong)Constants.OWNER_GROUP_POWERS;
-        }
-
-        public bool IsAgentGroupOwner(UUID agentID, UUID groupID)
-        {
-            if (groupID == UUID.Zero)
-                return false;
-
-            ScenePresence sp = World.GetScenePresence(agentID);
-            if (sp != null) {
-                IClientAPI remoteClient = sp.ControllingClient;
-                if (remoteClient != null)
-                    return IsAgentGroupOwner(remoteClient, groupID);
-            }
-
-            // Otherwise, do it the hard way.
-            IGroupsModule groupsModule = m_ScriptEngine.World.RequestModuleInterface<IGroupsModule>();
-
-            GroupRecord groupRec = groupsModule.GetGroupRecord(groupID);
-            if (groupRec == null) return false;
-
-            List<GroupRolesData> agentRoles = groupsModule.GroupRoleDataRequest(null, groupID);
-            foreach (GroupRolesData role in agentRoles)
-            {
-                if (role.RoleID == groupRec.OwnerRoleID)
-                    return true;
-            }
-            return false;
-        }
-
-        // Anyone can grant PERMISSION_RETURN_OBJECTS but it can be only used under strict rules.
-        // Returns 0 on success, or LSL error code on error.
-        int canUseReturnPermission(ILandObject parcel, TaskInventoryItem item)
-        {
-            if (item.PermsGranter == UUID.Zero)
-                return ScriptBaseClass.ERR_RUNTIME_PERMISSIONS;
-
-            // If the script is owned by an agent, PERMISSION_RETURN_OBJECTS may be granted by the owner of the script.
-            if (m_host.ParentGroup.OwnerID == item.PermsGranter)
-                return 0;
-            // not the owner of the script, see if it's group owned and group Owner
-
-            // If the script is owned by a group, this permission may be granted by an agent belonging to the group's "Owners" role.
-            if ((m_host.ParentGroup.GroupID == UUID.Zero) || (m_host.ParentGroup.GroupID != m_host.ParentGroup.OwnerID))
-                return ScriptBaseClass.ERR_PARCEL_PERMISSIONS; // not land owner owned, not group-owned
-
-            // group-owned, check if an owner (PermsGranter == script owner)
-            return IsAgentGroupOwner(item.PermsGranter, m_host.ParentGroup.GroupID) ? 0 : ScriptBaseClass.ERR_PARCEL_PERMISSIONS;
-        }
-
         public int llReturnObjectsByOwner(string owner, int scope)
         {
-            try
+            UUID targetAgentID;
+            if (!UUID.TryParse(owner, out targetAgentID))
+                return ScriptBaseClass.ERR_MALFORMED_PARAMS;
+
+            if (targetAgentID == UUID.Zero)
+                return 0;
+
+            UUID invItemID = InventorySelf();
+            if (invItemID == UUID.Zero)
             {
-                UUID targetAgentID;
-                if (!UUID.TryParse(owner, out targetAgentID))
-                    return ScriptBaseClass.ERR_MALFORMED_PARAMS;
+                LSLError("No item found from which to run script");
+                return ScriptBaseClass.ERR_GENERIC;
+            }
 
-                if (targetAgentID == UUID.Zero)
-                    return 0;
+            // After this, set rc for error code.
+            int rc = 0;
 
-                UUID invItemID = InventorySelf();
-                if (invItemID == UUID.Zero)
-                {
-                    LSLError("No item found from which to run script");
-                    return ScriptBaseClass.ERR_GENERIC;
-                }
+            try {
 
                 TaskInventoryItem item;
-                lock (m_host.TaskInventory)
-                {
+                lock (m_host.TaskInventory) {
                     item = m_host.TaskInventory[invItemID];
                 }
 
                 // First, just check if anyone has ERR_RUNTIME_PERMISSIONS ...
-                if (!CheckRuntimePerms(item, item.PermsGranter, ScriptBaseClass.PERMISSION_RETURN_OBJECTS))
-                {
-                    LSLError("No permissions to return objects");
-                    return ScriptBaseClass.ERR_RUNTIME_PERMISSIONS;
+                if (!CheckRuntimePerms(item, item.PermsGranter, ScriptBaseClass.PERMISSION_RETURN_OBJECTS)) {
+                    rc = ScriptBaseClass.ERR_RUNTIME_PERMISSIONS;
+                    return rc;
                 }
 
                 // We need the land parcel for everything after this.
                 Vector3 currentPos = m_host.ParentGroup.AbsolutePosition;
                 ILandObject currentParcel = World.LandChannel.GetLandObject(currentPos.X, currentPos.Y);
                 if ((currentParcel == null) && (scope == ScriptBaseClass.OBJECT_RETURN_REGION))
-                    return ScriptBaseClass.ERR_GENERIC;
-
-                // The more complex checks only need the parcel, item owner, perms granter, etc (all in item).
-                int rc = canUseReturnPermission(currentParcel, item);
-                if (rc != 0)
                 {
-                    // ScriptBaseClass.ERR_PARCEL_PERMISSIONS
-                    LSLError("No parcel/region permission to return objects");
+                    rc = ScriptBaseClass.ERR_GENERIC;
                     return rc;
                 }
 
                 LandData patternParcel = null;
                 bool sameOwner;
-                switch (scope)
-                {
+                switch (scope) {
                     case ScriptBaseClass.OBJECT_RETURN_PARCEL:
                         patternParcel = currentParcel.landData;
                         sameOwner = false;
@@ -18438,18 +18370,38 @@ namespace InWorldz.Phlox.Engine
                         sameOwner = true;
                         break;
                     case ScriptBaseClass.OBJECT_RETURN_REGION:
-                        patternParcel = null;  // wildcard for all parcels
+                        patternParcel = null; // wildcard for all parcels
                         sameOwner = false;
                         break;
                     default:
                         return ScriptBaseClass.ERR_MALFORMED_PARAMS;
                 }
-                return World.LandChannel.ScriptedReturnObjectsInParcelByOwner(item.OwnerID, targetAgentID, patternParcel, sameOwner);
+                rc = World.LandChannel.ScriptedReturnObjectsInParcelByOwner(item, targetAgentID, patternParcel, sameOwner);
             }
-            catch (Exception e)
-            {
+            catch (Exception e) {
                 return ScriptBaseClass.ERR_GENERIC;
             }
+            finally
+            {
+                switch (rc) {
+                    case ScriptBaseClass.ERR_GENERIC:
+                        LSLError("No parcel found for permissions to return objects");
+                        break;
+                    case ScriptBaseClass.ERR_PARCEL_PERMISSIONS:
+                        LSLError("No parcel/region permission to return objects");
+                        break;
+                    case ScriptBaseClass.ERR_RUNTIME_PERMISSIONS:
+                        LSLError("No permissions to return objects");
+                        break;
+                    case ScriptBaseClass.ERR_MALFORMED_PARAMS:
+                        LSLError("Bad parameters on scripted call to return objects");
+                        break;
+                    default:
+                        // do nothing for other 0, other errors, or >0 counts
+                        break;
+                }
+            }
+            return rc;
         }
 
         public int llReturnObjectsByID(LSL_List objects)
@@ -18508,7 +18460,7 @@ namespace InWorldz.Phlox.Engine
                 int count = 0;
                 foreach (KeyValuePair<int, List<UUID>> bucket in objectsByParcel)
                 {
-                    count += World.LandChannel.ScriptedReturnObjectsInParcelByIDs(m_host, bucket.Value, bucket.Key);
+                    count += World.LandChannel.ScriptedReturnObjectsInParcelByIDs(m_host, item, bucket.Value, bucket.Key);
                     
                 }
                 return count;

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -18376,7 +18376,10 @@ namespace InWorldz.Phlox.Engine
                     default:
                         return ScriptBaseClass.ERR_MALFORMED_PARAMS;
                 }
+
                 rc = World.LandChannel.ScriptedReturnObjectsInParcelByOwner(item, targetAgentID, patternParcel, sameOwner);
+                if (rc > 0)
+                    m_log.InfoFormat("[LAND]: Scripted object return of {0} objects owned by {1} by {2} for {3}", rc, targetAgentID, item.PermsGranter, item.OwnerID);
             }
             catch (Exception e) {
                 return ScriptBaseClass.ERR_GENERIC;
@@ -18461,8 +18464,9 @@ namespace InWorldz.Phlox.Engine
                 foreach (KeyValuePair<int, List<UUID>> bucket in objectsByParcel)
                 {
                     count += World.LandChannel.ScriptedReturnObjectsInParcelByIDs(m_host, item, bucket.Value, bucket.Key);
-                    
                 }
+                if (count > 0)
+                    m_log.InfoFormat("[LAND]: Scripted object list returned {0} objects by {1} for {2}", count, item.PermsGranter, item.OwnerID);
                 return count;
             }
             catch (Exception e)

--- a/OpenSim/Framework/Constants.cs
+++ b/OpenSim/Framework/Constants.cs
@@ -48,6 +48,12 @@ namespace OpenSim.Framework
         public const int LINK_ALL_OTHERS = -2;
         public const int LINK_ALL_CHILDREN = -3;
         public const int LINK_THIS = -4;
+        // Returned by llReturnObjectsByOwner and llReturnObjectsByID
+        public const int ERR_GENERIC = -1;
+        public const int ERR_PARCEL_PERMISSIONS = -2;
+        public const int ERR_MALFORMED_PARAMS = -3;
+        public const int ERR_RUNTIME_PERMISSIONS = -4;
+        public const int ERR_THROTTLED = -5;
 
         public const uint MaxGroups = 100;  // maximum number of groups a user can be a member of
         public const GroupPowers DefaultEveryonePowers = GroupPowers.AllowSetHome | GroupPowers.JoinChat | GroupPowers.AllowVoiceChat | GroupPowers.ReceiveNotices;

--- a/OpenSim/Framework/Constants.cs
+++ b/OpenSim/Framework/Constants.cs
@@ -51,6 +51,7 @@ namespace OpenSim.Framework
 
         public const uint MaxGroups = 100;  // maximum number of groups a user can be a member of
         public const GroupPowers DefaultEveryonePowers = GroupPowers.AllowSetHome | GroupPowers.JoinChat | GroupPowers.AllowVoiceChat | GroupPowers.ReceiveNotices;
+        public const GroupPowers OWNER_GROUP_POWERS = (GroupPowers)ulong.MaxValue;
 
         public const string DefaultTexture = "89556747-24cb-43ed-920b-47caed15465f";
 

--- a/OpenSim/Region/CoreModules/World/Land/LandChannel.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandChannel.cs
@@ -205,21 +205,21 @@ namespace OpenSim.Region.CoreModules.World.Land
             }
         }
 
-        public int ScriptedReturnObjectsInParcelByOwner(UUID actionAgentID, UUID targetAgentID, LandData parcel, bool sameOwner)
+        public int ScriptedReturnObjectsInParcelByOwner(TaskInventoryItem scriptItem, UUID targetAgentID, LandData parcel, bool sameOwner)
         {
             if (m_landManagementModule != null)
             {
-                return m_landManagementModule.ScriptedReturnObjectsInParcelByOwner(actionAgentID, targetAgentID, parcel, sameOwner);
+                return m_landManagementModule.ScriptedReturnObjectsInParcelByOwner(scriptItem, targetAgentID, parcel, sameOwner);
             }
 
             return -1;
         }
 
-        public int ScriptedReturnObjectsInParcelByIDs(SceneObjectPart callingPart, List<UUID> targetIDs, int parcelLocalID)
+        public int ScriptedReturnObjectsInParcelByIDs(SceneObjectPart callingPart, TaskInventoryItem scriptItem, List<UUID> targetIDs, int parcelLocalID)
         {
             if (m_landManagementModule != null)
             {
-                return m_landManagementModule.ScriptedReturnObjectsInParcelByIDs(callingPart, targetIDs, parcelLocalID);
+                return m_landManagementModule.ScriptedReturnObjectsInParcelByIDs(callingPart, scriptItem, targetIDs, parcelLocalID);
             }
 
             return -1;

--- a/OpenSim/Region/CoreModules/World/Land/LandChannel.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandChannel.cs
@@ -205,11 +205,11 @@ namespace OpenSim.Region.CoreModules.World.Land
             }
         }
 
-        public int ScriptedReturnObjectsInParcel(UUID actionAgentID, UUID targetAgentID, LandData parcel, bool sameOwner)
+        public int ScriptedReturnObjectsInParcelByOwner(UUID actionAgentID, UUID targetAgentID, LandData parcel, bool sameOwner)
         {
             if (m_landManagementModule != null)
             {
-                return m_landManagementModule.ScriptedReturnObjectsInParcel(actionAgentID, targetAgentID, parcel, sameOwner);
+                return m_landManagementModule.ScriptedReturnObjectsInParcelByOwner(actionAgentID, targetAgentID, parcel, sameOwner);
             }
 
             return -1;

--- a/OpenSim/Region/CoreModules/World/Land/LandChannel.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandChannel.cs
@@ -215,11 +215,11 @@ namespace OpenSim.Region.CoreModules.World.Land
             return -1;
         }
 
-        public int ScriptedReturnObjectsInParcelByIDs(UUID actionAgentID, List<UUID> targetIDs, int parcelLocalID)
+        public int ScriptedReturnObjectsInParcelByIDs(SceneObjectPart callingPart, List<UUID> targetIDs, int parcelLocalID)
         {
             if (m_landManagementModule != null)
             {
-                return m_landManagementModule.ScriptedReturnObjectsInParcelByIDs(actionAgentID, targetIDs, parcelLocalID);
+                return m_landManagementModule.ScriptedReturnObjectsInParcelByIDs(callingPart, targetIDs, parcelLocalID);
             }
 
             return -1;

--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -1542,7 +1542,7 @@ namespace OpenSim.Region.CoreModules.World.Land
 
         // Pass parcel==null for all parcels in the region, or parcel != null for a specific parcel
         // or all parcels owned by the same owner.
-        public int ScriptedReturnObjectsInParcelByOwner(UUID actionAgentID, UUID targetAgentID, LandData patternParcel, bool sameOwner)
+        public int ScriptedReturnObjectsInParcelByOwner(TaskInventoryItem scriptItem, UUID targetAgentID, LandData patternParcel, bool sameOwner)
         {
             int count = 0;
 
@@ -1561,7 +1561,7 @@ namespace OpenSim.Region.CoreModules.World.Land
 
                 if (includeParcel)
                 {
-                    int rc = landObject.scriptedReturnLandObjectsByOwner(actionAgentID, targetAgentID);
+                    int rc = landObject.scriptedReturnLandObjectsByOwner(scriptItem, targetAgentID);
                     // if we get an error, stop. If we've returned items, return the count, otherwise error code.
                     if (rc < 0) // error
                         return (count > 0) ? count : rc;
@@ -1572,13 +1572,13 @@ namespace OpenSim.Region.CoreModules.World.Land
             return count;
         }
 
-        public int ScriptedReturnObjectsInParcelByIDs(SceneObjectPart callingPart, List<UUID> targetIDs, int parcelLocalID)
+        public int ScriptedReturnObjectsInParcelByIDs(SceneObjectPart callingPart, TaskInventoryItem scriptItem, List<UUID> targetIDs, int parcelLocalID)
         {
             if (!m_landList.ContainsKey(parcelLocalID))
                 return 0;
 
             ILandObject parcel = m_landList[parcelLocalID];
-            return parcel.scriptedReturnLandObjectsByIDs(callingPart, targetIDs);
+            return parcel.scriptedReturnLandObjectsByIDs(callingPart, scriptItem, targetIDs);
         }
 
         public void NoLandDataFromStorage()

--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -1542,7 +1542,7 @@ namespace OpenSim.Region.CoreModules.World.Land
 
         // Pass parcel==null for all parcels in the region, or parcel != null for a specific parcel
         // or all parcels owned by the same owner.
-        public int ScriptedReturnObjectsInParcel(UUID actionAgentID, UUID targetAgentID, LandData patternParcel, bool sameOwner)
+        public int ScriptedReturnObjectsInParcelByOwner(UUID actionAgentID, UUID targetAgentID, LandData patternParcel, bool sameOwner)
         {
             int count = 0;
 

--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -1572,13 +1572,13 @@ namespace OpenSim.Region.CoreModules.World.Land
             return count;
         }
 
-        public int ScriptedReturnObjectsInParcelByIDs(UUID actionAgentID, List<UUID> targetIDs, int parcelLocalID)
+        public int ScriptedReturnObjectsInParcelByIDs(SceneObjectPart callingPart, List<UUID> targetIDs, int parcelLocalID)
         {
             if (!m_landList.ContainsKey(parcelLocalID))
                 return 0;
 
             ILandObject parcel = m_landList[parcelLocalID];
-            return parcel.scriptedReturnLandObjectsByIDs(actionAgentID, targetIDs);
+            return parcel.scriptedReturnLandObjectsByIDs(callingPart, targetIDs);
         }
 
         public void NoLandDataFromStorage()

--- a/OpenSim/Region/CoreModules/World/Land/LandObject.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandObject.cs
@@ -1361,8 +1361,8 @@ namespace OpenSim.Region.CoreModules.World.Land
                         continue;
                     if (m_scene.IsEstateManager(grp.OwnerID))
                         continue;
-                    // Objects owned (deeded), by the group the land is set to, will not be returned.
-                    if (landData.IsGroupOwned && (grp.GroupID == landData.GroupID))
+                    // Objects owned (deeded), to the group that the land is set to, will not be returned (ByOwner only)
+                    if (grp.IsGroupDeeded && (grp.GroupID == landData.GroupID))
                         continue;
 
                     returns.Add(grp);
@@ -1395,7 +1395,7 @@ namespace OpenSim.Region.CoreModules.World.Land
 
                     if ((grp != null) && (primsOverMe.Contains(grp)))
                     {
-                        // The rules inside this IF don't apply if the calling prim specifies itself.
+                        // The rules inside this IF only apply if the calling prim is not specifying itself.
                         if (grp.UUID != callingPart.ParentGroup.UUID)
                         {
                             // EO, EM and parcel owner's objects cannot be returned by this method.
@@ -1403,9 +1403,13 @@ namespace OpenSim.Region.CoreModules.World.Land
                                 continue;
                             if (m_scene.IsEstateManager(grp.OwnerID))
                                 continue;
-                            // Objects owned (deeded), by the group the land is set to, will not be returned.
-                            if ((landData.GroupID != UUID.Zero) && (grp.GroupID == landData.GroupID))
-                                continue;
+                            if (!m_scene.IsEstateManager(scriptItem.OwnerID))
+                            {
+                                // EO and EM can return from any parcel, otherwise allowed only on 
+                                // objects located in any parcel owned by the script owner in the region.
+                                if (landData.OwnerID != scriptItem.OwnerID)
+                                    continue;   // parcel has different owner
+                            }
                         }
 
                         returns.Add(grp);

--- a/OpenSim/Region/Framework/Interfaces/ILandChannel.cs
+++ b/OpenSim/Region/Framework/Interfaces/ILandChannel.cs
@@ -73,7 +73,7 @@ namespace OpenSim.Region.Framework.Interfaces
         void UpdateLandObject(int localID, LandData data);
         void UpdateLandPrimCounts();
         void ReturnObjectsInParcel(int localID, uint returnType, UUID[] agentIDs, UUID[] taskIDs, IClientAPI remoteClient);
-        int ScriptedReturnObjectsInParcel(UUID actionAgentID, UUID targetAgentID, LandData parcel, bool sameOwner);
+        int ScriptedReturnObjectsInParcelByOwner(UUID actionAgentID, UUID targetAgentID, LandData parcel, bool sameOwner);
         int ScriptedReturnObjectsInParcelByIDs(SceneObjectPart callingPart, List<UUID> targetIDs, int parcelLocalID);
         void setParcelObjectMaxOverride(overrideParcelMaxPrimCountDelegate overrideDel);
         void setSimulatorObjectMaxOverride(overrideSimulatorMaxPrimCountDelegate overrideDel);

--- a/OpenSim/Region/Framework/Interfaces/ILandChannel.cs
+++ b/OpenSim/Region/Framework/Interfaces/ILandChannel.cs
@@ -73,8 +73,8 @@ namespace OpenSim.Region.Framework.Interfaces
         void UpdateLandObject(int localID, LandData data);
         void UpdateLandPrimCounts();
         void ReturnObjectsInParcel(int localID, uint returnType, UUID[] agentIDs, UUID[] taskIDs, IClientAPI remoteClient);
-        int ScriptedReturnObjectsInParcelByOwner(UUID actionAgentID, UUID targetAgentID, LandData parcel, bool sameOwner);
-        int ScriptedReturnObjectsInParcelByIDs(SceneObjectPart callingPart, List<UUID> targetIDs, int parcelLocalID);
+        int ScriptedReturnObjectsInParcelByOwner(TaskInventoryItem scriptItem, UUID targetAgentID, LandData parcel, bool sameOwner);
+        int ScriptedReturnObjectsInParcelByIDs(SceneObjectPart callingPart, TaskInventoryItem scriptItem, List<UUID> targetIDs, int parcelLocalID);
         void setParcelObjectMaxOverride(overrideParcelMaxPrimCountDelegate overrideDel);
         void setSimulatorObjectMaxOverride(overrideSimulatorMaxPrimCountDelegate overrideDel);
         void SetParcelOtherCleanTime(IClientAPI remoteClient, int localID, int otherCleanTime);

--- a/OpenSim/Region/Framework/Interfaces/ILandChannel.cs
+++ b/OpenSim/Region/Framework/Interfaces/ILandChannel.cs
@@ -28,6 +28,7 @@
 using System.Collections.Generic;
 using OpenMetaverse;
 using OpenSim.Framework;
+using OpenSim.Region.Framework.Scenes;
 
 namespace OpenSim.Region.Framework.Interfaces
 {
@@ -73,7 +74,7 @@ namespace OpenSim.Region.Framework.Interfaces
         void UpdateLandPrimCounts();
         void ReturnObjectsInParcel(int localID, uint returnType, UUID[] agentIDs, UUID[] taskIDs, IClientAPI remoteClient);
         int ScriptedReturnObjectsInParcel(UUID actionAgentID, UUID targetAgentID, LandData parcel, bool sameOwner);
-        int ScriptedReturnObjectsInParcelByIDs(UUID actionAgentID, List<UUID> targetIDs, int parcelLocalID);
+        int ScriptedReturnObjectsInParcelByIDs(SceneObjectPart callingPart, List<UUID> targetIDs, int parcelLocalID);
         void setParcelObjectMaxOverride(overrideParcelMaxPrimCountDelegate overrideDel);
         void setSimulatorObjectMaxOverride(overrideSimulatorMaxPrimCountDelegate overrideDel);
         void SetParcelOtherCleanTime(IClientAPI remoteClient, int localID, int otherCleanTime);

--- a/OpenSim/Region/Framework/Interfaces/ILandObject.cs
+++ b/OpenSim/Region/Framework/Interfaces/ILandObject.cs
@@ -76,7 +76,7 @@ namespace OpenSim.Region.Framework.Interfaces
         void returnObject(SceneObjectGroup obj);
         void returnLandObjects(uint type, UUID[] owners, UUID[] tasks, IClientAPI remote_client);
         int scriptedReturnLandObjectsByOwner(UUID scriptOwnerID, UUID targetOwnerID);
-        int scriptedReturnLandObjectsByIDs(UUID scriptOwnerID, List<UUID> IDs);
+        int scriptedReturnLandObjectsByIDs(SceneObjectPart callingPart, List<UUID> IDs);
         void InspectParcelForAutoReturn();
         void resetLandPrimCounts();
         void addPrimToCount(SceneObjectGroup obj);

--- a/OpenSim/Region/Framework/Interfaces/ILandObject.cs
+++ b/OpenSim/Region/Framework/Interfaces/ILandObject.cs
@@ -75,8 +75,8 @@ namespace OpenSim.Region.Framework.Interfaces
         void sendLandObjectOwners(IClientAPI remote_client);
         void returnObject(SceneObjectGroup obj);
         void returnLandObjects(uint type, UUID[] owners, UUID[] tasks, IClientAPI remote_client);
-        int scriptedReturnLandObjectsByOwner(UUID scriptOwnerID, UUID targetOwnerID);
-        int scriptedReturnLandObjectsByIDs(SceneObjectPart callingPart, List<UUID> IDs);
+        int scriptedReturnLandObjectsByOwner(TaskInventoryItem scriptItem, UUID targetOwnerID);
+        int scriptedReturnLandObjectsByIDs(SceneObjectPart callingPart, TaskInventoryItem scriptItem, List<UUID> IDs);
         void InspectParcelForAutoReturn();
         void resetLandPrimCounts();
         void addPrimToCount(SceneObjectGroup obj);

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -471,6 +471,11 @@ namespace OpenSim.Region.Framework.Scenes
             set { m_rootPart.GroupID = value; }
         }
 
+        public bool IsGroupDeeded
+        {
+            get { return (GroupID != UUID.Zero) && (OwnerID == GroupID); }
+        }
+
         /// <value>
         /// The root part of this scene object
         /// </value>

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -1618,6 +1618,11 @@ namespace OpenSim.Region.Framework.Scenes
             set { _lastOwnerID = value; }
         }
 
+        public bool IsGroupDeeded
+        {
+            get { return (GroupID != UUID.Zero) && (OwnerID == GroupID); }
+        }
+
         public uint BaseMask
         {
             get { return _baseMask; }

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
@@ -844,11 +844,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
 
         public bool IsAgentInGroup(IClientAPI remoteClient, UUID groupID)
         {
-            // Use the known in-memory group membership data if available before going to db.
-            if (remoteClient != null)
-                return remoteClient.IsGroupMember(groupID);
+            if (remoteClient == null)
+                return false;   // we don't know who to check
 
-            return m_groupData.IsAgentInGroup(groupID, remoteClient.AgentId);
+            // Use the known in-memory group membership data if available before going to db.
+            return remoteClient.IsGroupMember(groupID);
         }
 
         /// <summary>

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/NativeGroupDataProvider.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/NativeGroupDataProvider.cs
@@ -91,8 +91,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                 UUID groupID = UUID.Random();
                 UUID ownerRoleID = UUID.Random();
                 
-                // Would this be cleaner as (GroupPowers)ulong.MaxValue;
-                GroupPowers ownerPowers = (GroupPowers)ulong.MaxValue;
+                GroupPowers ownerPowers = Constants.OWNER_GROUP_POWERS;
 
                 string query
                     =   "INSERT INTO osgroup " +

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/XmlRpcGroupData.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/XmlRpcGroupData.cs
@@ -91,8 +91,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             param["EveryonePowers"] = ((ulong)Constants.DefaultEveryonePowers).ToString();
             param["OwnerRoleID"] = OwnerRoleID.ToString();
 
-            // Would this be cleaner as (GroupPowers)ulong.MaxValue;
-            GroupPowers OwnerPowers = (GroupPowers)ulong.MaxValue;
+            GroupPowers OwnerPowers = Constants.OWNER_GROUP_POWERS;
             param["OwnersPowers"] = ((ulong)OwnerPowers).ToString();
 
 

--- a/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/XmlRpcGroupData.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/XmlRpcGroupData.cs
@@ -94,12 +94,8 @@ namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups
             //param["EveryonePowers"] = ((ulong)m_DefaultEveryonePowers).ToString();
             param["OwnerRoleID"] = OwnerRoleID.ToString();
 
-            // Would this be cleaner as (GroupPowers)ulong.MaxValue;
-            GroupPowers OwnerPowers = (GroupPowers)ulong.MaxValue; ;
+            GroupPowers OwnerPowers = Constants.OWNER_GROUP_POWERS;
             param["OwnersPowers"] = ((ulong)OwnerPowers).ToString();
-
-
-
 
             Hashtable respData = XmlRpcCall(requestID, "groups.createGroup", param);
 

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
@@ -843,7 +843,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
 
         // Returned by llReturnObjectsByOwner and llReturnObjectsByID
         public const int ERR_GENERIC = -1;
-        public const int ERR_PARCEL_PERMISSION = -2;
+        public const int ERR_PARCEL_PERMISSIONS = -2;
         public const int ERR_MALFORMED_PARAMS = -3;
         public const int ERR_RUNTIME_PERMISSIONS = -4;
         public const int ERR_THROTTLED = -5;


### PR DESCRIPTION
- Both [llReturnObjectsByOwner](http://wiki.secondlife.com/wiki/LlReturnObjectsByOwner) (wildcard) and [llReturnObjectsByID](http://wiki.secondlife.com/wiki/LlReturnObjectsByID) (specific IDs) return the number of items returned, or an ERR_ flag on error.
- Script check: PERMISSION_RETURN_OBJECTS can be used if:
   - script owner == PermsGranter, or if:
   - script object deeded and PermsGranter is a group "Owner"
   
- Parcel check: PERMISSION_RETURN_OBJECTS can be used if:
   - owner of the other parcel with the target prim == PermsGranter, or if:
   - the other parcel with the target prim is deeded to a group and PermsGranter is a group "Owner"
   
- If script lacks PERMISSION_RETURN_OBJECTS completely, error is reported.
- EO, EM, parcel owner cannot have items returned, except:
- _ByID only:_ If script owner is EO or EM, works anywhere on region. Otherwise:
   - Allowed on objects located in any parcel on region owned by the script owner.
- _ByID only:_ the scripted object *is* allowed to return itself by ID
- _ByOwnerOnly:_ objects *deeded*, to the group that their parcel is *set* to, are *not* returned
