### PR TITLE
Incoming HTTP fixes: x-query-string compatibility, null reference exceptions

### DIFF
--- a/OpenSim/Framework/Servers/HttpServer/AsyncHttpRequest.cs
+++ b/OpenSim/Framework/Servers/HttpServer/AsyncHttpRequest.cs
@@ -88,7 +88,12 @@ namespace OpenSim.Framework.Servers.HttpServer
             RequestData.Add("http-method", HttpRequest.HttpMethod);
 
             foreach (string queryname in querystringkeys)
-                RequestData.Add(queryname, HttpRequest.QueryString[queryname]);
+            {
+                // HttpRequest.QueryString.AllKeys returns a one-item array, with a null only,
+                // if passed something without an '=' in the query, such as URL/?abc or URL/?abc+def
+                if (queryname != null)
+                    RequestData.Add(queryname, HttpRequest.QueryString[queryname]);
+            }
 
             foreach (string headername in rHeaders)
                 headervals[headername] = HttpRequest.Headers[headername];

--- a/OpenSim/Framework/Servers/HttpServer/BaseHttpServer.cs
+++ b/OpenSim/Framework/Servers/HttpServer/BaseHttpServer.cs
@@ -1253,8 +1253,14 @@ namespace OpenSim.Framework.Servers.HttpServer
             {
 //                m_log.DebugFormat(
 //                    "[BASE HTTP SERVER]: Got query paremeter {0}={1}", queryname, request.QueryString[queryname]);
-                keysvals.Add(queryname, request.QueryString[queryname]);
-                requestVars.Add(queryname, keysvals[queryname]);
+
+                // HttpRequest.QueryString.AllKeys returns a one-item array, with a null only,
+                // if passed something without an '=' in the query, such as URL/?abc or URL/?abc+def
+                if (queryname != null)
+                {
+                    keysvals.Add(queryname, request.QueryString[queryname]);
+                    requestVars.Add(queryname, keysvals[queryname]);
+                }
             }
 
             foreach (string headername in rHeaders)

--- a/OpenSim/Region/CoreModules/Scripting/LSLHttp/UrlModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/LSLHttp/UrlModule.cs
@@ -506,7 +506,7 @@ namespace OpenSim.Region.CoreModules.Scripting.LSLHttp
                         String[] keys = (String[])de.Value;
                         foreach (String key in keys)
                         {
-                            if (request.ContainsKey(key))
+                            if ((key != null) && request.ContainsKey(key))
                             {
                                 string val = (String)request[key];
                                 queryString = queryString + key + "=" + val + "&";
@@ -518,11 +518,15 @@ namespace OpenSim.Region.CoreModules.Scripting.LSLHttp
                     }
                 }
 
+                // Grab the raw unprocessed original query string, if any.
+                int rawQueryPos = httpRequest.Url.Query.IndexOf('?');
+                string rawQueryStr = (rawQueryPos < 0) ? httpRequest.Url.Query : httpRequest.Url.Query.Substring(rawQueryPos + 1);
+
                 //if this machine is behind DNAT/port forwarding, currently this is being
                 //set to address of port forwarding router
                 requestData.headers["x-remote-ip"] = httpRequest.RemoteIPEndPoint.ToString();
                 requestData.headers["x-path-info"] = pathInfo;
-                requestData.headers["x-query-string"] = requestData.uri;    // raw (SL-compatible)
+                requestData.headers["x-query-string"] = rawQueryStr;        // raw original (SL-compatible)
                 requestData.headers["x-query-string-compat"] = queryString; // processed (old Halcyon scripts)
                 requestData.headers["x-script-url"] = urlData.url;
 

--- a/OpenSim/Region/CoreModules/Scripting/LSLHttp/UrlModule.cs
+++ b/OpenSim/Region/CoreModules/Scripting/LSLHttp/UrlModule.cs
@@ -522,7 +522,8 @@ namespace OpenSim.Region.CoreModules.Scripting.LSLHttp
                 //set to address of port forwarding router
                 requestData.headers["x-remote-ip"] = httpRequest.RemoteIPEndPoint.ToString();
                 requestData.headers["x-path-info"] = pathInfo;
-                requestData.headers["x-query-string"] = queryString;
+                requestData.headers["x-query-string"] = requestData.uri;    // raw (SL-compatible)
+                requestData.headers["x-query-string-compat"] = queryString; // processed (old Halcyon scripts)
                 requestData.headers["x-script-url"] = urlData.url;
 
                 lock (m_RequestMap)


### PR DESCRIPTION
This update fixes problems with:
- null reference exceptions in several places in the code if an incoming HTTP request includes a query string that does not have at least one `=` in it. This fixes `500` error responses on many HTTP requests.
- `llGetHTTPHeader(id, "x-query-string")` returned an empty string if there was a query with no `key=value`, such as `URL/?abc+def+ghi`.
- added `llGetHTTPHeader(id, "x-query-string-compat")` in case anyone still needs the old broken behavior
