### PR TITLE
Some tweaks to region limit checks to help debug

### DIFF
--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -4258,21 +4258,25 @@ namespace OpenSim.Region.Framework.Scenes
                 return false;
             }
 
-            if (this.m_sceneGraph.GetRootAgentCount() + 1 > m_maxRootAgents)
+            int currentRootAgents = SceneGraph.GetRootAgentCount();
+
+            // Check hard limit on region.
+            if (currentRootAgents >= m_maxRootAgents)
             {
-                m_log.WarnFormat("[SCENE]: User {0} ({1}) was denied access to the region because it was full", agentId, userName);
-                reason = "Region is full";
+                m_log.WarnFormat("[SCENE]: User {0} ({1}) was denied access to the region because it was full ({2})", agentId, userName, currentRootAgents);
+                reason = String.Format("Region is full ({0} of {1})", currentRootAgents, m_maxRootAgents);
                 return false;
             }
 
-            if (SceneGraph.GetRootAgentCount() + 1 > RegionInfo.RegionSettings.AgentLimit)
+            // Check estate soft limit on region.
+            if (currentRootAgents >= RegionInfo.RegionSettings.AgentLimit)
             {
                 if (RegionInfo.EstateSettings.HasAccess(agentId) == false)
                 {
                     m_log.WarnFormat(
-                        "[SCENE]: User {0} ({1}) was denied access to the region because agent limit was reached",
-                        agentId, userName);
-                    reason = "Region is full";
+                        "[SCENE]: User {0} ({1}) was denied access to the region because estate limit ({2} of {3}) was reached",
+                        agentId, userName, currentRootAgents, RegionInfo.RegionSettings.AgentLimit);
+                    reason = "Region estate limit has been reached";
                     return false;
                 }
             }


### PR DESCRIPTION
... and to help the end user better understand what is wrong.

Following up on reports and observations that imply the count of active root agents is getting messed up, doesn't match the actual number of agents in the region. Seen during one of the GT shows earlier in the year.  

No real functional changes here, just an incremental change to help diagnose what's going on if we get similar reports.  This PR only changes the cosmetics of the messages and is slightly more efficient code:
- Factored the SceneGraph.GetRootAgentCount() and removed the need for the +1 math.
- Recording of hard and soft limits in the log show current usage and limit.
- User sees a different message for hard and soft limits.
- Hard limit reached shows user the current usage and limit values.
- Soft limit just reports "Region estate limit has been reached" for the limit, since estate staff may temporarily set the limit very small to disable additional agent entry.