### PR TITLE
Configurable (and optional) server.crt file for RemoteAdmin and RemoteAccess

### DIFF
--- a/InWorldz/InWorldz.RemoteAdmin/RemoteAdmin.cs
+++ b/InWorldz/InWorldz.RemoteAdmin/RemoteAdmin.cs
@@ -65,12 +65,18 @@ namespace InWorldz.RemoteAdmin
         private Dictionary<string, Dictionary<string, XmlMethodHandler>> m_commands = 
             new Dictionary<string, Dictionary<string, XmlMethodHandler>>();
 
+        private IConfigSource m_config;
+
         private JWTSignatureUtil m_sigUtil;
+        private String m_certFilename = String.Empty;   // e.g. "server.crt"
 
         public delegate object XmlMethodHandler(IList args, IPEndPoint client);
 
         public RemoteAdmin()
         {
+            m_config = new IniConfigSource("Halcyon.ini");
+            m_certFilename = m_config.Configs["Network"].GetString("SSLCertFile", String.Empty);
+
             AddCommand("session", "login_with_password", SessionLoginWithPassword);
             AddCommand("session", "login_with_token", SessionLoginWithToken);
             AddCommand("session", "logout", SessionLogout);
@@ -82,7 +88,8 @@ namespace InWorldz.RemoteAdmin
             sessionTimer = new Timer(60000); // 60 seconds
             sessionTimer.Elapsed += sessionTimer_Elapsed;
             sessionTimer.Enabled = true;
-            m_sigUtil = new JWTSignatureUtil(publicKeyPath: "./server.crt");
+            if (!String.IsNullOrWhiteSpace(m_certFilename))
+                m_sigUtil = new JWTSignatureUtil(publicKeyPath: m_certFilename);
         }
 
         /// <summary>

--- a/OpenSim/Framework/Console/RemoteConsole.cs
+++ b/OpenSim/Framework/Console/RemoteConsole.cs
@@ -66,6 +66,7 @@ namespace OpenSim.Framework.Console
         private Dictionary<UUID, ConsoleConnection> m_Connections;
         private string m_AllowedOrigin;
         private JWTSignatureUtil m_sigUtil;
+        private String m_certFilename = String.Empty;   // e.g. "server.crt"
 
         public RemoteConsole(string defaultPrompt) : base(defaultPrompt)
         {
@@ -77,7 +78,7 @@ namespace OpenSim.Framework.Console
             m_LineNumber = 0;
             m_Connections = new Dictionary<UUID, ConsoleConnection>();
             m_AllowedOrigin = String.Empty;
-            m_sigUtil = new JWTSignatureUtil(publicKeyPath: "./server.crt");
+            m_sigUtil = null;   // conditionally initialized in ReadConfig
         }
 
         public void ReadConfig(IConfigSource config)
@@ -89,6 +90,11 @@ namespace OpenSim.Framework.Console
                 return;
 
             m_AllowedOrigin = netConfig.GetString("ConsoleAllowedOrigin", String.Empty);
+
+            m_certFilename = netConfig.GetString("SSLCertFile", String.Empty);
+
+            if (!String.IsNullOrWhiteSpace(m_certFilename))
+                m_sigUtil = new JWTSignatureUtil(publicKeyPath: m_certFilename);
         }
 
         public void SetServer(IHttpServer server)


### PR DESCRIPTION
RemoteAdmin and RemoteConsole now read the server.crt filename from `[Network]` option `SSLCertFile`
This configuration is optional, then it doesn't initialize a JWT signature util object.