### PR TITLE
Configurable JWT certificate paths and documentation update

### DIFF
--- a/InWorldz/InWorldz.RemoteAdmin/RemoteAdmin.cs
+++ b/InWorldz/InWorldz.RemoteAdmin/RemoteAdmin.cs
@@ -69,7 +69,7 @@ namespace InWorldz.RemoteAdmin
 
         public delegate object XmlMethodHandler(IList args, IPEndPoint client);
 
-        public RemoteAdmin()
+        public RemoteAdmin(string publicKeyPath = null)
         {
             AddCommand("session", "login_with_password", SessionLoginWithPassword);
             AddCommand("session", "login_with_token", SessionLoginWithToken);
@@ -82,7 +82,8 @@ namespace InWorldz.RemoteAdmin
             sessionTimer = new Timer(60000); // 60 seconds
             sessionTimer.Elapsed += sessionTimer_Elapsed;
             sessionTimer.Enabled = true;
-            m_sigUtil = new JWTSignatureUtil(publicKeyPath: "./server.crt");
+
+            m_sigUtil = new JWTSignatureUtil(publicKeyPath: publicKeyPath);
         }
 
         /// <summary>

--- a/InWorldz/InWorldz.RemoteAdmin/RemoteAdminPlugin.cs
+++ b/InWorldz/InWorldz.RemoteAdmin/RemoteAdminPlugin.cs
@@ -90,7 +90,7 @@ namespace InWorldz.RemoteAdmin
         public void Initialize(OpenSimBase openSim)
         {
             m_app = openSim;
-            m_admin = new RemoteAdmin();
+            m_admin = new RemoteAdmin(openSim.ConfigSource.Source.Configs["Network"]?.GetString("SSLCertFile", null));
         }
 
         public void PostInitialize()

--- a/OpenSim/Framework/Communications/JWT/JWTUserAuthenticationGateway.cs
+++ b/OpenSim/Framework/Communications/JWT/JWTUserAuthenticationGateway.cs
@@ -47,10 +47,10 @@ namespace OpenSim.Framework.Communications.JWT
 
         private readonly JWTSignatureUtil m_sigUtil;
 
-        public JWTUserAuthenticationGateway(IUserService userService)
+        public JWTUserAuthenticationGateway(IUserService userService, string privateKeyPath, string publicKeyPath)
         {
             _userService = userService;
-            m_sigUtil = new JWTSignatureUtil(privateKeyPath: "./server.p12", publicKeyPath:"./server.crt");
+            m_sigUtil = new JWTSignatureUtil(privateKeyPath, publicKeyPath);
         }
 
         /// <summary>

--- a/OpenSim/Framework/ConfigSettings.cs
+++ b/OpenSim/Framework/ConfigSettings.cs
@@ -221,5 +221,7 @@ namespace OpenSim.Framework
         public const bool DefaultMessageServerHttpSSL = false;
         public const uint DefaultGridServerHttpPort = 8001;
         public const uint DefaultInventoryServerHttpPort = 8004;
+
+        public const string DefaultSSLPublicCertFile = "";
     }
 }

--- a/OpenSim/Framework/GridConfig.cs
+++ b/OpenSim/Framework/GridConfig.cs
@@ -46,6 +46,8 @@ namespace OpenSim.Framework
         public string UserRecvKey = String.Empty;
         public string UserSendKey = String.Empty;
 
+        public string SSLPublicCertFile = ConfigSettings.DefaultSSLPublicCertFile;
+
         public GridConfig(string description, string filename)
         {
             m_configMember =
@@ -93,8 +95,11 @@ namespace OpenSim.Framework
             m_configMember.addConfigurationOption("allow_region_registration", 
                                                 ConfigurationOption.ConfigurationTypes.TYPE_BOOLEAN,
                                                 "Allow regions to register immediately upon grid server startup? true/false", 
-                                                "True", 
-                                                false);            
+                                                "True",
+                                                false);
+
+            m_configMember.addConfigurationOption("ssl_public_certificate", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                  $"Path to public key certificate [{ConfigSettings.DefaultSSLPublicCertFile}]", ConfigSettings.DefaultSSLPublicCertFile, true);
         }
 
         public bool handleIncomingConfiguration(string configuration_key, object configuration_result)
@@ -139,7 +144,10 @@ namespace OpenSim.Framework
                     break;
                 case "allow_region_registration":
                     AllowRegionRegistration = (bool)configuration_result;
-                    break;                
+                    break;
+                case "ssl_public_certificate":
+                    SSLPublicCertFile = (string)configuration_result;
+                    break;
             }
 
             return true;

--- a/OpenSim/Framework/MessageServerConfig.cs
+++ b/OpenSim/Framework/MessageServerConfig.cs
@@ -47,6 +47,8 @@ namespace OpenSim.Framework
         public string UserSendKey = String.Empty;
         public string UserServerURL = String.Empty;
 
+        public string SSLPublicCertFile = ConfigSettings.DefaultSSLPublicCertFile;
+
         public MessageServerConfig(string description, string filename)
         {
             m_configMember =
@@ -88,6 +90,9 @@ namespace OpenSim.Framework
                                                 "Use SSL? true/false", ConfigSettings.DefaultMessageServerHttpSSL.ToString(), false);
             m_configMember.addConfigurationOption("published_ip", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
                                                 "My Published IP Address", "127.0.0.1", false);
+
+            m_configMember.addConfigurationOption("ssl_public_certificate", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                  $"Path to public key certificate [{ConfigSettings.DefaultSSLPublicCertFile}]", ConfigSettings.DefaultSSLPublicCertFile, true);
         }
 
         public bool handleIncomingConfiguration(string configuration_key, object configuration_result)
@@ -129,6 +134,9 @@ namespace OpenSim.Framework
                     break;
                 case "published_ip":
                     MessageServerIP = (string) configuration_result;
+                    break;
+                case "ssl_public_certificate":
+                    SSLPublicCertFile = (string)configuration_result;
                     break;
             }
 

--- a/OpenSim/Framework/NetworkServersInfo.cs
+++ b/OpenSim/Framework/NetworkServersInfo.cs
@@ -84,16 +84,22 @@ namespace OpenSim.Framework
             m_defaultHomeLocX = (uint) config.Configs["StandAlone"].GetInt("default_location_x", 1000);
             m_defaultHomeLocY = (uint) config.Configs["StandAlone"].GetInt("default_location_y", 1000);
 
-            HostName = config.Configs["Network"].GetString("hostname", Util.RetrieveListenAddress());
-            HttpListenerPort = (uint) config.Configs["Network"].GetInt("http_listener_port", (int) ConfigSettings.DefaultRegionHttpPort);
-            httpSSLPort = (uint)config.Configs["Network"].GetInt("http_listener_sslport", ((int)ConfigSettings.DefaultRegionHttpPort+1));
-            HttpUsesSSL = config.Configs["Network"].GetBoolean("http_listener_ssl", false);
-            HttpSSLCN = config.Configs["Network"].GetString("http_listener_cn", "localhost");
-            HttpSSLCert = config.Configs["Network"].GetString("http_listener_ssl_cert", String.Empty);
-            HttpSSLPassword = config.Configs["Network"].GetString("http_listener_ssl_passwd", String.Empty);
-            useHTTPS = config.Configs["Network"].GetBoolean("use_https", false);
+            var networkConfigSection = config.Configs["Network"];
 
-            string sslproto = config.Configs["Network"].GetString("https_ssl_protocol", "Default");
+            HostName = networkConfigSection.GetString("hostname", Util.RetrieveListenAddress());
+            HttpListenerPort = (uint) networkConfigSection.GetInt("http_listener_port", (int) ConfigSettings.DefaultRegionHttpPort);
+            httpSSLPort = (uint) networkConfigSection.GetInt("http_listener_sslport", ((int)ConfigSettings.DefaultRegionHttpPort+1));
+            HttpUsesSSL = networkConfigSection.GetBoolean("http_listener_ssl", false);
+            HttpSSLCN = networkConfigSection.GetString("http_listener_cn", "localhost");
+            HttpSSLCert = networkConfigSection.GetString("http_listener_ssl_cert", string.Empty);
+            if (string.IsNullOrWhiteSpace(HttpSSLCert))
+            {
+                HttpSSLCert = networkConfigSection.GetString("SSLCertFile", ConfigSettings.DefaultSSLPublicCertFile);
+            }
+            HttpSSLPassword = networkConfigSection.GetString("http_listener_ssl_passwd", String.Empty);
+            useHTTPS = networkConfigSection.GetBoolean("use_https", false);
+
+            string sslproto = networkConfigSection.GetString("https_ssl_protocol", "Default");
             try
             {
                 sslProtocol = (SslProtocols)Enum.Parse(typeof(SslProtocols), sslproto);
@@ -104,24 +110,20 @@ namespace OpenSim.Framework
             }
             
             ConfigSettings.DefaultRegionRemotingPort =
-                (uint) config.Configs["Network"].GetInt("remoting_listener_port", (int) ConfigSettings.DefaultRegionRemotingPort);
-            GridURL =
-                config.Configs["Network"].GetString("grid_server_url",
-                                                    "http://127.0.0.1:" + ConfigSettings.DefaultGridServerHttpPort.ToString());
-            GridSendKey = config.Configs["Network"].GetString("grid_send_key", "null");
-            GridRecvKey = config.Configs["Network"].GetString("grid_recv_key", "null");
-            UserURL =
-                config.Configs["Network"].GetString("user_server_url",
-                                                    "http://127.0.0.1:" + ConfigSettings.DefaultUserServerHttpPort.ToString());
-            UserSendKey = config.Configs["Network"].GetString("user_send_key", "null");
-            UserRecvKey = config.Configs["Network"].GetString("user_recv_key", "null");
-            AssetURL = config.Configs["Network"].GetString("asset_server_url", AssetURL);
-            InventoryURL = config.Configs["Network"].GetString("inventory_server_url",
+                (uint) networkConfigSection.GetInt("remoting_listener_port", (int) ConfigSettings.DefaultRegionRemotingPort);
+            GridURL = networkConfigSection.GetString("grid_server_url", "http://127.0.0.1:" + ConfigSettings.DefaultGridServerHttpPort.ToString());
+            GridSendKey = networkConfigSection.GetString("grid_send_key", "null");
+            GridRecvKey = networkConfigSection.GetString("grid_recv_key", "null");
+            UserURL = networkConfigSection.GetString("user_server_url", "http://127.0.0.1:" + ConfigSettings.DefaultUserServerHttpPort.ToString());
+            UserSendKey = networkConfigSection.GetString("user_send_key", "null");
+            UserRecvKey = networkConfigSection.GetString("user_recv_key", "null");
+            AssetURL = networkConfigSection.GetString("asset_server_url", AssetURL);
+            InventoryURL = networkConfigSection.GetString("inventory_server_url",
                                                                "http://127.0.0.1:" +
                                                                ConfigSettings.DefaultInventoryServerHttpPort.ToString());
-            secureInventoryServer = config.Configs["Network"].GetBoolean("secure_inventory_server", true);
+            secureInventoryServer = networkConfigSection.GetBoolean("secure_inventory_server", true);
 
-            MessagingURL = config.Configs["Network"].GetString("messaging_server_url",
+            MessagingURL = networkConfigSection.GetString("messaging_server_url",
                                                                "http://127.0.0.1:" + ConfigSettings.DefaultMessageServerHttpPort);
         }
     }

--- a/OpenSim/Framework/UserConfig.cs
+++ b/OpenSim/Framework/UserConfig.cs
@@ -35,19 +35,21 @@ namespace OpenSim.Framework
     /// </summary>
     public class UserConfig:ConfigBase
     {
-        public string DatabaseProvider = String.Empty;
-        public string DatabaseConnect = String.Empty;
-        public string DefaultStartupMsg = String.Empty;
-        public string MapServerURI = String.Empty;
-        public string ProfileServerURI = String.Empty;
+        public string DatabaseProvider = string.Empty;
+        public string DatabaseConnect = string.Empty;
+        public string DefaultStartupMsg = string.Empty;
+        public string MapServerURI = string.Empty;
+        public string ProfileServerURI = string.Empty;
         public uint DefaultX = 1000;
         public uint DefaultY = 1000;
-        public string GridRecvKey = String.Empty;
-        public string GridSendKey = String.Empty;
+        public string GridRecvKey = string.Empty;
+        public string GridSendKey = string.Empty;
         public uint HttpPort = ConfigSettings.DefaultUserServerHttpPort;
         public bool HttpSSL = ConfigSettings.DefaultUserServerHttpSSL;
         public uint DefaultUserLevel = 0;
-        public string LibraryXmlfile = String.Empty;
+        public string LibraryXmlfile = string.Empty;
+        public string SSLPrivateCertFile = string.Empty;
+        public string SSLPublicCertFile = ConfigSettings.DefaultSSLPublicCertFile;
 
         private Uri m_inventoryUrl;
 
@@ -151,6 +153,11 @@ namespace OpenSim.Framework
 
             m_configMember.addConfigurationOption("default_loginLevel", ConfigurationOption.ConfigurationTypes.TYPE_UINT32,
                                                 "Minimum Level a user should have to login [0 default]", "0", false);
+
+            m_configMember.addConfigurationOption("ssl_private_certificate", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                  "Path to private key certificate", string.Empty, true);
+            m_configMember.addConfigurationOption("ssl_public_certificate", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                  $"Path to public key certificate [{ConfigSettings.DefaultSSLPublicCertFile}]", ConfigSettings.DefaultSSLPublicCertFile, true);
         }
 
         public bool handleIncomingConfiguration(string configuration_key, object configuration_result)
@@ -193,7 +200,7 @@ namespace OpenSim.Framework
                 case "default_Y":
                     DefaultY = (uint) configuration_result;
                     break;
-               case "enable_hg_login":
+                case "enable_hg_login":
                     EnableHGLogin = (bool)configuration_result;
                     break;
                 case "default_loginLevel":
@@ -207,6 +214,12 @@ namespace OpenSim.Framework
                     break;
                 case "profile_server_uri":
                     ProfileServerURI = (string)configuration_result;
+                    break;
+                case "ssl_private_certificate":
+                    SSLPrivateCertFile = (string)configuration_result;
+                    break;
+                case "ssl_public_certificate":
+                    SSLPublicCertFile = (string)configuration_result;
                     break;
             }
 

--- a/OpenSim/Grid/GridServer/GridServerBase.cs
+++ b/OpenSim/Grid/GridServer/GridServerBase.cs
@@ -87,7 +87,7 @@ namespace OpenSim.Grid.GridServer
 
             m_httpServer.Start();
 
-            m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin();
+            m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin(m_config.SSLPublicCertFile);
             m_radmin.AddCommand("GridService", "Shutdown", GridServerShutdownHandler);
             m_radmin.AddHandler(m_httpServer);
 

--- a/OpenSim/Grid/MessagingServer/Main.cs
+++ b/OpenSim/Grid/MessagingServer/Main.cs
@@ -121,7 +121,7 @@ namespace OpenSim.Grid.MessagingServer
                 m_httpServer.AddStreamHandler(new XmlRpcStreamHandler("POST", Util.XmlRpcRequestPrefix("region_startup"), m_regionModule.RegionStartup));
                 m_httpServer.AddStreamHandler(new XmlRpcStreamHandler("POST", Util.XmlRpcRequestPrefix("region_shutdown"), m_regionModule.RegionShutdown));
 
-                m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin();
+                m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin(Cfg.SSLPublicCertFile);
                 m_radmin.AddCommand("MessagingService", "Shutdown", MessagingServerShutdownHandler);
                 m_radmin.AddHandler(m_httpServer);
 

--- a/OpenSim/Grid/UserServer.Modules/JWTAuthenticator.cs
+++ b/OpenSim/Grid/UserServer.Modules/JWTAuthenticator.cs
@@ -31,15 +31,13 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using InWorldz.JWT;
+using LitJson;
+using log4net;
 using OpenSim.Framework.Communications.JWT;
 using OpenSim.Framework.Servers.HttpServer;
 using OpenSim.Grid.Framework;
-using LitJson;
-using log4net;
-using System.IO;
-using System.Text;
-using System.Text.RegularExpressions;
 
 namespace OpenSim.Grid.UserServer.Modules
 {
@@ -66,15 +64,15 @@ namespace OpenSim.Grid.UserServer.Modules
             m_coreService = core;
         }
 
-        public void PostInitialize()
+        public void PostInitialize(string privateKeyPath, string publicKeyPath)
         {
-            if (!m_coreService.TryGet<UserDataBaseService>(out m_userDataBaseService))
+            if (m_coreService.TryGet(out m_userDataBaseService))
             {
-                m_userDataBaseService = null;
+                m_authGateway = new JWTUserAuthenticationGateway(m_userDataBaseService, privateKeyPath, publicKeyPath);
             }
             else
             {
-                m_authGateway = new JWTUserAuthenticationGateway(m_userDataBaseService);
+                m_userDataBaseService = null;
             }
         }
 

--- a/OpenSim/Grid/UserServer/Main.cs
+++ b/OpenSim/Grid/UserServer/Main.cs
@@ -254,7 +254,7 @@ namespace OpenSim.Grid.UserServer
 
             if (m_useJwt)
             {
-                m_jwtAuthenticator.PostInitialize();
+                m_jwtAuthenticator.PostInitialize(Cfg.SSLPrivateCertFile, Cfg.SSLPublicCertFile);
             }
         }
 
@@ -274,7 +274,7 @@ namespace OpenSim.Grid.UserServer
             }
             
 
-            m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin();
+            m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin(Cfg.SSLPublicCertFile);
             m_radmin.AddCommand("UserService", "Shutdown", UserServerShutdownHandler);
             m_radmin.AddHandler(m_httpServer);
         }

--- a/bin/Halcyon.sample.ini
+++ b/bin/Halcyon.sample.ini
@@ -1,3 +1,4 @@
+
 ; Please note that options that are commented out are often the default.
 ; E.g.: save_crashes is false by default.  If you want it to be otherwise,
 ;  uncomment and change the value.
@@ -277,6 +278,10 @@
     ; web server.
     ;user_agent = "Halcyon LSL (Mozilla Compatible)"
 
+    ; Path to public key for verifying JWTs used for remote administration tools.
+    ; The default is empty, though a common value is "./server.crt" as is
+    ; documented in "doc/JWT Authentication/CreatingSelfSignedCert.txt"
+    ;SSLCertFile = ""
 
 [Chat]
     ; Controls whether the chat module is enabled.  Default is true.

--- a/doc/remote.postman_environment.json
+++ b/doc/remote.postman_environment.json
@@ -33,6 +33,30 @@
 			"enabled": true
 		},
 		{
+			"key": "MESSAGESERVER_URL",
+			"value": "localhost",
+			"type": "text",
+			"enabled": true
+		},
+		{
+			"key": "MESSAGESERVER_PORT",
+			"value": "8006",
+			"type": "text",
+			"enabled": true
+		},
+		{
+			"key": "GRIDSERVER_URL",
+			"value": "localhost",
+			"type": "text",
+			"enabled": true
+		},
+		{
+			"key": "GRIDSERVER_PORT",
+			"value": "8009",
+			"type": "text",
+			"enabled": true
+		},
+		{
 			"key": "USER",
 			"value": "fake",
 			"type": "text",

--- a/doc/remote_admin.postman_collection.json
+++ b/doc/remote_admin.postman_collection.json
@@ -12,25 +12,127 @@
 			"description": "",
 			"item": [
 				{
-					"name": "XMLRPC Login",
+					"name": "Get JWT Auth Token",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"type": "text/javascript",
-								"exec": "var jsonObject = {};\n\ntry {\n    jsonObject = xml2Json(responseBody);\n    \n    if (jsonObject.hasOwnProperty(\"methodResponse\") && jsonObject.methodResponse.hasOwnProperty(\"params\")) {\n        postman.setEnvironmentVariable(\"rpc_login_key\", jsonObject.methodResponse.params.param.value.struct.member[0].value.string);\n    }\n}\ncatch(e) {\n    tests[\"parserr: \" + JSON.stringify(e)] = false;\n    tests[\"data: \" + JSON.stringify(jsonObject)] = false;\n}\n\ntests[\"rpc_login_key: \" + environment.rpc_login_key] = environment.rpc_login_key !== null && environment.rpc_login_key.length > 0;"
+								"exec": [
+									"var jsonObject = {};",
+									"",
+									"try",
+									"{",
+									"    jsonObject = JSON.parse(responseBody);",
+									"    ",
+									"    tests[\"body: \" + responseBody] = true;",
+									"    ",
+									"    if (jsonObject.hasOwnProperty(\"token\"))",
+									"    {",
+									"        tests[\"Parameter 'token' in response object\"] = jsonObject.hasOwnProperty(\"token\");",
+									"        tests[\"Parameter 'token' is a string\"] = Object.prototype.toString.call(jsonObject.token) === \"[object String]\";",
+									"        tests[\"Token: \" + jsonObject.token] = true;",
+									"        postman.setEnvironmentVariable(\"restadmin_jwt_token\", jsonObject.token);",
+									"    }",
+									"    else",
+									"    {",
+									"        tests[\"Parameter 'denied' in response object\"] = jsonObject.hasOwnProperty(\"denied\");",
+									"        tests[\"Parameter 'denied' is a string\"] = Object.prototype.toString.call(jsonObject.denied) === \"[object String]\";",
+									"        tests[\"Denial reason: \" + jsonObject.denied] = false; // Fail the test so the user knows that something's amiss.",
+									"    }",
+									"}",
+									"catch(e)",
+									"{",
+									"    tests[\"parserr: \" + JSON.stringify(e)] = false;",
+									"    tests[\"data: \" + JSON.stringify(jsonObject)] = false;",
+									"}",
+									""
+								]
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"type": "text/javascript",
-								"exec": "postman.clearEnvironmentVariable(\"rpc_login_key\");"
+								"exec": [
+									"postman.clearEnvironmentVariable(\"restadmin_jwt_token\");"
+								]
 							}
 						}
 					],
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{USERSERVER_URL}}:{{USERSERVER_PORT}}/auth/jwt/remote-admin",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"username\": \"{{USER}}\",\n    \"password\": \"{{PASS}}\"\n}"
+						},
+						"description": "Gets a JWT token that can be used to access the remote console endpoints.\n"
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Grid Server",
+			"description": "",
+			"item": [
+				{
+					"name": "Get Grid Info",
+					"request": {
+						"url": "{{PROTOCOL}}://{{GRIDSERVER_URL}}:{{GRIDSERVER_PORT}}/get_grid_info",
+						"method": "GET",
+						"header": [],
+						"body": {},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "XMLRPC Login JWT",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var jsonObject = {};",
+									"",
+									"try {",
+									"    jsonObject = xml2Json(responseBody);",
+									"    ",
+									"    if (jsonObject.hasOwnProperty(\"methodResponse\") && jsonObject.methodResponse.hasOwnProperty(\"params\")) {",
+									"        postman.setEnvironmentVariable(\"rpc_login_key\", jsonObject.methodResponse.params.param.value.struct.member[0].value.string);",
+									"    }",
+									"}",
+									"catch(e) {",
+									"    tests[\"parserr: \" + JSON.stringify(e)] = false;",
+									"    tests[\"data: \" + JSON.stringify(jsonObject)] = false;",
+									"}",
+									"",
+									"tests[\"rpc_login_key: \" + environment.rpc_login_key] = environment.rpc_login_key !== null && environment.rpc_login_key.length > 0;"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"postman.clearEnvironmentVariable(\"rpc_login_key\");"
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{PROTOCOL}}://{{GRIDSERVER_URL}}:{{GRIDSERVER_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{
@@ -41,12 +143,13 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.login_with_password</methodName>\n    <params>\n        <param>\n            <value><string>{{USER}}</string></value>\n        </param>\n        <param>\n            <value><string>{{PASS}}</string></value>\n        </param>\n    </params>\n</methodCall>"
+							"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.login_with_token</methodName>\n    <params>\n        <param>\n            <value><string>{{restadmin_jwt_token}}</string></value>\n        </param>\n    </params>\n</methodCall>"
 						},
 						"description": "XMLRPC access point for remote administration.\n"
 					},
 					"response": [
 						{
+							"id": "93cce335-56d0-439d-ab2d-bc42247dcfc9",
 							"name": "ExampleLogin",
 							"originalRequest": {
 								"url": "http://localhost:9991/xmlrpc/RemoteAdmin",
@@ -119,12 +222,14 @@
 							"listen": "test",
 							"script": {
 								"type": "text/javascript",
-								"exec": "postman.clearEnvironmentVariable(\"rpc_login_key\");"
+								"exec": [
+									"postman.clearEnvironmentVariable(\"rpc_login_key\");"
+								]
 							}
 						}
 					],
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{GRIDSERVER_URL}}:{{GRIDSERVER_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{
@@ -142,49 +247,9 @@
 					"response": []
 				},
 				{
-					"name": "XMLRPC Arbitrary Command",
-					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "text/xml",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>Console.Command</methodName>\n    <params>\n        <param>\n            <value><string>{{rpc_login_key}}</string></value>\n        </param>\n        <param>\n            <value><string>alert general This is a ping from remote!</string></value>\n        </param>\n    </params>\n</methodCall>"
-						},
-						"description": "XMLRPC access point for remote administration.\n"
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Grid Server",
-			"description": "",
-			"item": [
-				{
-					"name": "Get Grid Info",
-					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/get_grid_info",
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "formdata",
-							"formdata": []
-						},
-						"description": ""
-					},
-					"response": []
-				},
-				{
 					"name": "XMLRPC Grid Server Shutdown",
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{GRIDSERVER_URL}}:{{GRIDSERVER_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{
@@ -208,9 +273,160 @@
 			"description": "",
 			"item": [
 				{
+					"name": "XMLRPC Login JWT",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var jsonObject = {};",
+									"",
+									"try {",
+									"    jsonObject = xml2Json(responseBody);",
+									"    ",
+									"    if (jsonObject.hasOwnProperty(\"methodResponse\") && jsonObject.methodResponse.hasOwnProperty(\"params\")) {",
+									"        postman.setEnvironmentVariable(\"rpc_login_key\", jsonObject.methodResponse.params.param.value.struct.member[0].value.string);",
+									"    }",
+									"}",
+									"catch(e) {",
+									"    tests[\"parserr: \" + JSON.stringify(e)] = false;",
+									"    tests[\"data: \" + JSON.stringify(jsonObject)] = false;",
+									"}",
+									"",
+									"tests[\"rpc_login_key: \" + environment.rpc_login_key] = environment.rpc_login_key !== null && environment.rpc_login_key.length > 0;"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"postman.clearEnvironmentVariable(\"rpc_login_key\");"
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{PROTOCOL}}://{{MESSAGESERVER_URL}}:{{MESSAGESERVER_PORT}}/xmlrpc/RemoteAdmin",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "text/xml",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.login_with_token</methodName>\n    <params>\n        <param>\n            <value><string>{{restadmin_jwt_token}}</string></value>\n        </param>\n    </params>\n</methodCall>"
+						},
+						"description": "XMLRPC access point for remote administration.\n"
+					},
+					"response": [
+						{
+							"id": "b23f8b80-f983-49b0-961f-aeb97c83caa5",
+							"name": "ExampleLogin",
+							"originalRequest": {
+								"url": "http://localhost:9991/xmlrpc/RemoteAdmin",
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/xml",
+										"enabled": true,
+										"description": "The mime type of this content"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.login_with_password</methodName>\n    <params>\n        <param>\n            <value><string>user</string></value>\n        </param>\n        <param>\n            <value><string>pass</string></value>\n        </param>\n    </params>\n</methodCall>"
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "xml",
+							"_postman_previewtype": "html",
+							"header": [
+								{
+									"name": "Content-Encoding",
+									"key": "Content-Encoding",
+									"value": "gzip",
+									"description": "The type of encoding used on the data."
+								},
+								{
+									"name": "Content-Length",
+									"key": "Content-Length",
+									"value": "196",
+									"description": "The length of the response body in octets (8-bit bytes)"
+								},
+								{
+									"name": "Content-Type",
+									"key": "Content-Type",
+									"value": "text/xml; charset=utf-8",
+									"description": "The mime type of this content"
+								},
+								{
+									"name": "Date",
+									"key": "Date",
+									"value": "Tue, 05 Jul 2016 05:41:19 GMT",
+									"description": "The date and time that the message was sent"
+								},
+								{
+									"name": "Keep-Alive",
+									"key": "Keep-Alive",
+									"value": "timeout=15,max=100",
+									"description": "Custom header"
+								},
+								{
+									"name": "Server",
+									"key": "Server",
+									"value": "Mono-HTTPAPI/1.0",
+									"description": "A name for the server"
+								}
+							],
+							"cookie": [],
+							"responseTime": 36,
+							"body": "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodResponse><params><param><value><struct><member><name>Value</name><value><string>ef4b81ff-0838-4979-b286-a2f8084c4ff9</string></value></member><member><name>Status</name><value><string>Success</string></value></member></struct></value></param></params></methodResponse>"
+						}
+					]
+				},
+				{
+					"name": "XMLRPC Logout",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"postman.clearEnvironmentVariable(\"rpc_login_key\");"
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{PROTOCOL}}://{{MESSAGESERVER_URL}}:{{MESSAGESERVER_PORT}}/xmlrpc/RemoteAdmin",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "text/xml",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.logout</methodName>\n    <params>\n        <param>\n            <value><string>{{rpc_login_key}}</string></value>\n        </param>\n    </params>\n</methodCall>"
+						},
+						"description": "XMLRPC access point for remote administration.\n"
+					},
+					"response": []
+				},
+				{
 					"name": "XMLRPC Message Server Shutdown",
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{MESSAGESERVER_URL}}:{{MESSAGESERVER_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{
@@ -234,9 +450,300 @@
 			"description": "",
 			"item": [
 				{
+					"name": "XMLRPC Login JWT",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var jsonObject = {};",
+									"",
+									"try {",
+									"    jsonObject = xml2Json(responseBody);",
+									"    ",
+									"    if (jsonObject.hasOwnProperty(\"methodResponse\") && jsonObject.methodResponse.hasOwnProperty(\"params\")) {",
+									"        postman.setEnvironmentVariable(\"rpc_login_key\", jsonObject.methodResponse.params.param.value.struct.member[0].value.string);",
+									"    }",
+									"}",
+									"catch(e) {",
+									"    tests[\"parserr: \" + JSON.stringify(e)] = false;",
+									"    tests[\"data: \" + JSON.stringify(jsonObject)] = false;",
+									"}",
+									"",
+									"tests[\"rpc_login_key: \" + environment.rpc_login_key] = environment.rpc_login_key !== null && environment.rpc_login_key.length > 0;"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"postman.clearEnvironmentVariable(\"rpc_login_key\");"
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{PROTOCOL}}://{{REGION_URL}}:{{REGION_PORT}}/xmlrpc/RemoteAdmin",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "text/xml",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.login_with_token</methodName>\n    <params>\n        <param>\n            <value><string>{{restadmin_jwt_token}}</string></value>\n        </param>\n    </params>\n</methodCall>"
+						},
+						"description": "XMLRPC access point for remote administration.\n"
+					},
+					"response": [
+						{
+							"id": "8b4e579b-c537-4ce8-a0f1-be7089e3813f",
+							"name": "ExampleLogin",
+							"originalRequest": {
+								"url": "http://localhost:9991/xmlrpc/RemoteAdmin",
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/xml",
+										"enabled": true,
+										"description": "The mime type of this content"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.login_with_password</methodName>\n    <params>\n        <param>\n            <value><string>user</string></value>\n        </param>\n        <param>\n            <value><string>pass</string></value>\n        </param>\n    </params>\n</methodCall>"
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "xml",
+							"_postman_previewtype": "html",
+							"header": [
+								{
+									"name": "Content-Encoding",
+									"key": "Content-Encoding",
+									"value": "gzip",
+									"description": "The type of encoding used on the data."
+								},
+								{
+									"name": "Content-Length",
+									"key": "Content-Length",
+									"value": "196",
+									"description": "The length of the response body in octets (8-bit bytes)"
+								},
+								{
+									"name": "Content-Type",
+									"key": "Content-Type",
+									"value": "text/xml; charset=utf-8",
+									"description": "The mime type of this content"
+								},
+								{
+									"name": "Date",
+									"key": "Date",
+									"value": "Tue, 05 Jul 2016 05:41:19 GMT",
+									"description": "The date and time that the message was sent"
+								},
+								{
+									"name": "Keep-Alive",
+									"key": "Keep-Alive",
+									"value": "timeout=15,max=100",
+									"description": "Custom header"
+								},
+								{
+									"name": "Server",
+									"key": "Server",
+									"value": "Mono-HTTPAPI/1.0",
+									"description": "A name for the server"
+								}
+							],
+							"cookie": [],
+							"responseTime": 36,
+							"body": "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodResponse><params><param><value><struct><member><name>Value</name><value><string>ef4b81ff-0838-4979-b286-a2f8084c4ff9</string></value></member><member><name>Status</name><value><string>Success</string></value></member></struct></value></param></params></methodResponse>"
+						}
+					]
+				},
+				{
+					"name": "XMLRPC Login User & Pass",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var jsonObject = {};",
+									"",
+									"try {",
+									"    jsonObject = xml2Json(responseBody);",
+									"    ",
+									"    if (jsonObject.hasOwnProperty(\"methodResponse\") && jsonObject.methodResponse.hasOwnProperty(\"params\")) {",
+									"        postman.setEnvironmentVariable(\"rpc_login_key\", jsonObject.methodResponse.params.param.value.struct.member[0].value.string);",
+									"    }",
+									"}",
+									"catch(e) {",
+									"    tests[\"parserr: \" + JSON.stringify(e)] = false;",
+									"    tests[\"data: \" + JSON.stringify(jsonObject)] = false;",
+									"}",
+									"",
+									"tests[\"rpc_login_key: \" + environment.rpc_login_key] = environment.rpc_login_key !== null && environment.rpc_login_key.length > 0;"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"postman.clearEnvironmentVariable(\"rpc_login_key\");"
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{PROTOCOL}}://{{REGION_URL}}:{{REGION_PORT}}/xmlrpc/RemoteAdmin",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "text/xml",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.login_with_password</methodName>\n    <params>\n        <param>\n            <value><string>{{USER}}</string></value>\n        </param>\n        <param>\n            <value><string>{{PASS}}</string></value>\n        </param>\n    </params>\n</methodCall>"
+						},
+						"description": "XMLRPC access point for remote administration.\n"
+					},
+					"response": [
+						{
+							"id": "74ee02e5-af9a-4c94-a06f-e7bb82b57017",
+							"name": "ExampleLogin",
+							"originalRequest": {
+								"url": "http://localhost:9991/xmlrpc/RemoteAdmin",
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/xml",
+										"enabled": true,
+										"description": "The mime type of this content"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.login_with_password</methodName>\n    <params>\n        <param>\n            <value><string>user</string></value>\n        </param>\n        <param>\n            <value><string>pass</string></value>\n        </param>\n    </params>\n</methodCall>"
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "xml",
+							"_postman_previewtype": "html",
+							"header": [
+								{
+									"name": "Content-Encoding",
+									"key": "Content-Encoding",
+									"value": "gzip",
+									"description": "The type of encoding used on the data."
+								},
+								{
+									"name": "Content-Length",
+									"key": "Content-Length",
+									"value": "196",
+									"description": "The length of the response body in octets (8-bit bytes)"
+								},
+								{
+									"name": "Content-Type",
+									"key": "Content-Type",
+									"value": "text/xml; charset=utf-8",
+									"description": "The mime type of this content"
+								},
+								{
+									"name": "Date",
+									"key": "Date",
+									"value": "Tue, 05 Jul 2016 05:41:19 GMT",
+									"description": "The date and time that the message was sent"
+								},
+								{
+									"name": "Keep-Alive",
+									"key": "Keep-Alive",
+									"value": "timeout=15,max=100",
+									"description": "Custom header"
+								},
+								{
+									"name": "Server",
+									"key": "Server",
+									"value": "Mono-HTTPAPI/1.0",
+									"description": "A name for the server"
+								}
+							],
+							"cookie": [],
+							"responseTime": 36,
+							"body": "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodResponse><params><param><value><struct><member><name>Value</name><value><string>ef4b81ff-0838-4979-b286-a2f8084c4ff9</string></value></member><member><name>Status</name><value><string>Success</string></value></member></struct></value></param></params></methodResponse>"
+						}
+					]
+				},
+				{
+					"name": "XMLRPC Logout",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"postman.clearEnvironmentVariable(\"rpc_login_key\");"
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{PROTOCOL}}://{{REGION_URL}}:{{REGION_PORT}}/xmlrpc/RemoteAdmin",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "text/xml",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.logout</methodName>\n    <params>\n        <param>\n            <value><string>{{rpc_login_key}}</string></value>\n        </param>\n    </params>\n</methodCall>"
+						},
+						"description": "XMLRPC access point for remote administration.\n"
+					},
+					"response": []
+				},
+				{
+					"name": "XMLRPC Arbitrary Command",
+					"request": {
+						"url": "{{PROTOCOL}}://{{REGION_URL}}:{{REGION_PORT}}/xmlrpc/RemoteAdmin",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "text/xml",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>Console.Command</methodName>\n    <params>\n        <param>\n            <value><string>{{rpc_login_key}}</string></value>\n        </param>\n        <param>\n            <value><string>alert general This is a ping from remote!</string></value>\n        </param>\n    </params>\n</methodCall>"
+						},
+						"description": "XMLRPC access point for remote administration.\n"
+					},
+					"response": []
+				},
+				{
 					"name": "XMLRPC Region Server Restart (specified region, default timeout)",
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{REGION_URL}}:{{REGION_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{
@@ -256,7 +763,7 @@
 				{
 					"name": "XMLRPC Region Server Shutdown (specified region, 10 sec)",
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{REGION_URL}}:{{REGION_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{
@@ -276,7 +783,7 @@
 				{
 					"name": "XMLRPC Region Server Send Alert",
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{REGION_URL}}:{{REGION_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{
@@ -296,7 +803,7 @@
 				{
 					"name": "XMLRPC Region Server Backup To File",
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{REGION_URL}}:{{REGION_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{
@@ -316,7 +823,7 @@
 				{
 					"name": "XMLRPC Region Server Restore From File",
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{REGION_URL}}:{{REGION_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{
@@ -336,7 +843,7 @@
 				{
 					"name": "XMLRPC Region Server Save OAR File",
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{REGION_URL}}:{{REGION_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{
@@ -356,7 +863,7 @@
 				{
 					"name": "XMLRPC Region Server Load OAR File",
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{REGION_URL}}:{{REGION_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{
@@ -376,7 +883,7 @@
 				{
 					"name": "XMLRPC Region Server Change Parcel Flags",
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{REGION_URL}}:{{REGION_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{
@@ -400,9 +907,160 @@
 			"description": "",
 			"item": [
 				{
+					"name": "XMLRPC Login JWT",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var jsonObject = {};",
+									"",
+									"try {",
+									"    jsonObject = xml2Json(responseBody);",
+									"    ",
+									"    if (jsonObject.hasOwnProperty(\"methodResponse\") && jsonObject.methodResponse.hasOwnProperty(\"params\")) {",
+									"        postman.setEnvironmentVariable(\"rpc_login_key\", jsonObject.methodResponse.params.param.value.struct.member[0].value.string);",
+									"    }",
+									"}",
+									"catch(e) {",
+									"    tests[\"parserr: \" + JSON.stringify(e)] = false;",
+									"    tests[\"data: \" + JSON.stringify(jsonObject)] = false;",
+									"}",
+									"",
+									"tests[\"rpc_login_key: \" + environment.rpc_login_key] = environment.rpc_login_key !== null && environment.rpc_login_key.length > 0;"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"postman.clearEnvironmentVariable(\"rpc_login_key\");"
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{PROTOCOL}}://{{USERSERVER_URL}}:{{USERSERVER_PORT}}/xmlrpc/RemoteAdmin",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "text/xml",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.login_with_token</methodName>\n    <params>\n        <param>\n            <value><string>{{restadmin_jwt_token}}</string></value>\n        </param>\n    </params>\n</methodCall>"
+						},
+						"description": "XMLRPC access point for remote administration.\n"
+					},
+					"response": [
+						{
+							"id": "57dab8fe-5248-4c19-9bef-203317c22123",
+							"name": "ExampleLogin",
+							"originalRequest": {
+								"url": "http://localhost:9991/xmlrpc/RemoteAdmin",
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/xml",
+										"enabled": true,
+										"description": "The mime type of this content"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.login_with_password</methodName>\n    <params>\n        <param>\n            <value><string>user</string></value>\n        </param>\n        <param>\n            <value><string>pass</string></value>\n        </param>\n    </params>\n</methodCall>"
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "xml",
+							"_postman_previewtype": "html",
+							"header": [
+								{
+									"name": "Content-Encoding",
+									"key": "Content-Encoding",
+									"value": "gzip",
+									"description": "The type of encoding used on the data."
+								},
+								{
+									"name": "Content-Length",
+									"key": "Content-Length",
+									"value": "196",
+									"description": "The length of the response body in octets (8-bit bytes)"
+								},
+								{
+									"name": "Content-Type",
+									"key": "Content-Type",
+									"value": "text/xml; charset=utf-8",
+									"description": "The mime type of this content"
+								},
+								{
+									"name": "Date",
+									"key": "Date",
+									"value": "Tue, 05 Jul 2016 05:41:19 GMT",
+									"description": "The date and time that the message was sent"
+								},
+								{
+									"name": "Keep-Alive",
+									"key": "Keep-Alive",
+									"value": "timeout=15,max=100",
+									"description": "Custom header"
+								},
+								{
+									"name": "Server",
+									"key": "Server",
+									"value": "Mono-HTTPAPI/1.0",
+									"description": "A name for the server"
+								}
+							],
+							"cookie": [],
+							"responseTime": 36,
+							"body": "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodResponse><params><param><value><struct><member><name>Value</name><value><string>ef4b81ff-0838-4979-b286-a2f8084c4ff9</string></value></member><member><name>Status</name><value><string>Success</string></value></member></struct></value></param></params></methodResponse>"
+						}
+					]
+				},
+				{
+					"name": "XMLRPC Logout",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"postman.clearEnvironmentVariable(\"rpc_login_key\");"
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{PROTOCOL}}://{{USERSERVER_URL}}:{{USERSERVER_PORT}}/xmlrpc/RemoteAdmin",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "text/xml",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "<?xml version=\"1.0\"?>\n<methodCall>\n    <methodName>session.logout</methodName>\n    <params>\n        <param>\n            <value><string>{{rpc_login_key}}</string></value>\n        </param>\n    </params>\n</methodCall>"
+						},
+						"description": "XMLRPC access point for remote administration.\n"
+					},
+					"response": []
+				},
+				{
 					"name": "XMLRPC User Server Shutdown",
 					"request": {
-						"url": "{{PROTOCOL}}://{{URL}}:{{PORT}}/xmlrpc/RemoteAdmin",
+						"url": "{{PROTOCOL}}://{{USERSERVER_URL}}:{{USERSERVER_PORT}}/xmlrpc/RemoteAdmin",
 						"method": "POST",
 						"header": [
 							{


### PR DESCRIPTION
JWT Certificate path config options, fixups, and docs.

This makes the administrator able to specify the path for the certificates used to verify and create JWTs.  It also updates the docs for the XMLRPC-based remote-admin.