### PR TITLE
Fixed presence error caused by MySQL exception on LogoutUsers() at region shutdown

### DIFF
--- a/OpenSim/Data/MySQL/MySQLUserData.cs
+++ b/OpenSim/Data/MySQL/MySQLUserData.cs
@@ -1838,7 +1838,7 @@ namespace OpenSim.Data.MySQL
         {
             Dictionary<string, object> param = new Dictionary<string, object>();
             param["?regionID"] = regionID.ToString();
-            param["?logoutTime"] = DateTime.Now;
+            param["?logoutTime"] = Util.UnixTimeSinceEpoch();
 
             try
             {


### PR DESCRIPTION
Fixed `MySqlException: Data truncated for column 'logoutTime' at row 1` which caused `MySQLUserData.LogoutUsers()` to fail to update the `agents` table on a region shutdown.  The problem was basically trying to stuff a `DateTime` into an `int(11)` SQL field, which caused an SQL overflow exception.