### PR TITLE
Remove duplicate key check in SceneView object culling path.

### DIFF
--- a/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
+++ b/OpenSim/Region/CoreModules/Agent/SceneView/SceneView.cs
@@ -796,10 +796,7 @@ namespace OpenSim.Region.CoreModules.Agent.SceneView
                             IReadOnlyCollection<SceneObjectPart> sogPrims = part.ParentGroup.GetParts();
                             foreach (SceneObjectPart prim in sogPrims)
                             {
-                                if (m_updateTimes.ContainsKey(prim.LocalId))
-                                {
-                                    m_updateTimes.Remove(prim.LocalId);
-                                }
+                                m_updateTimes.Remove(prim.LocalId);
                             }
                         }
                     }


### PR DESCRIPTION
This removes a call to m_updateTimes.ContainsKey around a call to
 m_updateTimes.Remove. The Dictionary.Remove call throws no exception
 on a missing key, and there are no side effects on a missing key.
 This very slightly optimizes the path by avoiding a duplicate
 key exists check inside the dictionary.

As an aside, I am not familiar enough with the code to know if part.ParentGroup.GetParts() will always contain part.LocalId or not. If there is not a guarantee that part.LocalId is present within the returned parts, it needs to be removed manually.