### PR TITLE
Separate CanExitRegion checks from IsFullyInRegion

### DIFF
--- a/OpenSim/Region/Framework/AvatarTransit/SendStates/TransitBeginState.cs
+++ b/OpenSim/Region/Framework/AvatarTransit/SendStates/TransitBeginState.cs
@@ -77,7 +77,7 @@ namespace OpenSim.Region.Framework.AvatarTransit.SendStates
             }
 
             //assert that this avatar is ready to leave the region
-            if (!_avatar.ScenePresence.IsFullyInRegion)
+            if (!_avatar.ScenePresence.CanExitRegion)
             {
 //                _avatar.ScenePresence.ControllingClient.SendAlertMessage("Can not move to a new region, until established in the current region");
                 throw new InvalidOperationException("An avatar can not begin transition to a new region until established in the current region");

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2776,7 +2776,7 @@ namespace OpenSim.Region.Framework.Scenes
             }
 
             //assert that this avatar is ready to leave the region
-            if (!avatar.IsFullyInRegion)
+            if (!avatar.CanExitRegion)
             {
                 result = "Can not move to a new region, until established in the current region";
                 return false;

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -781,7 +781,7 @@ namespace OpenSim.Region.Framework.Scenes
             //still have connections establishing, fail the crossing and let them establish
             this.ForEachSittingAvatar(delegate (ScenePresence avatar)
             {
-                if (!avatar.IsFullyInRegion)
+                if (!avatar.CanExitRegion)
                 {
                     // avatar.ControllingClient.SendAlertMessage("Can not move to a new region, still entering this one");
                     ForcePositionInRegion();

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -4045,6 +4045,8 @@ namespace OpenSim.Region.Framework.Scenes
             CopyFrom(cAgentData);
         }
 
+        private static Vector3 NO_POSITION = new Vector3(-1, -1, -1);
+        private Vector3 oldPos = NO_POSITION;
         /// <summary>
         /// This updates important decision making data about a child agent
         /// The main purpose is to figure out what objects to send to a child agent that's in a neighboring region
@@ -4069,10 +4071,12 @@ namespace OpenSim.Region.Framework.Scenes
                 m_log.Info("[SCENE PRESENCE]: ChildAgentPositionUpdate while in transit - ignored.");
                 return;
             }
-            if (cAgentData.Position != new Vector3(-1, -1, -1)) // UGH!!
+            if (cAgentData.Position.CompareTo(NO_POSITION) == 0) // UGH!!
             {
                 lock (m_posInfo)
                 {
+                    // if (cAgentData.Position.CompareTo(m_posInfo.m_pos) != 0)
+                    //    m_log.Warn("[SCENE PRESENCE]: >>> ChildAgentPositionUpdate (" + rRegionX + "," + rRegionY + ") at " + cAgentData.Position.ToString());
                     if (m_posInfo.Parent != null)
                     {
                         m_log.InfoFormat("[SCENE PRESENCE]: ChildAgentPositionUpdate move to {0} refused for agent already sitting at {1}.",

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -84,8 +84,9 @@ namespace OpenSim.Region.Framework.Scenes
         CompleteMovementReceived = 1,
         FetchedProfile = 2,
         InitialDataSent = 4,
-        MovementComplete = 8,
-        FullyInRegion = CompleteMovementReceived|FetchedProfile|InitialDataSent|MovementComplete
+        ParcelInfoSent = 8,
+        CanExitRegion = CompleteMovementReceived|FetchedProfile|InitialDataSent,
+        FullyInRegion = CompleteMovementReceived|FetchedProfile|InitialDataSent|ParcelInfoSent
     }
 
     public class ScenePresence : EntityBase
@@ -908,6 +909,10 @@ namespace OpenSim.Region.Framework.Scenes
         {
             get { return m_AgentInRegionFlags == AgentInRegionFlags.FullyInRegion; }
         }
+        public bool CanExitRegion
+        {
+            get { return m_AgentInRegionFlags == AgentInRegionFlags.CanExitRegion; }
+        }
 
         public bool IsInTransit
         {
@@ -1590,7 +1595,7 @@ namespace OpenSim.Region.Framework.Scenes
 
                     Thread.Sleep(250);
                     m_scene.LandChannel.RefreshParcelInfo(m_controllingClient, true);
-                    this.AgentInRegion |= AgentInRegionFlags.MovementComplete;
+                    this.AgentInRegion |= AgentInRegionFlags.ParcelInfoSent;
                 });
             }
             finally


### PR DESCRIPTION
Avoids any performance impact on crossings for recent avatar IsFullyInRegion check changes, while preserving the avatar/object culling/updates benefits to an avatar entering a region.