### PR TITLE
Restore and tweak original duplicate-on-link implementation

### DIFF
--- a/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
@@ -1045,6 +1045,38 @@ namespace OpenSim.Region.CoreModules.Capabilities
                         {
                             item.SerializeToLLSD(contents);
                             count++; 
+                                
+                            if (item.AssetType == (int)AssetType.LinkFolder)
+                            {
+                                // Add this when we do categories below
+                                linkedFolders.Add(item.AssetID);
+                            }
+                            else if (item.AssetType == (int)AssetType.Link)
+                            {
+                                try 
+                                {
+                                    InventoryItemBase linkedItem = m_checkedStorageProvider.GetItem(m_agentID, item.AssetID, UUID.Zero);
+
+                                    if (linkedItem != null)
+                                    {
+                                        linkedItem.SerializeToLLSD(contents);
+                                    }
+                                    else
+                                    {
+                                        m_log.ErrorFormat(
+                                            "[CAPS/INVENTORY] Failed to resolve link to item {0} for {1}",
+                                            item.AssetID, m_Caps.AgentID);
+                                    }
+                                    // Don't add it to the count. It was accounted for with the link.
+                                    //count++;
+                                }
+                                catch (Exception e)
+                                {
+                                    m_log.ErrorFormat(
+                                        "[CAPS/INVENTORY] Failed to resolve link to item {0} for {1}: {2}",
+                                        item.AssetID, m_Caps.AgentID, e.Message);
+                                }
+                            }
                         } 
                     }
 
@@ -1053,6 +1085,35 @@ namespace OpenSim.Region.CoreModules.Capabilities
                     contents.WriteKey("categories"); //Start array cats
                     contents.WriteStartArray("categories"); //We don't send any folders
 
+                    // If there were linked folders include the folders referenced here
+                    if (linkedFolders.Count > 0)
+                    {
+                        foreach (UUID linkedFolderID in linkedFolders)
+                        {
+                            try
+                            {
+                                InventoryFolderBase linkedFolder = m_checkedStorageProvider.GetFolderAttributes(m_agentID, linkedFolderID);
+                                if (linkedFolder != null)
+                                {
+                                    linkedFolder.SerializeToLLSD(contents);
+                                    // Don't add it to the count.. it was accounted for with the link.
+                                    //count++;
+                                }
+                            }
+                            catch (InventoryObjectMissingException)
+                            {
+                                m_log.ErrorFormat("[CAPS/INVENTORY] Failed to resolve link to folder {0} for {1}",
+                                    linkedFolderID, m_agentID);
+                            }
+                            catch (Exception e)
+                            {
+                                m_log.ErrorFormat(
+                                    "[CAPS/INVENTORY] Failed to resolve link to folder {0} for {1}: {2}",
+                                    linkedFolderID, m_agentID, e);
+                            }
+                        }
+                    }
+                        
                     if (fetchFolders)
                     {
                         foreach (InventorySubFolderBase subFolder in folder.SubFolders)

--- a/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
@@ -1043,9 +1043,6 @@ namespace OpenSim.Region.CoreModules.Capabilities
                     {
                         foreach (InventoryItemBase item in folder.Items)
                         {
-                            item.SerializeToLLSD(contents);
-                            count++; 
-                                
                             if (item.AssetType == (int)AssetType.LinkFolder)
                             {
                                 // Add this when we do categories below
@@ -1077,6 +1074,12 @@ namespace OpenSim.Region.CoreModules.Capabilities
                                         item.AssetID, m_Caps.AgentID, e.Message);
                                 }
                             }
+
+                            // Now that we've sent the original to the viewer, and it has created a dummy 
+                            // node for the parent if it's new to the viewer, we can send the actual link
+                            // to the item or folder it is now aware of.
+                            item.SerializeToLLSD(contents);
+                            count++; 
                         } 
                     }
 


### PR DESCRIPTION
The original inventory link handling -- to send the inventory link as well as the original -- was actually very close.  The only problem with it was that it sent the link and then the original, so that when the viewer received the link, it reported a lot of broken links and other problems in the viewer log.  These were not seen at the user level, but while attempting to fix some of the other problems (now fixed elsewhere), of course the link-related errors stood out as a problem.  However, with those other problems fixed, and broken links still showing, I reexamined the original implementation, along with the viewer code.

The viewer code shows a complete lack of resolving (forward) links once the inventory completes.  It does not reexamine broken links after receiving new inventory folder contents.  However, it does have some pretty good flexibility in receiving inventory items. Results of my viewer observations:
1. When requesting the contents of a folder, the server is allowed to respond with something in a _different_ folder, mixed with the requested one.  (i.e. items with different parent IDs)
2. The server is allowed to send the same item (or folder) more than once.  Receipt of an item a second time merely replaces the one it already had.
3. When receiving an item that does not live in the current (requested) folder, if the parent ID is unknown, the viewer will create a dummy stub node for that folder.

Points 1 means that it is safe to send the duplicate items with the links to them, as long as the correct (different) parent ID is specified with the original.  And if that parent is not yet known, point 3 means that will still be allowed, at least until inventory is fully loaded.  Point 2 means that when the server gets to the original, it's perfectly fine to send it again, or as many times for as many copies of links are in the inventory.

This PR reverts the original change that I made to remove the duplicates.  The only problem with the original code is that the original must be sent before the link, so the second commit in this PR makes that tweak.

When combined with the other fixes, the viewer logs are much much cleaner, and the user-level functionality seems much more reliable.  (This should mean that we've fixed the problems Astoria and others were having.)
