### PR TITLE
Inventory folder fetch no longer follows and includes contents of links

### DIFF
--- a/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
@@ -1045,38 +1045,6 @@ namespace OpenSim.Region.CoreModules.Capabilities
                         {
                             item.SerializeToLLSD(contents);
                             count++; 
-                                
-                            if (item.AssetType == (int)AssetType.LinkFolder)
-                            {
-                                // Add this when we do categories below
-                                linkedFolders.Add(item.AssetID);
-                            }
-                            else if (item.AssetType == (int)AssetType.Link)
-                            {
-                                try 
-                                {
-                                    InventoryItemBase linkedItem = m_checkedStorageProvider.GetItem(m_agentID, item.AssetID, UUID.Zero);
-
-                                    if (linkedItem != null)
-                                    {
-                                        linkedItem.SerializeToLLSD(contents);
-                                    }
-                                    else
-                                    {
-                                        m_log.ErrorFormat(
-                                            "[CAPS/INVENTORY] Failed to resolve link to item {0} for {1}",
-                                            item.AssetID, m_Caps.AgentID);
-                                    }
-                                    // Don't add it to the count. It was accounted for with the link.
-                                    //count++;
-                                }
-                                catch (Exception e)
-                                {
-                                    m_log.ErrorFormat(
-                                        "[CAPS/INVENTORY] Failed to resolve link to item {0} for {1}: {2}",
-                                        item.AssetID, m_Caps.AgentID, e.Message);
-                                }
-                            }
                         } 
                     }
 
@@ -1085,35 +1053,6 @@ namespace OpenSim.Region.CoreModules.Capabilities
                     contents.WriteKey("categories"); //Start array cats
                     contents.WriteStartArray("categories"); //We don't send any folders
 
-                    // If there were linked folders include the folders referenced here
-                    if (linkedFolders.Count > 0)
-                    {
-                        foreach (UUID linkedFolderID in linkedFolders)
-                        {
-                            try
-                            {
-                                InventoryFolderBase linkedFolder = m_checkedStorageProvider.GetFolderAttributes(m_agentID, linkedFolderID);
-                                if (linkedFolder != null)
-                                {
-                                    linkedFolder.SerializeToLLSD(contents);
-                                    // Don't add it to the count.. it was accounted for with the link.
-                                    //count++;
-                                }
-                            }
-                            catch (InventoryObjectMissingException)
-                            {
-                                m_log.ErrorFormat("[CAPS/INVENTORY] Failed to resolve link to folder {0} for {1}",
-                                    linkedFolderID, m_agentID);
-                            }
-                            catch (Exception e)
-                            {
-                                m_log.ErrorFormat(
-                                    "[CAPS/INVENTORY] Failed to resolve link to folder {0} for {1}: {2}",
-                                    linkedFolderID, m_agentID, e);
-                            }
-                        }
-                    }
-                        
                     if (fetchFolders)
                     {
                         foreach (InventorySubFolderBase subFolder in folder.SubFolders)


### PR DESCRIPTION
I noticed that folder contents fetches were actually following and expanding links, both to items and other folders.  I am pretty confident that just retrieving the folder descendants listing should _not_ include the _actual_ items linked to, especially in the case of _folder_ links. 

In both cases, this probably results in both the link _and_ the original being present in the viewer's folder content, which could be particularly troublesome for folders since their parent may not yet even be loaded at the viewer end when we send this subfolder contents down (and inside the folder of another folder other than it's actual parent folder). This change just sends links as links, when filling a folder list, and does not attempt to follow them.

This problem presents itself as unexpected missing inventory item error messages / exception reports trying to follow dead links, even when the viewer is not trying to follow them or do anything with them. 

I've compared the inventory caches from SL and IW and this change seems consistent with those. I've also done some viewer-side testing with the change and found only that the viewer seems very happy with these unfollowed links, correctly using them, or showing them as broken links where the referred-to item has been deleted.  Errors are now only produced when the viewer actually references them, which is protected in most cases but can be visible if the broken link is inside an outfit which is worn.