### PR TITLE
Fixed exception saving scripts under updated viewers (e.g. Alchemy 5)

### DIFF
--- a/OpenSim/Framework/Communications/Capabilities/LLSDHelpers.cs
+++ b/OpenSim/Framework/Communications/Capabilities/LLSDHelpers.cs
@@ -157,6 +157,12 @@ namespace OpenSim.Framework.Communications.Capabilities
                                     // the LLSD map/array types in the array need to be deserialized
                                     // but first we need to know the right class to deserialize them into.
                                 }
+                                else if (enumerator.Value is Boolean && field.FieldType == typeof(int))
+                                {
+                                    // LLSD booleans aren't actually booleans, they are ints with a value of 0 or 1
+                                    int i = (bool)enumerator.Value ? 1 : 0;
+                                    field.SetValue(obj, (object)i);
+                                }
                                 else
                                 {
                                     field.SetValue(obj, enumerator.Value);


### PR DESCRIPTION
Newer viewers are using the sim CAP now, which passes a bool, but LLSD doesn't actually use a real bool, it's an int under the covers, so we need to convert or we get a C# type exception. 

This matches the fix in OpenSim for the same lack of support in the server code. This should actually be fixed at the OSD level but until that happens, this change should avoid the exceptions for all LLSD messages that include bools. Thanks to Cinder for this one.