### PR TITLE
Missing attachments on viewer relogs

### DIFF
--- a/InWorldz/InWorldz.Data.Assets.Stratus/StratusAssetClient.cs
+++ b/InWorldz/InWorldz.Data.Assets.Stratus/StratusAssetClient.cs
@@ -283,6 +283,7 @@ namespace InWorldz.Data.Assets.Stratus
         //see IAssetReceiver
         public void AssetNotFound(OpenMetaverse.UUID assetID, AssetRequestInfo data)
         {
+            m_log.WarnFormat("[InWorldz.Stratus]: Asset not found {0}", assetID);
             this.HandleAssetCallback(assetID, data, null);
         }
 

--- a/InWorldz/InWorldz.Data.Inventory.Cassandra/InventoryStorage.cs
+++ b/InWorldz/InWorldz.Data.Inventory.Cassandra/InventoryStorage.cs
@@ -2374,7 +2374,16 @@ namespace InWorldz.Data.Inventory.Cassandra
 
             try
             {
-                _log.DebugFormat("[Inworldz.Data.Inventory.Cassandra] Purge of item {0} '{1}' for user {2} requested", item.ID, item.Name, item.Owner);
+                string invType;
+                if (item.AssetType == (int)AssetType.Link)
+                    invType = "link";
+                else
+                if (item.AssetType == (int)AssetType.LinkFolder)
+                    invType = "folder link";
+                else
+                    invType = "type "+item.AssetType.ToString();
+
+                _log.WarnFormat("[Inworldz.Data.Inventory.Cassandra] Purge of {0} id={1} asset={2} '{3}' for user={4}", invType, item.ID, item.AssetID, item.Name, item.Owner);
                 PurgeItemInternal(item, timeStamp);
             }
             catch (Exception e)

--- a/OpenSim/Framework/Communications/Cache/CachedUserInfo.cs
+++ b/OpenSim/Framework/Communications/Cache/CachedUserInfo.cs
@@ -315,7 +315,7 @@ namespace OpenSim.Framework.Communications.Cache
             return folderInfo;
         }
 
-        public InventoryItemBase FindItem(UUID itemId)
+        public InventoryItemBase FindItem(UUID itemId, bool quiet=false)
         {
             try
             {
@@ -326,7 +326,8 @@ namespace OpenSim.Framework.Communications.Cache
             }
             catch (InventoryStorageException e)
             {
-                m_log.ErrorFormat("[INVENTORY] Could not find requested item {0}: {1}", itemId, e);
+                if ((!quiet) || !e.ErrorDetails.Contains("Item was not found")) // don't report "not found" when quiet == true
+                    m_log.ErrorFormat("[INVENTORY] Could not find requested item {0}: {1}", itemId, e);
             }
 
             return null;

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -8177,7 +8177,8 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 }
                 #endregion
 
-                bool haveAllObjects = false;
+                // Use a copy of the 
+                List<RezMultipleAttachmentsFromInvPacket.ObjectDataBlock> attachmentsData = null;
                 lock (_rezMultupleAttachmentsData)
                 {
                     if (rez.HeaderData.CompoundMsgID != _rezMutipleAttachmentsTransactionId)
@@ -8190,13 +8191,14 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                     _rezMultupleAttachmentsData.AddRange(rez.ObjectData);
                     if (rez.HeaderData.TotalObjects == _rezMultupleAttachmentsData.Count)
                     {
-                        haveAllObjects = true;
+                        // we have them all, ready to send off. Create a local copy use outside the lock.
+                        attachmentsData = new List<RezMultipleAttachmentsFromInvPacket.ObjectDataBlock>(_rezMultupleAttachmentsData);
                     }
                 }
 
-                if (haveAllObjects)
+                if (attachmentsData != null)    // we have them all, ready to send off
                 {
-                    handlerRezMultipleAttachments(this, rez.HeaderData, _rezMultupleAttachmentsData.ToArray());
+                    handlerRezMultipleAttachments(this, rez.HeaderData, attachmentsData.ToArray());
                 }
             }
 

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -1546,7 +1546,7 @@ namespace OpenSim.Region.Framework.Scenes
             }
 
             //verify this user actually owns the item
-            InventoryItemBase item = userInfo.FindItem(itemID);
+            InventoryItemBase item = userInfo.FindItem(itemID, true); // find it quietly since this is a remove
 
             if (item == null)
             {


### PR DESCRIPTION
Fixed a possible race condition with session global `_rezMultupleAttachmentsData`.  It is used outside the lock; it might be getting cleared during async processing by another packet, especially if the asset cache isn't warmed up, such as on a different region from where the attachments were added.  Also some small tweaks to some of the inventory/asset reporting to help us investigate issues like this.