### PR TITLE
Release v0.9.34.6334

### DIFF
--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -83,11 +83,11 @@ namespace OpenSim.Region.Framework.Scenes
         None = 0,
         CompleteMovementReceived = 1,
         FetchedProfile = 2,
-        InitialDataSent = 4,
+        InitialDataReady = 4,
         ParcelInfoSent = 8,
         CanExitRegion = CompleteMovementReceived,   // don't care much about this region if leaving
         // FullyInRegion doesn't need parcel info to start sending updates, especially with 250ms delay
-        FullyInRegion = CompleteMovementReceived|FetchedProfile|InitialDataSent
+        FullyInRegion = CompleteMovementReceived|FetchedProfile|InitialDataReady
     }
 
     public class ScenePresence : EntityBase
@@ -1617,8 +1617,8 @@ namespace OpenSim.Region.Framework.Scenes
 
             if (!IsBot)
                 SendAvatarData(ControllingClient, true);
+            this.AgentInRegion |= AgentInRegionFlags.InitialDataReady;
             SceneView.SendInitialFullUpdateToAllClients();
-            this.AgentInRegion |= AgentInRegionFlags.InitialDataSent;
 
             SendAnimPack();
         }
@@ -4077,12 +4077,12 @@ namespace OpenSim.Region.Framework.Scenes
                 m_log.Info("[SCENE PRESENCE]: ChildAgentPositionUpdate while in transit - ignored.");
                 return;
             }
-            if (cAgentData.Position.CompareTo(NO_POSITION) == 0) // UGH!!
+            if (cAgentData.Position != NO_POSITION) // if valid, use it.
             {
                 lock (m_posInfo)
                 {
-                    // if (cAgentData.Position.CompareTo(m_posInfo.m_pos) != 0)
-                    //    m_log.Warn("[SCENE PRESENCE]: >>> ChildAgentPositionUpdate (" + rRegionX + "," + rRegionY + ") at " + cAgentData.Position.ToString());
+                    if (cAgentData.Position.CompareTo(m_posInfo.m_pos) != 0)
+                        m_log.Warn("[SCENE PRESENCE]: >>> ChildAgentPositionUpdate (" + rRegionX + "," + rRegionY + ") at " + cAgentData.Position.ToString());
                     if (m_posInfo.Parent != null)
                     {
                         m_log.InfoFormat("[SCENE PRESENCE]: ChildAgentPositionUpdate move to {0} refused for agent already sitting at {1}.",

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -4082,8 +4082,8 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 lock (m_posInfo)
                 {
-                    if (cAgentData.Position.CompareTo(m_posInfo.m_pos) != 0)
-                        m_log.Warn("[SCENE PRESENCE]: >>> ChildAgentPositionUpdate (" + rRegionX + "," + rRegionY + ") at " + cAgentData.Position.ToString());
+                    // if (cAgentData.Position.CompareTo(m_posInfo.m_pos) != 0)
+                    //    m_log.Warn("[SCENE PRESENCE]: >>> ChildAgentPositionUpdate (" + rRegionX + "," + rRegionY + ") at " + cAgentData.Position.ToString());
                     if (m_posInfo.Parent != null)
                     {
                         m_log.InfoFormat("[SCENE PRESENCE]: ChildAgentPositionUpdate move to {0} refused for agent already sitting at {1}.",

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -3614,7 +3614,7 @@ namespace OpenSim.Region.Framework.Scenes
             if (m_isChildAgent)
                 return;
             // this should be sent when the initial data is also sent, which matches when culling is ready to send (IsFullyInRegion).
-            if (this.IsFullyInRegion)
+            if (!this.IsFullyInRegion)
             {
 //                m_log.WarnFormat("[SCENE PRESENCE]: NOT sending anim pack to {0}: avatar not yet in region.", this.Name);
                 return;

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -3613,7 +3613,8 @@ namespace OpenSim.Region.Framework.Scenes
         {
             if (m_isChildAgent)
                 return;
-            if ((this.AgentInRegion & AgentInRegionFlags.CompleteMovementReceived) != AgentInRegionFlags.CompleteMovementReceived)
+            // this should be sent when the initial data is also sent, which matches when culling is ready to send (IsFullyInRegion).
+            if (this.IsFullyInRegion)
             {
 //                m_log.WarnFormat("[SCENE PRESENCE]: NOT sending anim pack to {0}: avatar not yet in region.", this.Name);
                 return;


### PR DESCRIPTION
Fixed two regressions in avatar position and a possible one in anim packs:
- avatars not sent on login until avatar movement or camera changes (`InitialDataSent` needed to be set _before_ sent, so now it's `InitialDataReady`)
- child agent update `NO_POSITION` test got inverted in the "nothing" change. Brain fart, got the logic in the `==` and `!=` backwards in the conversion to `CompareTo`. Scrap that, it's harder to read anyway.
- `SendAnimPack` now needs the same agent in region flags as sending the initial data. Avoids allowing anim pack to be sent before the initial avatar data.  Restored the old code there.