### PR TITLE
Two changes missed from #373

### DIFF
--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -85,8 +85,9 @@ namespace OpenSim.Region.Framework.Scenes
         FetchedProfile = 2,
         InitialDataSent = 4,
         ParcelInfoSent = 8,
-        CanExitRegion = CompleteMovementReceived|FetchedProfile|InitialDataSent,
-        FullyInRegion = CompleteMovementReceived|FetchedProfile|InitialDataSent|ParcelInfoSent
+        CanExitRegion = CompleteMovementReceived,   // don't care much about this region if leaving
+        // FullyInRegion doesn't need parcel info to start sending updates, especially with 250ms delay
+        FullyInRegion = CompleteMovementReceived|FetchedProfile|InitialDataSent
     }
 
     public class ScenePresence : EntityBase


### PR DESCRIPTION
These were intended to be part 2 of the previous can-exit-region changes meant for performance compatibility with previous releases:
- CanExitRegion only needs CompleteMovementReceived in order to allow exit (as in .32)
- FullyInRegion (updates support) does not need ParcelInfoSent in order to start (avoids 250ms delay).