### PR TITLE
PID Files

### DIFF
--- a/InWorldz/Halcyon/Application.cs
+++ b/InWorldz/Halcyon/Application.cs
@@ -72,8 +72,12 @@ namespace OpenSim
             ServicePointManager.DefaultConnectionLimit = 12;
 
             // Add the arguments supplied when running the application to the configuration
-            ArgvConfigSource configSource = new ArgvConfigSource(args);
+            var configSource = new ArgvConfigSource(args);
 
+            configSource.AddSwitch("Startup", "pidfile");
+            var pidFile = new PIDFileManager(configSource.Configs["Startup"].GetString("pidfile", string.Empty));
+
+            pidFile.SetStatus(PIDFileManager.Status.Starting);
             // Configure Log4Net
             configSource.AddSwitch("Startup", "logconfig");
             string logConfigFile = configSource.Configs["Startup"].GetString("logconfig", String.Empty);
@@ -136,6 +140,7 @@ namespace OpenSim
             if (background)
             {
                 m_sim = new OpenSimBackground(configSource);
+                pidFile.SetStatus(PIDFileManager.Status.Running);
                 m_sim.Startup();
             }
             else
@@ -144,6 +149,7 @@ namespace OpenSim
                           
                 m_sim.Startup();
 
+                pidFile.SetStatus(PIDFileManager.Status.Running);
                 while (true)
                 {
                     try

--- a/OpenSim/Grid/GridServer/Program.cs
+++ b/OpenSim/Grid/GridServer/Program.cs
@@ -34,41 +34,43 @@ namespace OpenSim.Grid.GridServer
 {
     public static class Program
     {
-		private static readonly ILog m_log = LogManager.GetLogger("OpenSim.Grid.GridServer");
+        private static readonly ILog m_log = LogManager.GetLogger("OpenSim.Grid.GridServer");
 
         public static void Main(string[] args)
         {
             ServicePointManager.DefaultConnectionLimit = 12;
 
-			m_log.Info ("starting up");
+            m_log.Info("starting up");
 
             XmlConfigurator.Configure();
 
-			// Add the arguments supplied when running the application to the configuration
-			ArgvConfigSource configSource = new ArgvConfigSource(args);
+            // Add the arguments supplied when running the application to the configuration
+            ArgvConfigSource configSource = new ArgvConfigSource(args);
 
-			configSource.Alias.AddAlias("On", true);
-			configSource.Alias.AddAlias("Off", false);
-			configSource.Alias.AddAlias("True", true);
-			configSource.Alias.AddAlias("False", false);
-			configSource.Alias.AddAlias("Yes", true);
-			configSource.Alias.AddAlias("No", false);
+            configSource.Alias.AddAlias("On", true);
+            configSource.Alias.AddAlias("Off", false);
+            configSource.Alias.AddAlias("True", true);
+            configSource.Alias.AddAlias("False", false);
+            configSource.Alias.AddAlias("Yes", true);
+            configSource.Alias.AddAlias("No", false);
 
-			configSource.AddSwitch("Startup", "background");
+            configSource.AddSwitch("Startup", "background");
 
-			bool background = configSource.Configs["Startup"].GetBoolean("background", false);
-           
-			if (background) {
-				m_log.Info ("[GridServer MAIN]: set to background");
-				GridServerBackground app = new GridServerBackground ();
-				app.Startup();
-				app.Work();
-			} else {
-				m_log.Info ("[GridServer MAIN]: set to foreground");
-				GridServerBase app = new GridServerBase();
-				app.Startup();
-				app.Work();
-			}
+            bool background = configSource.Configs["Startup"].GetBoolean("background", false);
+
+            if (background)
+            {
+                m_log.Info("[GridServer MAIN]: set to background");
+                GridServerBackground app = new GridServerBackground();
+                app.Startup();
+                app.Work();
+            }
+            else {
+                m_log.Info("[GridServer MAIN]: set to foreground");
+                GridServerBase app = new GridServerBase();
+                app.Startup();
+                app.Work();
+            }
         }
     }
 }

--- a/OpenSim/Grid/MessagingServer/Main.cs
+++ b/OpenSim/Grid/MessagingServer/Main.cs
@@ -51,7 +51,7 @@ namespace OpenSim.Grid.MessagingServer
 {
     /// <summary>
     /// </summary>
-    public class OpenMessage_Main : BaseOpenSimServer , IGridServiceCore
+    public class OpenMessage_Main : BaseOpenSimServer, IGridServiceCore
     {
         private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
@@ -63,7 +63,7 @@ namespace OpenSim.Grid.MessagingServer
 
         private UserDataBaseService m_userDataBaseService;
 
-		private ManualResetEvent Terminating = new ManualResetEvent(false);
+        private ManualResetEvent Terminating = new ManualResetEvent(false);
 
         private InWorldz.RemoteAdmin.RemoteAdmin m_radmin;
 
@@ -73,21 +73,21 @@ namespace OpenSim.Grid.MessagingServer
 
             XmlConfigurator.Configure();
 
-			ArgvConfigSource configSource = new ArgvConfigSource(args);
-			configSource.Alias.AddAlias("On", true);
-			configSource.Alias.AddAlias("Off", false);
-			configSource.Alias.AddAlias("True", true);
-			configSource.Alias.AddAlias("False", false);
-			configSource.Alias.AddAlias("Yes", true);
-			configSource.Alias.AddAlias("No", false);
-			configSource.AddSwitch("Startup", "background");
+            ArgvConfigSource configSource = new ArgvConfigSource(args);
+            configSource.Alias.AddAlias("On", true);
+            configSource.Alias.AddAlias("Off", false);
+            configSource.Alias.AddAlias("True", true);
+            configSource.Alias.AddAlias("False", false);
+            configSource.Alias.AddAlias("Yes", true);
+            configSource.Alias.AddAlias("No", false);
+            configSource.AddSwitch("Startup", "background");
 
             m_log.Info("[SERVER]: Launching MessagingServer...");
 
             OpenMessage_Main messageserver = new OpenMessage_Main();
 
             messageserver.Startup();
-			messageserver.Work(configSource.Configs["Startup"].GetBoolean("background", false));
+            messageserver.Work(configSource.Configs["Startup"].GetBoolean("background", false));
         }
 
         public OpenMessage_Main()
@@ -96,24 +96,26 @@ namespace OpenSim.Grid.MessagingServer
             MainConsole.Instance = m_console;
         }
 
-		private void Work(bool background)
+        private void Work(bool background)
         {
-			if (background) {
-				Terminating.WaitOne();
-				Terminating.Close();
-			} else {
-				m_console.Notice("Enter help for a list of commands\n");
+            if (background)
+            {
+                Terminating.WaitOne();
+                Terminating.Close();
+            }
+            else {
+                m_console.Notice("Enter help for a list of commands\n");
 
-				while (true)
-				{
-					m_console.Prompt();
-				}
-			}
+                while (true)
+                {
+                    m_console.Prompt();
+                }
+            }
         }
 
         private void registerWithUserServer()
         {
-            retry:
+        retry:
 
             if (m_userServerModule.registerWithUserServer())
             {
@@ -210,7 +212,7 @@ namespace OpenSim.Grid.MessagingServer
             m_userDataBaseService.AddPlugin(Cfg.DatabaseProvider, Cfg.DatabaseConnect);
 
             //Register the database access service so modules can fetch it
-           // RegisterInterface<UserDataBaseService>(m_userDataBaseService);
+            // RegisterInterface<UserDataBaseService>(m_userDataBaseService);
 
             m_userServerModule = new InterMessageUserServerModule(Cfg, this);
             m_userServerModule.Initialize();
@@ -255,7 +257,7 @@ namespace OpenSim.Grid.MessagingServer
 
         public override void ShutdownSpecific()
         {
-			Terminating.Set();
+            Terminating.Set();
             m_userServerModule.deregisterWithUserServer();
         }
 

--- a/OpenSim/Grid/UserServer/Main.cs
+++ b/OpenSim/Grid/UserServer/Main.cs
@@ -81,7 +81,7 @@ namespace OpenSim.Grid.UserServer
 
         protected JWTAuthenticator m_jwtAuthenticator;
 
-		private ManualResetEvent Terminating = new ManualResetEvent(false);
+        private ManualResetEvent Terminating = new ManualResetEvent(false);
 
         private bool m_useJwt;
 
@@ -89,17 +89,17 @@ namespace OpenSim.Grid.UserServer
         {
             ServicePointManager.DefaultConnectionLimit = 12;
 
-            PIDFileManager pidFile = new PIDFileManager();
+            var pidFile = new PIDFileManager();
             XmlConfigurator.Configure();
 
-			ArgvConfigSource configSource = new ArgvConfigSource(args);
-			configSource.Alias.AddAlias("On", true);
-			configSource.Alias.AddAlias("Off", false);
-			configSource.Alias.AddAlias("True", true);
-			configSource.Alias.AddAlias("False", false);
-			configSource.Alias.AddAlias("Yes", true);
-			configSource.Alias.AddAlias("No", false);
-			configSource.AddSwitch("Startup", "background");
+            ArgvConfigSource configSource = new ArgvConfigSource(args);
+            configSource.Alias.AddAlias("On", true);
+            configSource.Alias.AddAlias("Off", false);
+            configSource.Alias.AddAlias("True", true);
+            configSource.Alias.AddAlias("False", false);
+            configSource.Alias.AddAlias("Yes", true);
+            configSource.Alias.AddAlias("No", false);
+            configSource.AddSwitch("Startup", "background");
 
             m_log.Info("Launching UserServer...");
 
@@ -109,7 +109,7 @@ namespace OpenSim.Grid.UserServer
             userserver.Startup();
 
             pidFile.SetStatus(PIDFileManager.Status.Running);
-			userserver.Work(configSource.Configs["Startup"].GetBoolean("background", false));
+            userserver.Work(configSource.Configs["Startup"].GetBoolean("background", false));
         }
 
         public OpenUser_Main()
@@ -118,19 +118,21 @@ namespace OpenSim.Grid.UserServer
             MainConsole.Instance = m_console;
         }
 
-		public void Work(bool background)
+        public void Work(bool background)
         {
-			if (background) {
-				Terminating.WaitOne();
-				Terminating.Close();
-			} else {
-				m_console.Notice("Enter help for a list of commands\n");
+            if (background)
+            {
+                Terminating.WaitOne();
+                Terminating.Close();
+            }
+            else {
+                m_console.Notice("Enter help for a list of commands\n");
 
-				while (true)
-				{
-					m_console.Prompt();
-				}
-			}
+                while (true)
+                {
+                    m_console.Prompt();
+                }
+            }
         }
 
         protected override void StartupSpecific()
@@ -196,11 +198,11 @@ namespace OpenSim.Grid.UserServer
         protected virtual void StartupUserServerModules()
         {
             m_log.Info("[STARTUP]: Establishing data connection");
-            
+
             //we only need core components so we can request them from here
             IInterServiceInventoryServices inventoryService;
             TryGet<IInterServiceInventoryServices>(out inventoryService);
-            
+
             CommunicationsManager commsManager = new UserServerCommsManager();
 
             //setup database access service, for now this has to be created before the other modules.
@@ -223,7 +225,7 @@ namespace OpenSim.Grid.UserServer
                 m_jwtAuthenticator = new JWTAuthenticator();
                 m_jwtAuthenticator.Initialize(this);
             }
-            
+
             m_consoleCommandModule = new UserServerCommandModule();
             m_consoleCommandModule.Initialize(this);
 
@@ -289,7 +291,7 @@ namespace OpenSim.Grid.UserServer
             {
                 m_jwtAuthenticator.RegisterHandlers(m_httpServer);
             }
-            
+
 
             m_radmin = new InWorldz.RemoteAdmin.RemoteAdmin(Cfg.SSLPublicCertFile);
             m_radmin.AddCommand("UserService", "Shutdown", UserServerShutdownHandler);
@@ -332,7 +334,7 @@ namespace OpenSim.Grid.UserServer
 
         public override void ShutdownSpecific()
         {
-			Terminating.Set();
+            Terminating.Set();
             m_eventDispatcher.Close();
         }
 

--- a/OpenSim/Grid/UserServer/Main.cs
+++ b/OpenSim/Grid/UserServer/Main.cs
@@ -87,23 +87,28 @@ namespace OpenSim.Grid.UserServer
 
         public static void Main(string[] args)
         {
+            // Please note that if you are changing something in this function you should check to see if you need to change the other server's Main functions as well.
             ServicePointManager.DefaultConnectionLimit = 12;
 
-            var pidFile = new PIDFileManager();
-            XmlConfigurator.Configure();
+            // Add the arguments supplied when running the application to the configuration
+            var configSource = new ArgvConfigSource(args);
 
-            ArgvConfigSource configSource = new ArgvConfigSource(args);
             configSource.Alias.AddAlias("On", true);
             configSource.Alias.AddAlias("Off", false);
             configSource.Alias.AddAlias("True", true);
             configSource.Alias.AddAlias("False", false);
             configSource.Alias.AddAlias("Yes", true);
             configSource.Alias.AddAlias("No", false);
+
             configSource.AddSwitch("Startup", "background");
+            configSource.AddSwitch("Startup", "pidfile");
 
-            m_log.Info("Launching UserServer...");
+            m_log.Info("[SERVER]: Launching UserServer...");
 
-            OpenUser_Main userserver = new OpenUser_Main();
+            var pidFile = new PIDFileManager(configSource.Configs["Startup"].GetString("pidfile", string.Empty));
+            XmlConfigurator.Configure();
+
+            var userserver = new OpenUser_Main();
 
             pidFile.SetStatus(PIDFileManager.Status.Starting);
             userserver.Startup();
@@ -125,7 +130,8 @@ namespace OpenSim.Grid.UserServer
                 Terminating.WaitOne();
                 Terminating.Close();
             }
-            else {
+            else
+            {
                 m_console.Notice("Enter help for a list of commands\n");
 
                 while (true)


### PR DESCRIPTION
This makes all servers generate PID files just like the User server already does.

It also adds a new commandline flag, `--pidfile=path`, so that external systems can specify where the PID file is to be placed.

Lastly it cleans up the `main()` functions of all three grid services so that they match each other.  This should help with future maintenance, assuming people read the comment I left...