### PR TITLE
Mantis 948: Parameters passed were reversed from what they should be.

### DIFF
--- a/OpenSimProfile/Modules/OpenProfile.cs
+++ b/OpenSimProfile/Modules/OpenProfile.cs
@@ -175,10 +175,10 @@ namespace OpenSimProfile.Modules.OpenProfile
                 }
 
                 remoteClient.SendAvatarInterestsReply(avatarID,
-                    wantToMask,
-                    wantToText,
                     skillsMask,
                     skillsText,
+                    wantToMask,
+                    wantToText,
                     languagesText);
             }
 


### PR DESCRIPTION
This was just a bit of careless coding (typo) that someone did years ago. The parameters (skills, wants) were reversed on the call (wants, skills) so that they were always displayed backwards from what was saved. Can't believe it took this long to be fixed.  Fixes [Mantis 948](https://bugs.inworldz.com/mantis/view.php?id=948).