### PR TITLE
Culling fix for missing prims after leaving draw distance and returning.

### DIFF
--- a/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
+++ b/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
@@ -788,12 +788,26 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
                     {
                         if (m_updateTimes.ContainsKey(part.LocalId))
                         {
-                            m_updateTimes.Remove(part.LocalId);
                             sendKill = true;
+                            // If we are going to send a kill, it is for the complete object.
+                            // We are telling the viewer to nuke everything it knows about ALL of 
+                            // the prims, not just the child prim. So we need to remove ALL of the 
+                            // prims from m_updateTimes before continuing.
+                            IReadOnlyCollection<SceneObjectPart> sogPrims = part.ParentGroup.GetParts();
+                            foreach (SceneObjectPart prim in sogPrims)
+                            {
+                                if (m_updateTimes.ContainsKey(prim.LocalId))
+                                {
+                                    m_updateTimes.Remove(prim.LocalId);
+                                }
+                            }
                         }
                     }
 
                     //Only send the kill object packet if we have seen this object
+                    //Note: I'm not sure we should be sending a kill at all in this case. -Jim
+                    //      The viewer has already hidden the object if outside DD, and the
+                    //      KillObject causes the viewer to discard its cache of the objects.
                     if (sendKill)
                         m_presence.ControllingClient.SendNonPermanentKillObject(m_presence.Scene.RegionInfo.RegionHandle,
                             part.ParentGroup.RootPart.LocalId);


### PR DESCRIPTION
This should fix [Mantis 3298](https://bugs.inworldz.com/mantis/view.php?id=3298) and other cases like it.