### PR TITLE
Added a user-configurable limit (1 or 2) on the range of neighbor regions.

### DIFF
--- a/InWorldz/InWorldz.Testing/MockClientAPI.cs
+++ b/InWorldz/InWorldz.Testing/MockClientAPI.cs
@@ -132,6 +132,12 @@ namespace InWorldz.Testing
             set { }
         }
 
+        public uint NeighborsRange
+        {
+            get { return 1; }
+            set { }
+        }
+
         public uint CircuitCode { get; set; }
 
 #pragma warning disable 0067 // disable "X is never used"

--- a/OpenSim/Framework/ChildAgentDataUpdate.cs
+++ b/OpenSim/Framework/ChildAgentDataUpdate.cs
@@ -252,7 +252,8 @@ namespace OpenSim.Framework
     [Flags]
     public enum PresenceFlags
     {
-        DebugCrossings = (1 << 0)
+        DebugCrossings = (1 << 0),
+        LimitNeighbors = (1 << 1)   // when set, neighbors range is only 1
     }
 
     public class AgentData : IAgentData

--- a/OpenSim/Framework/IClientAPI.cs
+++ b/OpenSim/Framework/IClientAPI.cs
@@ -650,6 +650,7 @@ namespace OpenSim.Framework
         bool SendLogoutPacketWhenClosing { set; }
 
         bool DebugCrossings { get; set; }
+        uint NeighborsRange { get; set; }
 
         // [Obsolete("LLClientView Specific - Circuits are unique to LLClientView")]
         uint CircuitCode { get; }

--- a/OpenSim/Framework/Util.cs
+++ b/OpenSim/Framework/Util.cs
@@ -2422,7 +2422,7 @@ namespace OpenSim.Framework
         /// <param name="xmax">Outputs the X maximum for the DD rectangle</param>
         /// <param name="ymin">Outputs the Y minimum for the DD rectangle</param>
         /// <param name="ymax">Outputs the Y maximum for the DD rectangle</param>
-        public static void GetDrawDistanceBasedRegionRectangle(uint drawDistance, uint regionLocX, uint regionLocY, 
+        public static void GetDrawDistanceBasedRegionRectangle(uint drawDistance, uint maxRange, uint regionLocX, uint regionLocY, 
             out uint xmin, out uint xmax, out uint ymin, out uint ymax)
         {
             uint ddRegionWidth = GetRegionUnitsFromDD(drawDistance);
@@ -2431,6 +2431,18 @@ namespace OpenSim.Framework
             xmax = regionLocX + ddRegionWidth;
             ymin = ddRegionWidth > regionLocY ? 0U : regionLocY - ddRegionWidth;
             ymax = regionLocY + ddRegionWidth;
+
+            if (maxRange > 0)   // apply it
+            {
+                if ((regionLocX - xmin) > maxRange)
+                    xmin = regionLocX - maxRange;
+                if ((regionLocY - ymin) > maxRange)
+                    ymin = regionLocY - maxRange;
+                if ((xmax - regionLocX) > maxRange)
+                    xmax = regionLocX + maxRange;
+                if ((ymax - regionLocY) > maxRange)
+                    ymax = regionLocY + maxRange;
+            }
         }
 
         /// <summary>

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -173,6 +173,8 @@ namespace OpenSim.Region.ClientStack.LindenUDP
 
         private bool m_DebugCrossings = false;
 
+        private uint m_NeighborsRange = 2;
+
         // Used to adjust Sun Orbit values so Linden based viewers properly position sun
         private const float m_sunPainDaHalfOrbitalCutoff = 4.712388980384689858f;
 
@@ -543,6 +545,18 @@ namespace OpenSim.Region.ClientStack.LindenUDP
         {
             get { return m_DebugCrossings; }
             set { m_DebugCrossings = value;  }
+        }
+
+
+        public uint NeighborsRange
+        {
+            get { return m_NeighborsRange; }
+            set {
+                if ((value == 1) || (value == 2))   // only legal values
+                    m_NeighborsRange = value;
+                else // 0 or anything else sets it to default
+                    m_NeighborsRange = 2;   // default neighbors range is 2 regions away
+            }
         }
 
         public IPEndPoint RemoteEndPoint 

--- a/OpenSim/Region/Communications/OGS1/OGS1GridServices.cs
+++ b/OpenSim/Region/Communications/OGS1/OGS1GridServices.cs
@@ -1104,7 +1104,7 @@ namespace OpenSim.Region.Communications.OGS1
             Task<List<SimpleRegionInfo>> requestTask = new Task<List<SimpleRegionInfo>>(() =>
                 {
                     uint xmin, xmax, ymin, ymax;
-                    Util.GetDrawDistanceBasedRegionRectangle((uint)maxDD, x, y, out xmin, out xmax, out ymin, out ymax);
+                    Util.GetDrawDistanceBasedRegionRectangle((uint)maxDD, 0, x, y, out xmin, out xmax, out ymin, out ymax);
 
                     Hashtable block = MapBlockQuery((int)xmin, (int)ymin, (int)xmax, (int)ymax);
                     if (block == null)

--- a/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
+++ b/OpenSim/Region/CoreModules/Agent/BotManager/BotClient.cs
@@ -447,6 +447,12 @@ namespace OpenSim.Region.CoreModules.Agent.BotManager
             set { }
         }
 
+        public uint NeighborsRange
+        {
+            get { return 1U; }
+            set { }
+        }
+
         public uint CircuitCode
         {
             get { return m_circuitCode; }

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -3833,7 +3833,7 @@ namespace OpenSim.Region.Framework.Scenes
 
                     uint xmin, xmax, ymin, ymax;
 
-                    Util.GetDrawDistanceBasedRegionRectangle((uint)client.DrawDistance, regionX, regionY,
+                    Util.GetDrawDistanceBasedRegionRectangle((uint)client.DrawDistance, 0, regionX, regionY,
                         out xmin, out xmax, out ymin, out ymax);
 
                     if (!Util.IsWithinDDRectangle(destinationRegion.RegionLocX, destinationRegion.RegionLocY, xmin, xmax, ymin, ymax))

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1719,6 +1719,11 @@ namespace OpenSim.Region.Framework.Scenes
             return IsAtTarget(target, MOVE_TO_TARGET_TOLERANCE * 2.0f);
         }
 
+        public void UpdateForDrawDistanceChange()
+        {
+            m_remotePresences.HandleDrawDistanceChanged((uint)m_DrawDistance);
+        }
+
         /// <summary>
         /// This is the event handler for client movement.   If a client is moving, this event is triggering.
         /// </summary>
@@ -1819,7 +1824,7 @@ namespace OpenSim.Region.Framework.Scenes
             if (m_DrawDistance != agentData.Far)
             {
                 m_DrawDistance = agentData.Far;
-                m_remotePresences.HandleDrawDistanceChanged((uint)agentData.Far);
+                UpdateForDrawDistanceChange();
             }
 
             if ((flags & (uint) AgentManager.ControlFlags.AGENT_CONTROL_STAND_UP) != 0)
@@ -4161,6 +4166,8 @@ namespace OpenSim.Region.Framework.Scenes
             cAgent.Throttles = ControllingClient.GetThrottlesPacked(1.0f);
 
             cAgent.PresenceFlags = 0;
+            if (ControllingClient.NeighborsRange == 1)
+                cAgent.PresenceFlags |= (ulong)PresenceFlags.LimitNeighbors;
             if (ControllingClient.DebugCrossings)
                 cAgent.PresenceFlags |= (ulong)PresenceFlags.DebugCrossings;
             if (m_scene.Permissions.IsGod(new UUID(cAgent.AgentID)))
@@ -4263,6 +4270,7 @@ namespace OpenSim.Region.Framework.Scenes
                 ControllingClient.SetChildAgentThrottle(cAgent.Throttles);
 
             ControllingClient.DebugCrossings = (cAgent.PresenceFlags & (ulong)PresenceFlags.DebugCrossings) != 0;
+            ControllingClient.NeighborsRange = ((cAgent.PresenceFlags & (ulong)PresenceFlags.LimitNeighbors) != 0) ? 1U : 2U;
 
             if (m_scene.Permissions.IsGod(new UUID(cAgent.AgentID)))
                 m_godlevel = cAgent.GodLevel;

--- a/OpenSim/Region/Framework/Scenes/SurroundingRegionManager.cs
+++ b/OpenSim/Region/Framework/Scenes/SurroundingRegionManager.cs
@@ -677,7 +677,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         /// <param name="drawDistance">DD in meters</param>
         /// <returns>List of known neighbors</returns>
-        public List<SimpleRegionInfo> GetKnownNeighborsWithinClientDD(uint drawDistance)
+        public List<SimpleRegionInfo> GetKnownNeighborsWithinClientDD(uint drawDistance, uint maxRange)
         {
             drawDistance = Math.Max(drawDistance, 64);
 
@@ -685,7 +685,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             uint xmin, xmax, ymin, ymax;
             var regionInfo = _scene.RegionInfo;
-            Util.GetDrawDistanceBasedRegionRectangle(drawDistance, regionInfo.RegionLocX, regionInfo.RegionLocY, out xmin, out xmax, out ymin, out ymax);
+            Util.GetDrawDistanceBasedRegionRectangle(drawDistance, maxRange, regionInfo.RegionLocX, regionInfo.RegionLocY, out xmin, out xmax, out ymin, out ymax);
 
             uint gridsize = xmax - xmin + 1;
             uint center = (xmax - xmin) / 2;
@@ -737,37 +737,5 @@ namespace OpenSim.Region.Framework.Scenes
             }
         }
 
-        /// <summary>
-        /// Returns the count of neighbors we are aware of that are within the given client draw distance from any
-        /// of our edges
-        /// </summary>
-        /// <param name="drawDistance">DD in meters</param>
-        /// <returns>Number of known neighbors</returns>
-        public int GetKnownNeighborCountWithinClientDD(uint drawDistance)
-        {
-            if (drawDistance == 0)
-                throw new ArgumentOutOfRangeException("drawDistance can't be 0");
-
-            drawDistance = Math.Min(drawDistance, MAX_DRAW_DISTANCE);
-
-            uint xmin, xmax, ymin, ymax;
-            var regionInfo = _scene.RegionInfo;
-            Util.GetDrawDistanceBasedRegionRectangle(drawDistance, regionInfo.RegionLocX, regionInfo.RegionLocY, out xmin, out xmax, out ymin, out ymax);
-
-            int neighborCount = 0;
-            lock (_knownNeighbors)
-            {
-                foreach (KnownNeighborRegion neighbor in _knownNeighbors.Values)
-                {
-                    if (Util.IsWithinDDRectangle(neighbor.RegionInfo.RegionLocX, neighbor.RegionInfo.RegionLocY,
-                        xmin, xmax, ymin, ymax))
-                    {
-                        neighborCount++;
-                    }
-                }
-            }
-
-            return neighborCount;
-        }
     }
 }

--- a/OpenSim/Region/FrameworkTests/SurroundingRegionManagerTests.cs
+++ b/OpenSim/Region/FrameworkTests/SurroundingRegionManagerTests.cs
@@ -363,8 +363,8 @@ namespace OpenSim.Region.FrameworkTests
             Assert.NotNull(srm.GetKnownNeighborAt(1001, 1001));
 
             //try a surrounding query
-            Assert.AreEqual(8, srm.GetKnownNeighborsWithinClientDD(1).Count);
-            Assert.AreEqual(8, srm.GetKnownNeighborsWithinClientDD(256).Count);
+            Assert.AreEqual(8, srm.GetKnownNeighborsWithinClientDD(1, 2).Count);
+            Assert.AreEqual(8, srm.GetKnownNeighborsWithinClientDD(256, 2).Count);
         }
 
         [Test]
@@ -453,11 +453,11 @@ namespace OpenSim.Region.FrameworkTests
 
 
             //try a surrounding query
-            Assert.AreEqual(8, srm.GetKnownNeighborsWithinClientDD(1).Count);
-            Assert.AreEqual(8, srm.GetKnownNeighborsWithinClientDD(256).Count);
-            Assert.AreEqual(24, srm.GetKnownNeighborsWithinClientDD(257).Count);
-            Assert.AreEqual(24, srm.GetKnownNeighborsWithinClientDD(512).Count);
-            Assert.AreEqual(24, srm.GetKnownNeighborsWithinClientDD(1024).Count);
+            Assert.AreEqual(8, srm.GetKnownNeighborsWithinClientDD(1, 2).Count);
+            Assert.AreEqual(8, srm.GetKnownNeighborsWithinClientDD(256, 2).Count);
+            Assert.AreEqual(24, srm.GetKnownNeighborsWithinClientDD(257, 2).Count);
+            Assert.AreEqual(24, srm.GetKnownNeighborsWithinClientDD(512, 2).Count);
+            Assert.AreEqual(24, srm.GetKnownNeighborsWithinClientDD(1024, 2).Count);
         }
     }
 }


### PR DESCRIPTION
Added a `LimitNeighbors` option to the `PresenceFlags` for region changes, and `/!neighbors range 1` command. Does not affect the range that region servers see, only the range viewers are informed about on region entrance.

The purpose of this is to test whether it would be beneficial to restore the old range of 1 region for neighbors, for bandwidth and connection reasons.  The current value of 2 can result in as many as 25 last regions connected to a viewer session, 30 regions on a crossing, and as many as 50 regions connected (on a teleport).  If a fair number of these have high content in the region, it has crashed viewers and seriously impacted performance. This is in some ways a stop-gap solution until Halcyon servers support view frustums and interest lists, but even then this option may be useful to limit wasted bandwidth when you don't care about neighbors, to limit neighbors during photography or recording, to test various features, to force a reconnection to distant regions, or even to provide region-wide privacy in some cases.

Also removed unused `GetKnownNeighborCountWithinClientDD` function.