### PR TITLE
Attempt to fix script engine crash seen on SB5, SB6 and Plus SB.

### DIFF
--- a/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
@@ -700,17 +700,18 @@ namespace OpenSim.Region.Framework.Scenes
             // for a delete which is a *duplicate*. This can happen if the user deletes the TaskInventoryItem 
             // a *second* time before the viewer updates the Contents to remove it. This change just handle 
             // the itemID no longer being present in the items list.
-            if (!m_items.ContainsKey(itemID))
+            TaskInventoryItem item;
+            if (!m_items.TryGetValue(itemID, out item))
                 return;
 
-            InventoryType type = (InventoryType) m_items[itemID].InvType;
+            InventoryType type = (InventoryType) item.InvType;
             if (type == InventoryType.LSL) // Script
                 scriptUpdate = true;
             if ((replaceArgs != null) && (replaceArgs.ReplacementItem != null))
                 newItem = replaceArgs.ReplacementItem;
 
-            m_items.Remove(itemID);
-            _removedItems.Add(itemID);
+            if (m_items.Remove(itemID))
+                _removedItems.Add(itemID);
             m_inventorySerial++;
             m_part.TriggerScriptChangedEvent(Changed.INVENTORY);
             HasInventoryChanged = true;

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
@@ -695,8 +695,16 @@ namespace OpenSim.Region.Framework.Scenes
         {
             TaskInventoryItem newItem = null;
             bool scriptUpdate = false;
-            int type = m_items[itemID].InvType;
-            if (type == 10) // Script
+
+            // Avoid a race condition where the viewer might send what results in a second _Replace(itemID, null) 
+            // for a delete which is a *duplicate*. This can happen if the user deletes the TaskInventoryItem 
+            // a *second* time before the viewer updates the Contents to remove it. This change just handle 
+            // the itemID no longer being present in the items list.
+            if (!m_items.ContainsKey(itemID))
+                return;
+
+            InventoryType type = (InventoryType) m_items[itemID].InvType;
+            if (type == InventoryType.LSL) // Script
                 scriptUpdate = true;
             if ((replaceArgs != null) && (replaceArgs.ReplacementItem != null))
                 newItem = replaceArgs.ReplacementItem;


### PR DESCRIPTION
- Avoid a race condition where the viewer might send (or a script might request) what results in a second _Replace(itemID, null) for a delete which is a *duplicate*.  This can happen if the user deletes the TaskInventoryItem a *second* time before the viewer updates the Contents to remove it. There must be a script-based equivalent.  This change just handle the itemID no longer being present in the items list. 
See [the forum post](https://inworldz.zendesk.com/hc/en-us/community/posts/115001158408-Sandboxes-updated-to-0-9-32-test-version) reporting it. 
- Also replaced the magic numbers with InventoryType constants.