### PR TITLE
Doh. CanExitRegion can't test for == or it won't work when there are more bits.

### DIFF
--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -908,11 +908,11 @@ namespace OpenSim.Region.Framework.Scenes
         }
         public bool IsFullyInRegion
         {
-            get { return m_AgentInRegionFlags == AgentInRegionFlags.FullyInRegion; }
+            get { return (m_AgentInRegionFlags & AgentInRegionFlags.FullyInRegion) == AgentInRegionFlags.FullyInRegion; }
         }
         public bool CanExitRegion
         {
-            get { return m_AgentInRegionFlags == AgentInRegionFlags.CanExitRegion; }
+            get { return (m_AgentInRegionFlags & AgentInRegionFlags.CanExitRegion) == AgentInRegionFlags.CanExitRegion; }
         }
 
         public bool IsInTransit


### PR DESCRIPTION
Fixed the logic of the bit-wise tests to support bit subsets.