### PR TITLE
Insert additional auth mechanism for remote admin using JWT

### DIFF
--- a/InWorldz/InWorldz.RemoteAdmin/RemoteAdmin.cs
+++ b/InWorldz/InWorldz.RemoteAdmin/RemoteAdmin.cs
@@ -222,9 +222,9 @@ namespace InWorldz.RemoteAdmin
             UUID sessionId;
             var token = new JWToken((string)args[0], m_sigUtil);
 
-            if (!(token.HasValidSignature && token.IsNotExpired && token.Payload.Scope == "remote-admin"))
+            if (token.Payload.Scope != "remote-admin")
             {
-                throw new Exception("Invalid Token");
+                throw new Exception("Invalid Token Scope");
             }
             else
             {

--- a/prebuild.xml
+++ b/prebuild.xml
@@ -2367,6 +2367,7 @@
       <Reference name="OpenSim.Framework.Servers"/>
       <Reference name="OpenSim.Framework.Servers.HttpServer"/>
       <Reference name="OpenSim.Framework.Console"/>
+      <Reference name="InWorldz.JWT"/>
       <Reference name="log4net" path="../../bin/"/>
 
       <Files>


### PR DESCRIPTION
The RemoteAdmin functionality already has a login_with_password mechanism that uses the Windows Credentials in order to start an xmlrpc session.  I have added an additional login_with_token to allow for JWT token-based authorization against this endpoint.  It operates similarly to the JWT for the RemoteConsole, but has the JWT scope remote-admin instead of remote-console.