### PR TITLE
Mantis 760 changed events, plus region agent limit messages.

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -1746,7 +1746,7 @@ namespace InWorldz.Phlox.Engine
                 texcolor.G = Util.Clip((float)color.Y, 0.0f, 1.0f);
                 texcolor.B = Util.Clip((float)color.Z, 0.0f, 1.0f);
                 tex.FaceTextures[face].RGBA = texcolor;
-                part.UpdateTexture(tex);
+                part.UpdateTexture(tex, Changed.COLOR);
                 return;
             }
             else if (face == ScriptBaseClass.ALL_SIDES)
@@ -1767,7 +1767,7 @@ namespace InWorldz.Phlox.Engine
                     texcolor.B = Util.Clip((float)color.Z, 0.0f, 1.0f);
                     tex.DefaultTexture.RGBA = texcolor;
                 }
-                part.UpdateTexture(tex);
+                part.UpdateTexture(tex, Changed.COLOR);
                 return;
             }
         }
@@ -1784,7 +1784,7 @@ namespace InWorldz.Phlox.Engine
             {
                 tex.CreateFace((uint)face);
                 tex.FaceTextures[face].TexMapType = textype;
-                part.UpdateTexture(tex);
+                part.UpdateTexture(tex, 0); // no changed notification for this
                 return;
             }
             else if (face == ScriptBaseClass.ALL_SIDES)
@@ -1797,7 +1797,7 @@ namespace InWorldz.Phlox.Engine
                     }
                     tex.DefaultTexture.TexMapType = textype;
                 }
-                part.UpdateTexture(tex);
+                part.UpdateTexture(tex, 0); // no changed notification for this
                 return;
             }
         }
@@ -1946,7 +1946,7 @@ namespace InWorldz.Phlox.Engine
                 texcolor = tex.CreateFace((uint)face).RGBA;
                 texcolor.A = Util.Clip((float)alpha, 0.0f, 1.0f);
                 tex.FaceTextures[face].RGBA = texcolor;
-                part.UpdateTexture(tex);
+                part.UpdateTexture(tex, Changed.COLOR);
                 return;
             }
             else if (face == ScriptBaseClass.ALL_SIDES)
@@ -1963,7 +1963,7 @@ namespace InWorldz.Phlox.Engine
                 texcolor = tex.DefaultTexture.RGBA;
                 texcolor.A = Util.Clip((float)alpha, 0.0f, 1.0f);
                 tex.DefaultTexture.RGBA = texcolor;
-                part.UpdateTexture(tex);
+                part.UpdateTexture(tex, Changed.COLOR);
                 return;
             }
         }

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -4258,21 +4258,25 @@ namespace OpenSim.Region.Framework.Scenes
                 return false;
             }
 
-            if (this.m_sceneGraph.GetRootAgentCount() + 1 > m_maxRootAgents)
+            int currentRootAgents = SceneGraph.GetRootAgentCount();
+
+            // Check hard limit on region.
+            if (currentRootAgents >= m_maxRootAgents)
             {
-                m_log.WarnFormat("[SCENE]: User {0} ({1}) was denied access to the region because it was full", agentId, userName);
-                reason = "Region is full";
+                m_log.WarnFormat("[SCENE]: User {0} ({1}) was denied access to the region because it was full ({2})", agentId, userName, currentRootAgents);
+                reason = String.Format("Region is full ({0} of {1})", currentRootAgents, m_maxRootAgents);
                 return false;
             }
 
-            if (SceneGraph.GetRootAgentCount() + 1 > RegionInfo.RegionSettings.AgentLimit)
+            // Check estate soft limit on region.
+            if (currentRootAgents >= RegionInfo.RegionSettings.AgentLimit)
             {
                 if (RegionInfo.EstateSettings.HasAccess(agentId) == false)
                 {
                     m_log.WarnFormat(
-                        "[SCENE]: User {0} ({1}) was denied access to the region because agent limit was reached",
-                        agentId, userName);
-                    reason = "Region is full";
+                        "[SCENE]: User {0} ({1}) was denied access to the region because estate limit ({2} of {3}) was reached",
+                        agentId, userName, currentRootAgents, RegionInfo.RegionSettings.AgentLimit);
+                    reason = "Region estate limit has been reached";
                     return false;
                 }
             }

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -4794,14 +4794,20 @@ namespace OpenSim.Region.Framework.Scenes
         /// This also nulls the m_textureEntryBytes (blob) and TextureEntryBytes
         /// until someone calls them.
         /// </summary>
-        /// <param name="tex"></param>
-        public void UpdateTexture(Primitive.TextureEntry tex)
+        /// <param name="tex">TextureEntry</param>
+        /// <param name="change">changed event to send</param>
+        public void UpdateTexture(Primitive.TextureEntry tex, Changed change)
         {
             m_shape.Textures = tex;
 
-            TriggerScriptChangedEvent(Changed.TEXTURE);
+            if (change != 0)
+                TriggerScriptChangedEvent(change);
             ParentGroup.HasGroupChanged = true;
             ScheduleFullUpdate(PrimUpdateFlags.Textures);
+        }
+        public void UpdateTexture(Primitive.TextureEntry tex)
+        {
+            UpdateTexture(tex, Changed.TEXTURE);
         }
 
         /// <summary>

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -4785,6 +4785,7 @@ namespace OpenSim.Region.Framework.Scenes
             if (ParentGroup.RootPart != this)
                 ParentGroup.RootPart.Rezzed = DateTime.Now;
 
+            TriggerScriptChangedEvent(Changed.SHAPE);
             ParentGroup.HasGroupChanged = true;
             ScheduleFullUpdate(PrimUpdateFlags.Shape);
         }


### PR DESCRIPTION
1. Fixes for Mantis 760. Changes to match SL object Edit form changes:
- Color changes now fire CHANGED_COLOR instead of CHANGED_TEXTURE.
- Alpha changes now fire CHANGED_COLOR instead of CHANGED_TEXTURE.
- Texgen mode (e.g. planar vs default) changes no longer fire an event.
- Changes to prim shape now correctly trigger a CHANGED_SHAPE event for both scripted and manual edit changes.
**Note:** SL does not send any changed events AT ALL for _scripted_ changes. Attempts to fix this problem broke some existing content in SL. However, InWorldz is already sending the changed events for scripted changes, so the same concern does not apply here. See [SL JIRA report SVC-914](https://jira.secondlife.com/browse/SVC-914) for more on that issue there (summary in final comment at bottom).

2. Some tweaks to region limit checks to help debug (and for the user to better understand)
- Factored the SceneGraph.GetRootAgentCount() and removed the need for the +1 math.
- Recording of hard and soft limits in the log show current usage and limit.
- User sees a different message for hard and soft limits.
- Hard limit reached shows user the current usage and limit values.
- Soft limit just reports "Region estate limit has been reached" for the limit, since estate staff may temporarily set the limit very small to disable additional agent entry.
