### PR TITLE
Lowered most notecard delays, new delays on some errors. (Mantis 3304)

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -14500,6 +14500,9 @@ namespace InWorldz.Phlox.Engine
 
         public string GetNumberOfNotecardLines(SceneObjectPart part, string name)
         {
+            const int ERROR_DELAY = 100;
+            const int LONG_DELAY = 50;
+            const int FAST_DELAY = 25;
             TaskInventoryDictionary itemsDictionary = (TaskInventoryDictionary)part.TaskInventory.Clone();
 
             UUID assetID = UUID.Zero;
@@ -14520,7 +14523,7 @@ namespace InWorldz.Phlox.Engine
             {
                 // => complain loudly, as specified by the LSL docs
                 ScriptShoutError("Notecard '" + name + "' could not be found.");
-
+                ScriptSleep(ERROR_DELAY);
                 return UUID.Zero.ToString();
             }
 
@@ -14533,7 +14536,7 @@ namespace InWorldz.Phlox.Engine
             {
                 AsyncCommands.
                 DataserverPlugin.DataserverReply(reqIdentifier, NotecardCache.GetLines(assetID).ToString());
-                ScriptSleep(100);
+                ScriptSleep(FAST_DELAY);
                 return tid.ToString();
             }
 
@@ -14542,6 +14545,7 @@ namespace InWorldz.Phlox.Engine
                 if (a == null || a.Type != 7)
                 {
                     ScriptShoutError("Notecard '" + name + "' could not be found.");
+                    ScriptSleep(ERROR_DELAY);
                     return;
                 }
 
@@ -14552,7 +14556,7 @@ namespace InWorldz.Phlox.Engine
 
             NotecardCache.CacheCheck(); //this must be done in the script engine thread to avoid race conditions
 
-            ScriptSleep(100);
+            ScriptSleep(LONG_DELAY);
             return tid.ToString();
         }
         public string llGetNumberOfNotecardLines(string name)
@@ -14577,7 +14581,9 @@ namespace InWorldz.Phlox.Engine
 
         private string GetNotecardSegment(SceneObjectPart part, string name, int line, int startOffset, int maxLength)
         {
-            const int DELAY = 25;
+            const int LONG_DELAY = 25;
+            const int FAST_DELAY = 1;
+            const int LINES_PER_DELAY = 16; // every 16 lines, delay FAST_DELAY
 
             TaskInventoryDictionary itemsDictionary = (TaskInventoryDictionary)part.TaskInventory.Clone();
 
@@ -14612,7 +14618,8 @@ namespace InWorldz.Phlox.Engine
             {
                 AsyncCommands.
                 DataserverPlugin.DataserverReply(reqIdentifier, NotecardCache.GetLine(assetID, line, startOffset, maxLength));
-                ScriptSleep(DELAY);
+                if (((line % LINES_PER_DELAY) == 0) && (startOffset == 0))
+                    ScriptSleep(FAST_DELAY);
                 return tid.ToString();
             }
 
@@ -14630,7 +14637,7 @@ namespace InWorldz.Phlox.Engine
 
             NotecardCache.CacheCheck(); //this must be done in the script engine thread to avoid race conditions
 
-            ScriptSleep(DELAY);
+            ScriptSleep(LONG_DELAY);
             return tid.ToString();
         }
 


### PR DESCRIPTION
As per the discussion in [Mantis 3304](https://bugs.inworldz.com/mantis/view.php?id=3304):
- GetNumberOfNotecardLines now includes the old 100ms delay on "notecard not found" error cases.  (Previously no delay at all, even if errors.)
- If cached, GetNumberOfNotecardLines only delays 25ms now instead of 100.
- If asset fetch required (uncached), GetNumberOfNotecardLines only delays 50ms now instead of 100.
- Notecard line/segment fetches now delay only 1ms (probably 16ms) every 16 lines, starting at the first line, if cached.  (Should result in be 1000 lines per second now.)
- Notecard line/segment fetches continue to delay by 25ms if not cached (i.e. first line only), same as above.