### PR TITLE
Delay the SceneView updates until viewer established in region.

### DIFF
--- a/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
+++ b/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
@@ -375,8 +375,12 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
                 return;
             if (avatar.IsChildAgent)
                 return;
+            // uint inRegion = (uint)avatar.AgentInRegion;
             if (!avatar.IsFullyInRegion)
+            {
+                // m_log.WarnFormat("[SendPresenceToUs]: AgentInRegion={0:x2}",inRegion);
                 return; // don't send to them yet, they aren't ready
+            }
             if (avatar.IsDeleted)
                 return; // don't send them, they're on their way outta here
 
@@ -712,8 +716,12 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
 
             if (m_presence.IsInTransit)
                 return; // disable prim updates during a crossing, but leave them queued for after transition
+            // uint inRegion = (uint)m_presence.AgentInRegion;
             if (!m_presence.IsChildAgent && !m_presence.IsFullyInRegion) 
-                return;
+            {
+                // m_log.WarnFormat("[SendPrimUpdates]: AgentInRegion={0:x2}",inRegion);
+                return; // don't send to them yet, they aren't ready
+            }
 
             m_perfMonMS = Environment.TickCount;
 

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -4605,7 +4605,7 @@ namespace OpenSim.Region.Framework.Scenes
             if ((sp != null) && (!sp.IsChildAgent))
             {
                 sp.IsChildAgent = true;
-                sp.IsFullyInRegion = false;
+                sp.AgentInRegion = AgentInRegionFlags.None;
                 return sp.CopyAgent(out agent);
             }
 


### PR DESCRIPTION
Split IsFullyInRegion into multiple separate completion flags, causes agent and object culling agent/prim updates from SceneView to wait until the agent is fully in the region, initial avatar data sent, anim pack sent, and SP move from child agent to root agent is fully complete.

This is likely to resolve a lot of the issues with attachments or prims in the region missing, animations not being active on login/teleport, 0,0,0 agent position on region entry being assumed (thus incorrect viewer radar messages and lots of visual glitches) and seems to resolve a lot of the broken link cases.