### PR TITLE
Skip UUIDs (that can't be) read from damaged assets

### DIFF
--- a/OpenSim/Region/Framework/Scenes/UuidGatherer.cs
+++ b/OpenSim/Region/Framework/Scenes/UuidGatherer.cs
@@ -284,7 +284,8 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 string xml = Utils.BytesToString(objectAsset.Data);
                 SceneObjectGroup sog = SceneObjectSerializer.FromOriginalXmlFormat(xml);
-                GatherAssetUuids(sog, assetUuids);
+                if (sog != null)
+                    GatherAssetUuids(sog, assetUuids);
             }
         }
     }


### PR DESCRIPTION
Reported by Vinhold as a null reference exception when `save oar` was called with a 1.