### PR TITLE
Background processing

### DIFF
--- a/OpenSim/Framework/Servers/BaseOpenSimServer.cs
+++ b/OpenSim/Framework/Servers/BaseOpenSimServer.cs
@@ -126,9 +126,9 @@ namespace OpenSim.Framework.Servers
 
         protected void HandleConsoleCancelEvent(object sender, ConsoleCancelEventArgs args)
         {
-            System.Console.Write("\nUse the SHUTDOWN command to exit this server cleanly.\nOr press the console close box to abort this server.\n" + m_console.DefaultPrompt + "# ");
-            // Set the Cancel property to true to prevent the process from terminating.
-            args.Cancel = true;
+            // The system may be running without a console prompt and cannot issue SHUTDOWN command
+            // call shutdown on ctrl-c
+            this.Shutdown();
         }
         
         /// <summary>

--- a/OpenSim/Framework/Servers/VersionInfo.cs
+++ b/OpenSim/Framework/Servers/VersionInfo.cs
@@ -30,7 +30,7 @@ using System.Reflection;
 // Using a * for the third number means auto-fill with the # days since 2000. Good for us here.
 // That only leaves us with two in front, so we'll divide the first number by 10.
 // i.e. 9.18.R in the assembly is presented as 0.9.18.R
-[assembly: AssemblyVersion("9.33.*")]
+[assembly: AssemblyVersion("9.32.*")]
 // Do not provide AssemblyFileVersion and it will be kept in sync.
 
 namespace OpenSim

--- a/OpenSim/Grid/GridServer/GridServerBackground.cs
+++ b/OpenSim/Grid/GridServer/GridServerBackground.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) InWorldz Halcyon Developers
  * Copyright (c) Contributors, http://opensimulator.org/
  *
@@ -9,7 +9,7 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the OpenSim Project nor the
+ *     * Neither the name of the OpenSimulator Project nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
  *
@@ -25,55 +25,39 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Net;
-using log4net.Config;
+using System;
+using System.Reflection;
+using System.Threading;
 using log4net;
-using Nini.Config;
 
 namespace OpenSim.Grid.GridServer
 {
-    public static class Program
-    {
-		private static readonly ILog m_log = LogManager.GetLogger("OpenSim.Grid.GridServer");
+	/// <summary>
+	/// Consoleless OpenSimulator GridServer
+	/// </summary>
+	public class GridServerBackground : GridServerBase
+	{
+		private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        public static void Main(string[] args)
-        {
-            ServicePointManager.DefaultConnectionLimit = 12;
+		private ManualResetEvent WorldHasComeToAnEnd = new ManualResetEvent(false);
 
-			m_log.Info ("starting up");
+		public GridServerBackground() : base()
+		{
+		}
 
-            XmlConfigurator.Configure();
+		new public void Work()
+		{
+			WorldHasComeToAnEnd.WaitOne();
+			WorldHasComeToAnEnd.Close();
+		}
 
-			// Add the arguments supplied when running the application to the configuration
-			ArgvConfigSource configSource = new ArgvConfigSource(args);
-
-			configSource.Alias.AddAlias("On", true);
-			configSource.Alias.AddAlias("Off", false);
-			configSource.Alias.AddAlias("True", true);
-			configSource.Alias.AddAlias("False", false);
-			configSource.Alias.AddAlias("Yes", true);
-			configSource.Alias.AddAlias("No", false);
-
-			configSource.AddSwitch("Startup", "background");
-
-			bool background = configSource.Configs["Startup"].GetBoolean("background", false);
-			foreach(string arg in args){
-				if (arg == "--background")
-					background = true;
-			}
-
-           
-			if (background) {
-				m_log.Info ("[GridServer MAIN]: set to background");
-				GridServerBackground app = new GridServerBackground ();
-				app.Startup();
-				app.Work();
-			} else {
-				m_log.Info ("[GridServer MAIN]: set to foreground");
-				GridServerBase app = new GridServerBase();
-				app.Startup();
-				app.Work();
-			}
-        }
-    }
+		/// <summary>
+		/// Performs any last-minute sanity checking and shuts down the region server
+		/// </summary>
+		public override void Shutdown()
+		{
+			WorldHasComeToAnEnd.Set();
+			base.Shutdown();
+		}
+	}
 }

--- a/OpenSim/Grid/GridServer/GridServerBackground.cs
+++ b/OpenSim/Grid/GridServer/GridServerBackground.cs
@@ -37,9 +37,7 @@ namespace OpenSim.Grid.GridServer
 	/// </summary>
 	public class GridServerBackground : GridServerBase
 	{
-		private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-
-		private ManualResetEvent WorldHasComeToAnEnd = new ManualResetEvent(false);
+		private ManualResetEvent Terminating = new ManualResetEvent(false);
 
 		public GridServerBackground() : base()
 		{
@@ -47,8 +45,8 @@ namespace OpenSim.Grid.GridServer
 
 		new public void Work()
 		{
-			WorldHasComeToAnEnd.WaitOne();
-			WorldHasComeToAnEnd.Close();
+			Terminating.WaitOne();
+			Terminating.Close();
 		}
 
 		/// <summary>
@@ -56,7 +54,7 @@ namespace OpenSim.Grid.GridServer
 		/// </summary>
 		public override void Shutdown()
 		{
-			WorldHasComeToAnEnd.Set();
+			Terminating.Set();
 			base.Shutdown();
 		}
 	}

--- a/OpenSim/Grid/GridServer/Program.cs
+++ b/OpenSim/Grid/GridServer/Program.cs
@@ -57,11 +57,6 @@ namespace OpenSim.Grid.GridServer
 			configSource.AddSwitch("Startup", "background");
 
 			bool background = configSource.Configs["Startup"].GetBoolean("background", false);
-			foreach(string arg in args){
-				if (arg == "--background")
-					background = true;
-			}
-
            
 			if (background) {
 				m_log.Info ("[GridServer MAIN]: set to background");

--- a/OpenSim/Grid/MessagingServer/Main.cs
+++ b/OpenSim/Grid/MessagingServer/Main.cs
@@ -36,6 +36,7 @@ using System.Threading.Tasks;
 
 using log4net;
 using log4net.Config;
+using Nini.Config;
 using OpenMetaverse;
 
 using OpenSim.Framework;
@@ -44,6 +45,7 @@ using OpenSim.Framework.Servers;
 using OpenSim.Framework.Servers.HttpServer;
 using OpenSim.Grid.Framework;
 using OpenSim.Grid.MessagingServer.Modules;
+using System.Threading;
 
 namespace OpenSim.Grid.MessagingServer
 {
@@ -61,6 +63,8 @@ namespace OpenSim.Grid.MessagingServer
 
         private UserDataBaseService m_userDataBaseService;
 
+		private ManualResetEvent Terminating = new ManualResetEvent(false);
+
         private InWorldz.RemoteAdmin.RemoteAdmin m_radmin;
 
         public static void Main(string[] args)
@@ -69,12 +73,21 @@ namespace OpenSim.Grid.MessagingServer
 
             XmlConfigurator.Configure();
 
+			ArgvConfigSource configSource = new ArgvConfigSource(args);
+			configSource.Alias.AddAlias("On", true);
+			configSource.Alias.AddAlias("Off", false);
+			configSource.Alias.AddAlias("True", true);
+			configSource.Alias.AddAlias("False", false);
+			configSource.Alias.AddAlias("Yes", true);
+			configSource.Alias.AddAlias("No", false);
+			configSource.AddSwitch("Startup", "background");
+
             m_log.Info("[SERVER]: Launching MessagingServer...");
 
             OpenMessage_Main messageserver = new OpenMessage_Main();
 
             messageserver.Startup();
-            messageserver.Work();
+			messageserver.Work(configSource.Configs["Startup"].GetBoolean("background", false));
         }
 
         public OpenMessage_Main()
@@ -83,14 +96,19 @@ namespace OpenSim.Grid.MessagingServer
             MainConsole.Instance = m_console;
         }
 
-        private void Work()
+		private void Work(bool background)
         {
-            m_console.Notice("Enter help for a list of commands\n");
+			if (background) {
+				Terminating.WaitOne();
+				Terminating.Close();
+			} else {
+				m_console.Notice("Enter help for a list of commands\n");
 
-            while (true)
-            {
-                m_console.Prompt();
-            }
+				while (true)
+				{
+					m_console.Prompt();
+				}
+			}
         }
 
         private void registerWithUserServer()
@@ -237,6 +255,7 @@ namespace OpenSim.Grid.MessagingServer
 
         public override void ShutdownSpecific()
         {
+			Terminating.Set();
             m_userServerModule.deregisterWithUserServer();
         }
 

--- a/OpenSim/Grid/UserServer/Main.cs
+++ b/OpenSim/Grid/UserServer/Main.cs
@@ -49,6 +49,7 @@ using OpenSim.Framework.Servers.HttpServer;
 using OpenSim.Framework.Statistics;
 using OpenSim.Grid.Framework;
 using OpenSim.Grid.UserServer.Modules;
+using System.Threading;
 
 namespace OpenSim.Grid.UserServer
 {
@@ -80,6 +81,8 @@ namespace OpenSim.Grid.UserServer
 
         protected JWTAuthenticator m_jwtAuthenticator;
 
+		private ManualResetEvent Terminating = new ManualResetEvent(false);
+
         private bool m_useJwt;
 
         public static void Main(string[] args)
@@ -89,6 +92,15 @@ namespace OpenSim.Grid.UserServer
             PIDFileManager pidFile = new PIDFileManager();
             XmlConfigurator.Configure();
 
+			ArgvConfigSource configSource = new ArgvConfigSource(args);
+			configSource.Alias.AddAlias("On", true);
+			configSource.Alias.AddAlias("Off", false);
+			configSource.Alias.AddAlias("True", true);
+			configSource.Alias.AddAlias("False", false);
+			configSource.Alias.AddAlias("Yes", true);
+			configSource.Alias.AddAlias("No", false);
+			configSource.AddSwitch("Startup", "background");
+
             m_log.Info("Launching UserServer...");
 
             OpenUser_Main userserver = new OpenUser_Main();
@@ -97,7 +109,7 @@ namespace OpenSim.Grid.UserServer
             userserver.Startup();
 
             pidFile.SetStatus(PIDFileManager.Status.Running);
-            userserver.Work();
+			userserver.Work(configSource.Configs["Startup"].GetBoolean("background", false));
         }
 
         public OpenUser_Main()
@@ -106,14 +118,19 @@ namespace OpenSim.Grid.UserServer
             MainConsole.Instance = m_console;
         }
 
-        public void Work()
+		public void Work(bool background)
         {
-            m_console.Notice("Enter help for a list of commands\n");
+			if (background) {
+				Terminating.WaitOne();
+				Terminating.Close();
+			} else {
+				m_console.Notice("Enter help for a list of commands\n");
 
-            while (true)
-            {
-                m_console.Prompt();
-            }
+				while (true)
+				{
+					m_console.Prompt();
+				}
+			}
         }
 
         protected override void StartupSpecific()
@@ -315,6 +332,7 @@ namespace OpenSim.Grid.UserServer
 
         public override void ShutdownSpecific()
         {
+			Terminating.Set();
             m_eventDispatcher.Close();
         }
 

--- a/prebuild.xml
+++ b/prebuild.xml
@@ -877,6 +877,7 @@
       <Reference name="OpenSim.Data.MySQL"/>
       <Reference name="OpenSim.Grid.Framework"/>
       <Reference name="InWorldz.RemoteAdmin"/>
+      <Reference name="Nini" path="../../bin/"/>
 
       <Files>
         <Match pattern="*.cs" recurse="true"/>

--- a/prebuild.xml
+++ b/prebuild.xml
@@ -1062,6 +1062,7 @@
       <Reference name="OpenSim.Grid.Framework"/>
       <Reference name="OpenSim.Grid.MessagingServer.Modules"/>
       <Reference name="InWorldz.RemoteAdmin"/>
+      <Reference name="Nini" path="../../bin/"/>
 
       <Reference name="OpenMetaverseTypes" path="../../../bin/"/>
       <Reference name="OpenMetaverse" path="../../../bin/"/>


### PR DESCRIPTION
Adding functionality to enable the halcyon grid services to run smoothly in docker containers.  Current Grid Service code will sit at 100% CPU usage when idle.  I traced this to the interactive console, which cannot block appropriately when launched as a docker service.  By adding the "--background true" CLI option that Halcyon already has, the processes do not prompt and idle at 0% CPU.

Experimenting with background modes in the console, I discovered that the ctrl-c does not exist the console.  It instead requests the users to enter SHUTDOWN to safely exit the process, or force-terminate the process.  When run with the 'background' switch set, the user can only forcefully abort the process.  To support non-interactive consoles, and to align with normal ctrl-c to exit console applications on most operating systems, ctrl-c in the console now safely exits the process by calling shutdown.

This pull request has the following changes:

1. Changes the behavior of ctrl-c to the console that is used for Halcyon, and the grid services.  Entering ctrl-c while in a console would print a message asking the user to enter SHUTDOWN to exit the process, or close the terminal to abort the process.  

2. Added a '--background true' command line argument to the GridServer, UserServer, and MessagingServer so they can be started in 'background mode' similar to Halcyon.exe.

