### PR TITLE
Fixed a null reference exception seen during Astoria's appearance updates.

### DIFF
--- a/OpenSim/Framework/Communications/Cache/CachedUserInfo.cs
+++ b/OpenSim/Framework/Communications/Cache/CachedUserInfo.cs
@@ -531,6 +531,12 @@ namespace OpenSim.Framework.Communications.Cache
                 baseItem = this.FindItem(baseItem.AssetID);
             }
 
+            if (baseItem == null)
+            {
+                //broken link cannot be followed
+                return null;
+            }
+
             if (baseItem.AssetType == (int)AssetType.Link)
             {
                 //recursion limit was hit


### PR DESCRIPTION
```
2017-04-19 09:46:01,254 [STP SmartThreadPool Thread #78] ERROR OpenSim.Region.ClientStack.LindenUDP.LLClientView - [CLIENT]: Job threw an exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at OpenSim.Framework.Communications.Cache.CachedUserInfo.ResolveLink(InventoryItemBase baseItem) in D:\Beta_Desktop\Halcyon\Source\OpenSim\Framework\Communications\Cache\CachedUserInfo.cs:line 534
   at OpenSim.Region.CoreModules.Avatar.AvatarFactory.AvatarFactoryModule.SetAppearanceAssets(CachedUserInfo profile, List`1& wearables, IClientAPI clientView) in D:\Beta_Desktop\Halcyon\Source\OpenSim\Region\CoreModules\Avatar\AvatarFactory\AvatarFactoryModule.cs:line 516
   at OpenSim.Region.CoreModules.Avatar.AvatarFactory.AvatarFactoryModule.AvatarIsWearing(Object sender, AvatarWearingArgs e) in D:\Beta_Desktop\Halcyon\Source\OpenSim\Region\CoreModules\Avatar\AvatarFactory\AvatarFactoryModule.cs:line 646
   at OpenSim.Region.ClientStack.LindenUDP.LLClientView.HandlerAgentIsNowWearing(IClientAPI sender, Packet Pack) in D:\Beta_Desktop\Halcyon\Source\OpenSim\Region\ClientStack\LindenUDP\LLClientView.cs:line 8121
```