### PR TITLE
Forward slash is the only valid dir separator

### DIFF
--- a/OpenSim/Framework/PluginLoader.cs
+++ b/OpenSim/Framework/PluginLoader.cs
@@ -217,7 +217,7 @@ namespace OpenSim.Framework
             }
             
             suppress_console_output_(true);
-            Directory.CreateDirectory("addin-db-001\\addin-dir-data");
+            Directory.CreateDirectory("addin-db-001/addin-dir-data");
             AddinManager.Initialize(dir);
             AddinManager.Registry.Update(null);
             suppress_console_output_(false);


### PR DESCRIPTION
It even works right in Windows, but the backslash doesn't work right in Linux.