### PR TITLE
ACK all received UCC requests.

### DIFF
--- a/OpenSim/Region/ClientStack/LindenUDP/LLUDPServer.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLUDPServer.cs
@@ -954,13 +954,18 @@ namespace OpenSim.Region.ClientStack.LindenUDP
 //            m_log.WarnFormat("[LLUDPSERVER]: HandleUseCircuitCode, client {0}, circuit code {1}, session {2}", UCC.CircuitCode.ID, UCC.CircuitCode.Code, UCC.CircuitCode.SessionID);
             try
             {
+                UUID agentID = UCC.CircuitCode.ID;
+                uint circuitCode = UCC.CircuitCode.Code;
+                UUID sessionID = UCC.CircuitCode.SessionID;
+
                 IPEndPoint remoteEndPoint = (IPEndPoint)array[0];
                 // Begin the process of adding the client to the simulator
-                if (AddNewClient(UCC, remoteEndPoint))
+                if (!AddNewClient(UCC, remoteEndPoint))
                 {
-                    // Acknowledge the UseCircuitCode packet
-                    SendAckImmediate(remoteEndPoint, UCC.Header.Sequence);
+                    m_log.WarnFormat("[LLUDPSERVER]: HandleUseCircuitCode could not add new client for {0}: cc={1} ses={2}", agentID, circuitCode, sessionID);
                 }
+                // Acknowledge the UseCircuitCode packet regardless.
+                SendAckImmediate(remoteEndPoint, UCC.Header.Sequence);
             }
             finally
             {
@@ -1012,7 +1017,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             {
                 if (e.CircuitAlreadyExisted)
                 {
-                    m_log.WarnFormat("[LLUDPSERVER]: Ignoring duplicate UDP connection request. {0}", e.Message);
+                    m_log.WarnFormat("[LLUDPSERVER]: Duplicate UDP connection request. {0}", e.Message);
 
                     //if the circuit matches, we can ACK the UCC since the client should be
                     //able to communicate with the current circuit

--- a/OpenSim/Region/Framework/Connection/AvatarConnectionManager.cs
+++ b/OpenSim/Region/Framework/Connection/AvatarConnectionManager.cs
@@ -158,7 +158,7 @@ namespace OpenSim.Region.Framework.Connection
                 {
                     conn = new AvatarConnection(circuitData, reason);
                     conn.OnConnectionTerminated += conn_OnConnectionTerminated;
-                    _connectionsByUserId.Add(circuitData.AgentID, conn);
+                    _connectionsByUserId[circuitData.AgentID] = conn;
                 }
             }
 
@@ -246,7 +246,7 @@ namespace OpenSim.Region.Framework.Connection
                     udpCircuit.AfterAttachedToConnection(conn.CircuitData);
 
                     if (udpCircuit.RemoteEndPoint.Port != 0)
-                        _connectionsByEndpoint.Add(udpCircuit.RemoteEndPoint, conn);
+                        _connectionsByEndpoint[udpCircuit.RemoteEndPoint] = conn;
                 }
                 else
                 {

--- a/OpenSim/Region/Framework/Connection/AvatarConnectionManager.cs
+++ b/OpenSim/Region/Framework/Connection/AvatarConnectionManager.cs
@@ -157,8 +157,8 @@ namespace OpenSim.Region.Framework.Connection
                 else
                 {
                     conn = new AvatarConnection(circuitData, reason);
-                    _connectionsByUserId.Add(circuitData.AgentID, conn);
                     conn.OnConnectionTerminated += conn_OnConnectionTerminated;
+                    _connectionsByUserId.Add(circuitData.AgentID, conn);
                 }
             }
 


### PR DESCRIPTION
Time to move on from that weird protocol kludge of not ACKing some valid packets received. We can't ignore repeated  UCC requests as that does not allow cleanup of old data. If an error happens, the user just cannot communicate with the region after that, without a region restart.

And I may have fixed the error cleaning up that caused all subsequent UCC updates to not update. The _connectionsByEndpoint.Add() should have been a dictionary update. I witnessed an "already exists" exception here, which is why there's a dict[key] assignment now instead of the call to .Add that was there before.