### PR TITLE
Ci integration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: {build}
+version: 0.9.00.{build}
 
 image: Visual Studio 2017
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,7 @@ after_build:
     - ps: >-
       If(Test-Path "bin/OpenSim.Framework.Servers.dll") {
         $halcyon_version = (ls bin/OpenSim.Framework.Servers.dll | % versioninfo).ProductVersion
-        Update-AppveyorBuild -Version "0.$($halcyon_version.Substring(0, $halcyon_version.lastIndexOf('.'))"
+        Update-AppveyorBuild -Version "0.$($halcyon_version.Substring(0, $halcyon_version.lastIndexOf('.')))"
       }
     - move bin halcyon
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,29 @@
+version: {build}
+
+image: Visual Studio 2017
+
+configuration: Release
+
+cache:
+    - packages -> **\packages.config
+
+before_build:
+    - IF EXIST runprebuild.bat runprebuild.bat
+    - nuget restore Halcyon.sln
+
+build:
+    parallel: true
+    verbosity: minimal
+    project: Halcyon.sln
+
+after_build:
+    - ps: >-
+      If(Test-Path "bin/OpenSim.Framework.Servers.dll") {
+        $halcyon_version = (ls bin/OpenSim.Framework.Servers.dll | % versioninfo).ProductVersion
+        Update-AppveyorBuild -Version "0.$($halcyon_version.Substring(0, $halcyon_version.lastIndexOf('.'))"
+      }
+    - move bin halcyon
+
+artifacts:
+    - path: halcyon
+      name: Halcyon-{version}-{branch}-{build}

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ build:
     project: Halcyon.sln
 
 after_build:
-    - ps: >-
+    - ps: |
       If(Test-Path "bin/OpenSim.Framework.Servers.dll") {
         $halcyon_version = (ls bin/OpenSim.Framework.Servers.dll | % versioninfo).ProductVersion
         Update-AppveyorBuild -Version "0.$($halcyon_version.Substring(0, $halcyon_version.lastIndexOf('.')))"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,6 +24,9 @@ after_build:
         }
     - cmd: move bin halcyon
 
+# No tests for now.
+test: off
+
 artifacts:
     - path: halcyon
       name: Halcyon-{version}-{branch}-{build}

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ after_build:
         $halcyon_version = (ls bin/OpenSim.Framework.Servers.dll | % versioninfo).ProductVersion
         Update-AppveyorBuild -Version "0.$($halcyon_version.Substring(0, $halcyon_version.lastIndexOf('.')))"
       }
-    - move bin halcyon
+    - cmd: move bin halcyon
 
 artifacts:
     - path: halcyon

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,7 @@ after_build:
     - ps: |
         If(Test-Path "bin/OpenSim.Framework.Servers.dll") {
           $halcyon_version = (ls bin/OpenSim.Framework.Servers.dll | % versioninfo).ProductVersion
-          Update-AppveyorBuild -Version "0.$($halcyon_version.Substring(0, $halcyon_version.lastIndexOf('.')))"
+          Update-AppveyorBuild -Version "0.$($halcyon_version.Substring(0, $halcyon_version.lastIndexOf('.')))-$env:APPVEYOR_BUILD_NUMBER"
         }
     - cmd: move bin halcyon
 
@@ -29,4 +29,4 @@ test: off
 
 artifacts:
     - path: halcyon
-      name: Halcyon-$(version)-$(branch)-$(build)
+      name: Halcyon-$(APPVEYOR_BUILD_VERSION)-$(APPVEYOR_REPO_BRANCH)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,10 +18,10 @@ build:
 
 after_build:
     - ps: |
-      If(Test-Path "bin/OpenSim.Framework.Servers.dll") {
-        $halcyon_version = (ls bin/OpenSim.Framework.Servers.dll | % versioninfo).ProductVersion
-        Update-AppveyorBuild -Version "0.$($halcyon_version.Substring(0, $halcyon_version.lastIndexOf('.')))"
-      }
+        If(Test-Path "bin/OpenSim.Framework.Servers.dll") {
+          $halcyon_version = (ls bin/OpenSim.Framework.Servers.dll | % versioninfo).ProductVersion
+          Update-AppveyorBuild -Version "0.$($halcyon_version.Substring(0, $halcyon_version.lastIndexOf('.')))"
+        }
     - cmd: move bin halcyon
 
 artifacts:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,4 +29,4 @@ test: off
 
 artifacts:
     - path: halcyon
-      name: Halcyon-$(APPVEYOR_BUILD_VERSION)-$(APPVEYOR_REPO_BRANCH)
+      name: Halcyon-$(APPVEYOR_BUILD_VERSION)-$(APPVEYOR_REPO_BRANCH)-Windows

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,4 +29,4 @@ test: off
 
 artifacts:
     - path: halcyon
-      name: Halcyon-{version}-{branch}-{build}
+      name: Halcyon-$(version)-$(branch)-$(build)


### PR DESCRIPTION
How would you like your compilation served?  This iteration is just Windows .NET AppVeyor builds and works with runprebuild.bat if it exists, and skips it if it does not.

The version is pulled from the resulting OpenSim.Framework.Servers.dll, so should reflect real-world versioning of Halcyon.

It is set to build on pushes to every branch.  This can be restricted to any specific branch or set thereof.

I can also set it up to push the result to a draft GitHub release if it is a tagged commit.

See example build here: https://ci.appveyor.com/project/kf6kjg/halcyon
And see example resulting artifact ZIP at: https://ci.appveyor.com/project/kf6kjg/halcyon/build/artifacts