### PR TITLE
Bandwidth usage fixes

### DIFF
--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -1077,6 +1077,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
         private Int32 m_LastQueueFill = 0;
         private Int32 m_maxUpdates = 0;
         private bool m_lastSentFull = false;
+        private Int32 m_prevOutboundQueueSize = 0;
 
         private void EmptyQueueProcessUpdates(ThrottleOutPacketTypeFlags categories)
         {
@@ -1093,13 +1094,15 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                         evt.Set();
                     }
 
+                    m_LastQueueFill = 0;
                     return;
                 }
 
                 int lastLatency = 0;
                 if (m_maxUpdates == 0 || m_LastQueueFill == 0)
                 {
-                    m_maxUpdates = m_udpServer.PrimUpdatesPerCallback;
+                    if (m_maxUpdates == 0)
+                        m_maxUpdates = m_udpServer.PrimUpdatesPerCallback;
                 }
                 else
                 {
@@ -1149,7 +1152,11 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 m_lastSentFull = sentAllTerse || sentAllFull;
 
                 //if (lastLatency > 35)
-               //     m_log.DebugFormat("[LLCV]: Last latency {0}, Max Updates {1}, Queue Size: {2}", lastLatency, m_maxUpdates, m_udpClient.OutboundQueueSize);
+                if ((m_udpClient.OutboundQueueSize > 0) && (m_udpClient.OutboundQueueSize != m_prevOutboundQueueSize))
+                {
+                    // m_log.DebugFormat("[LLCV]: Last latency {0}, Max Updates {1}, Queue Size: {2}", lastLatency, m_maxUpdates, m_udpClient.OutboundQueueSize);
+                    m_prevOutboundQueueSize = m_udpClient.OutboundQueueSize;
+                }
             }
         }
 
@@ -3564,6 +3571,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                         (ushort)(Scene.TimeDilation * ushort.MaxValue);
 
                 int max = Math.Min(m_primFullUpdates.Count, updatesToSend);
+                // m_log.DebugFormat("[ProcessPrimFullUpdates]: m_primFullUpdates={0} updatesToSend={1} max={2}", m_primFullUpdates.Count, updatesToSend, max);
 
                 outPacket.ObjectData = new ObjectUpdatePacket.ObjectDataBlock[max];
 
@@ -5769,6 +5777,11 @@ namespace OpenSim.Region.ClientStack.LindenUDP
         /// <param name="throttles"></param>
         public void SetChildAgentThrottle(byte[] throttles)
         {
+            float total = 0;
+            foreach (float throttle in throttles)
+                total += throttle;
+            m_log.DebugFormat("[LLCV]: SetChildAgentThrottle: [0]={0} total={1}", throttles[0], total);
+
             if (m_udpClient.SetThrottles(throttles)) //if throttle changed reset updates
             {
                 m_maxUpdates = m_udpServer.PrimUpdatesPerCallback;

--- a/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLClientView.cs
@@ -5777,11 +5777,6 @@ namespace OpenSim.Region.ClientStack.LindenUDP
         /// <param name="throttles"></param>
         public void SetChildAgentThrottle(byte[] throttles)
         {
-            float total = 0;
-            foreach (float throttle in throttles)
-                total += throttle;
-            m_log.DebugFormat("[LLCV]: SetChildAgentThrottle: [0]={0} total={1}", throttles[0], total);
-
             if (m_udpClient.SetThrottles(throttles)) //if throttle changed reset updates
             {
                 m_maxUpdates = m_udpServer.PrimUpdatesPerCallback;

--- a/OpenSim/Region/ClientStack/LindenUDP/LLUDPClient.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLUDPClient.cs
@@ -373,9 +373,12 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             // Update the token buckets with new throttle values
             TokenBucket bucket;
             int oldRate = m_throttle.DripRate;
+            // DripRates are in bytes per second, throttles for encoding to viewer are in bits per second.
+            int oldKBits = (oldRate * 8) / 1024;    // convert to bits then KBits
             bool throttleChanged = (m_throttle.DripRate != m_throttle.NormalizedDripRate(totalBytes));
-            if (throttleChanged) m_log.InfoFormat("[LLUDPCLIENT]: Viewer agent bandwidth throttle request {0} kbps -> {1} kbps.", oldRate, totalKBits);
+            if (throttleChanged) m_log.InfoFormat("[LLUDPCLIENT]: Viewer agent bandwidth throttle request {0} kbps -> {1} kbps.", oldKBits, totalKBits);
 
+            // Bucket drip/burst rates are in bytes per second (stored internally as bytes per millisecond)
             bucket = m_throttle;
             bucket.DripRate = totalBytes;
             bucket.MaxBurst = totalBytes;

--- a/OpenSim/Region/ClientStack/LindenUDP/LLUDPClient.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLUDPClient.cs
@@ -444,6 +444,10 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 m_unpackedThrottles = throttles;
             }
 
+            m_log.DebugFormat("[THROTTLE]: Task throttle resend={0} and task={1} kpbs of {2} kbps.",
+                m_throttleCategories[(int)ThrottleOutPacketType.Resend].DripRate * 8 / 1024,
+                m_throttleCategories[(int)ThrottleOutPacketType.Task].DripRate * 8 / 1024,
+                m_throttle.DripRate * 8 / 1024);
             return throttles;
         }
 

--- a/OpenSim/Region/ClientStack/LindenUDP/LLUDPClient.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLUDPClient.cs
@@ -364,7 +364,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             int totalBytes = resend + land + wind + cloud + task + texture + asset + state;
             int totalBits = totalBytes * 8;
             int totalKBits = totalBits / 1024;
-            m_log.DebugFormat("[UDP]: Throttle task={0} of {1} Kbps", (task * 8) / 1024, totalKBits);
+            // m_log.DebugFormat("[UDP]: Throttle task={0} of {1} Kbps", (task * 8) / 1024, totalKBits);
 
             //m_log.InfoFormat("[LLUDP] Client {0} throttle {1}", AgentID, total); 
             //m_log.DebugFormat("[LLUDPCLIENT]: {0} is setting throttles. Resend={1}, Land={2}, Wind={3}, Cloud={4}, Task={5}, Texture={6}, Asset={7}, State={8}, Total={9}",
@@ -444,10 +444,10 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 m_unpackedThrottles = throttles;
             }
 
-            m_log.DebugFormat("[THROTTLE]: Task throttle resend={0} and task={1} kpbs of {2} kbps.",
-                m_throttleCategories[(int)ThrottleOutPacketType.Resend].DripRate * 8 / 1024,
-                m_throttleCategories[(int)ThrottleOutPacketType.Task].DripRate * 8 / 1024,
-                m_throttle.DripRate * 8 / 1024);
+            //m_log.DebugFormat("[THROTTLE]: Task throttle resend={0} and task={1} kpbs of {2} kbps.",
+            //    m_throttleCategories[(int)ThrottleOutPacketType.Resend].DripRate * 8 / 1024,
+            //    m_throttleCategories[(int)ThrottleOutPacketType.Task].DripRate * 8 / 1024,
+            //    m_throttle.DripRate * 8 / 1024);
             return throttles;
         }
 

--- a/OpenSim/Region/ClientStack/LindenUDP/LLUDPClient.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/LLUDPClient.cs
@@ -316,30 +316,38 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 adjData = throttleData;
             }
 
-            // 0.125f converts from bits to bytes
-            int resend = (int)(BitConverter.ToSingle(adjData, pos) * 0.125f); pos += 4;
-            int land = (int)(BitConverter.ToSingle(adjData, pos) * 0.125f); pos += 4;
-            int wind = (int)(BitConverter.ToSingle(adjData, pos) * 0.125f); pos += 4;
-            int cloud = (int)(BitConverter.ToSingle(adjData, pos) * 0.125f); pos += 4;
-            int task = (int)(BitConverter.ToSingle(adjData, pos) * 0.125f); pos += 4;
-            int texture = (int)(BitConverter.ToSingle(adjData, pos) * 0.125f); pos += 4;
-            int asset = (int)(BitConverter.ToSingle(adjData, pos) * 0.125f);
+            // These adjData values come in from the viewer in bits. (Not Kbits, not bytes, not Kbytes.)
+            int resend = (int)(BitConverter.ToSingle(adjData, pos)); pos += 4;
+            int land = (int)(BitConverter.ToSingle(adjData, pos)); pos += 4;
+            int wind = (int)(BitConverter.ToSingle(adjData, pos)); pos += 4;
+            int cloud = (int)(BitConverter.ToSingle(adjData, pos)); pos += 4;
+            int task = (int)(BitConverter.ToSingle(adjData, pos)); pos += 4;
+            int texture = (int)(BitConverter.ToSingle(adjData, pos)); pos += 4;
+            int asset = (int)(BitConverter.ToSingle(adjData, pos));
+            // m_log.DebugFormat("[LLUDPCLIENT]: throttles: Resend={0}, Land={1}, Wind={2}, Cloud={3}, Task={4}, Texture={5}, Asset={6}, Total={7}", resend, land, wind, cloud, task, texture, asset, resend + land + wind + cloud + task + texture + asset);
 
-            //int totalKbps = ((resend + land + wind + cloud + task + texture + asset)/1024)*8;   // save this original value for below
+            // undo LL's 50% hack first, this yields original bps rates (from viewer preferences).
+            resend = (int)(resend / 1.5f);
+            land = (int)(land / 1.5f);
+            wind = (int)(wind / 1.5f);
+            cloud = (int)(cloud / 1.5f);
+            task = (int)(task / 1.5f);
+            texture = (int)(texture / 1.5f);
+            asset = (int)(asset / 1.5f);
+
+            // convert from bits to bytes (sometimes not multiples of 8)
+            resend = (resend + 7)/8;
+            land = (land + 7) / 8;
+            wind = (wind + 7) / 8;
+            cloud = (cloud + 7) / 8;
+            task = (task + 7) / 8;
+            texture = (texture + 7) / 8;
+            asset = (asset + 7) / 8;
+            // Now these category sizes are in bytes, for server use, including matching units for MTU check.
 
             // State is a subcategory of task that we allocate a percentage to
             int state = (int)((float)task * STATE_TASK_PERCENTAGE);
             task -= state;
-
-            //subtract 33% from the total to make up for LL's 50% hack
-            resend = (int)(resend * 0.6667);
-            land = (int)(land * 0.6667);
-            wind = (int)(wind * 0.6667);
-            cloud = (int)(cloud * 0.6667);
-            task = (int)(task * 0.6667);
-            texture = (int)(texture * 0.6667);
-            asset = (int)(asset * 0.6667);
-            state = (int)(state * 0.6667);
 
             // Make sure none of the throttles are set below our packet MTU,
             // otherwise a throttle could become permanently clogged
@@ -352,21 +360,25 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             asset = Math.Max(asset, LLUDPServer.MTU);
             state = Math.Max(state, LLUDPServer.MTU);
 
-            int total = resend + land + wind + cloud + task + texture + asset + state;
+            // Let's calculate some convenience totals.
+            int totalBytes = resend + land + wind + cloud + task + texture + asset + state;
+            int totalBits = totalBytes * 8;
+            int totalKBits = totalBits / 1024;
+            m_log.DebugFormat("[UDP]: Throttle task={0} of {1} Kbps", (task * 8) / 1024, totalKBits);
 
             //m_log.InfoFormat("[LLUDP] Client {0} throttle {1}", AgentID, total); 
             //m_log.DebugFormat("[LLUDPCLIENT]: {0} is setting throttles. Resend={1}, Land={2}, Wind={3}, Cloud={4}, Task={5}, Texture={6}, Asset={7}, State={8}, Total={9}",
-            //    AgentID, resend, land, wind, cloud, task, texture, asset, state, total);
+            //    AgentID, resend, land, wind, cloud, task+state, texture, asset, state, total);
 
             // Update the token buckets with new throttle values
             TokenBucket bucket;
-
-            bool throttleChanged = (m_throttle.DripRate != m_throttle.NormalizedDripRate(total));
-//            if (throttleChanged) m_log.InfoFormat("[LLUDPCLIENT]: Viewer agent bandwidth throttle request for {0} to {1} kbps.", this.AgentID, totalKbps);
+            int oldRate = m_throttle.DripRate;
+            bool throttleChanged = (m_throttle.DripRate != m_throttle.NormalizedDripRate(totalBytes));
+            if (throttleChanged) m_log.InfoFormat("[LLUDPCLIENT]: Viewer agent bandwidth throttle request {0} kbps -> {1} kbps.", oldRate, totalKBits);
 
             bucket = m_throttle;
-            bucket.DripRate = total;
-            bucket.MaxBurst = total;
+            bucket.DripRate = totalBytes;
+            bucket.MaxBurst = totalBytes;
 
             bucket = m_throttleCategories[(int)ThrottleOutPacketType.Resend];
             bucket.DripRate = resend;
@@ -415,14 +427,15 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 float[] fthrottles = new float[THROTTLE_CATEGORY_COUNT - 1];
                 int i = 0;
 
-                fthrottles[i++] = (float)m_throttleCategories[(int)ThrottleOutPacketType.Resend].DripRate;
-                fthrottles[i++] = (float)m_throttleCategories[(int)ThrottleOutPacketType.Land].DripRate;
-                fthrottles[i++] = (float)m_throttleCategories[(int)ThrottleOutPacketType.Wind].DripRate;
-                fthrottles[i++] = (float)m_throttleCategories[(int)ThrottleOutPacketType.Cloud].DripRate;
-                fthrottles[i++] = (float)(m_throttleCategories[(int)ThrottleOutPacketType.Task].DripRate +
-                                          m_throttleCategories[(int)ThrottleOutPacketType.State].DripRate);
-                fthrottles[i++] = (float)m_throttleCategories[(int)ThrottleOutPacketType.Texture].DripRate;
-                fthrottles[i++] = (float)m_throttleCategories[(int)ThrottleOutPacketType.Asset].DripRate;
+                // DripRates are in bytes per second, throttles for encoding to viewer are in bits per second.
+                fthrottles[i++] = (float)m_throttleCategories[(int)ThrottleOutPacketType.Resend].DripRate * 8;
+                fthrottles[i++] = (float)m_throttleCategories[(int)ThrottleOutPacketType.Land].DripRate * 8;
+                fthrottles[i++] = (float)m_throttleCategories[(int)ThrottleOutPacketType.Wind].DripRate * 8;
+                fthrottles[i++] = (float)m_throttleCategories[(int)ThrottleOutPacketType.Cloud].DripRate * 8;
+                fthrottles[i++] = (float)(m_throttleCategories[(int)ThrottleOutPacketType.Task].DripRate * 8 +
+                                          m_throttleCategories[(int)ThrottleOutPacketType.State].DripRate * 8);
+                fthrottles[i++] = (float)m_throttleCategories[(int)ThrottleOutPacketType.Texture].DripRate * 8;
+                fthrottles[i++] = (float)m_throttleCategories[(int)ThrottleOutPacketType.Asset].DripRate * 8;
 
                 throttles = new UnpackedThrottles(fthrottles);
                 m_unpackedThrottles = throttles;

--- a/OpenSim/Region/ClientStack/LindenUDP/ThrottleRates.cs
+++ b/OpenSim/Region/ClientStack/LindenUDP/ThrottleRates.cs
@@ -38,22 +38,26 @@ namespace OpenSim.Region.ClientStack.LindenUDP
     /// </summary>
     public sealed class ThrottleRates
     {
+        // Viewer rates in Kbps for a total bandwidth value of 1000 kbps:
+        // BW_PRESET_1000[] = { 100, 100,  20,  20, 310, 310, 140 };
+        // We'll use the same (but store in bytes not Kbits).
+
         /// <summary>Drip rate for resent packets</summary>
-        public int Resend = 12500;
+        public int Resend = 12500;  // 100Kbps / 8b per B
         /// <summary>Drip rate for terrain packets</summary>
-        public int Land = 1400;
+        public int Land = 12500;    // 100Kbps / 8b per B
         /// <summary>Drip rate for wind packets</summary>
-        public int Wind = 1400;
+        public int Wind = 2500;     //  20Kbps / 8b per B
         /// <summary>Drip rate for cloud packets</summary>
-        public int Cloud = 1400;
+        public int Cloud = 2500;    //  20Kbps / 8b per B
         /// <summary>Drip rate for task packets</summary>
-        public int Task = 1400;
+        public int Task = 38750;    // 310Kbps / 8b per B
         /// <summary>Drip rate for texture packets</summary>
-        public int Texture = 1400;
+        public int Texture = 38750; // 310Kbps / 8b per B
         /// <summary>Drip rate for asset packets</summary>
-        public int Asset = 1400;
+        public int Asset = 17500;   // 140Kbps / 8b per B
         /// <summary>Drip rate for state packets</summary>
-        public int State = 1400;
+        public int State = 31000;    // 80% of Task
         /// <summary>Drip rate for the parent token bucket</summary>
         public int Total;
 

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -3733,6 +3733,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         // Neighbor regions bandwidth percentage (as float).
         private const float NEIGHBORS_BANDWIDTH_PERCENTAGE = 0.60f;
+        private const float MINIMUM_BANDWIDTH_PERCENTAGE = 0.10f;
         private float CalculateNeighborBandwidthMultiplier()
         {
             int innacurateNeighbors = this.m_remotePresences.GetRemotePresenceCount();
@@ -3740,7 +3741,8 @@ namespace OpenSim.Region.Framework.Scenes
             if (innacurateNeighbors != 0)
             {
                 //only allow a percentage of our bandwidth to be used for neighbor regions
-                return NEIGHBORS_BANDWIDTH_PERCENTAGE / (float)innacurateNeighbors;
+                float multiplier = NEIGHBORS_BANDWIDTH_PERCENTAGE / (float)innacurateNeighbors;
+                return (multiplier < MINIMUM_BANDWIDTH_PERCENTAGE) ? MINIMUM_BANDWIDTH_PERCENTAGE : multiplier;
             }
             else
             {

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -3731,18 +3731,20 @@ namespace OpenSim.Region.Framework.Scenes
             m_scene.SendOutChildAgentUpdates(agentpos, this);
         }
 
+        // Neighbor regions bandwidth percentage (as float).
+        private const float NEIGHBORS_BANDWIDTH_PERCENTAGE = 0.60f;
         private float CalculateNeighborBandwidthMultiplier()
         {
             int innacurateNeighbors = this.m_remotePresences.GetRemotePresenceCount();
 
             if (innacurateNeighbors != 0)
             {
-                //only allow 30% of our bandwidth to be used for neighbor regions
-                return 0.30f / (float)innacurateNeighbors;
+                //only allow a percentage of our bandwidth to be used for neighbor regions
+                return NEIGHBORS_BANDWIDTH_PERCENTAGE / (float)innacurateNeighbors;
             }
             else
             {
-                return 0.30f;
+                return NEIGHBORS_BANDWIDTH_PERCENTAGE;
             }
         }
 


### PR DESCRIPTION

Fixed bandwidth calculation problems, especially neighbor regions. …
- Fixed the DripRate to throttle value conversion, which confused bits with bytes, causing rates to be 1/8 what they should have been.
- The above problem was because the units of measurement (bps, Kbps, bytes, KBps) were confused throughout most of this code, so I've added a lot more comments, small tweaks to the code to make it more readable, understandable and maintainable. Hopefully the units of measurement are now clear.
- Fixed a total stall of outbound queues if latency was high (which is somewhat intentional on neighbor regions with the 30ms timer).
- Bandwidth is _seriously_ underused, with a cap of 250KB/s at the viewer end, which results from the effective viewer cap of 2000 kbps, which comes from the hard limit of 3000 kbps.  (Note, IW3 allows a larger number in the Preferences form, but still caps it at 3000 when sending to the server.)  So let's allow more for bandwidth to neighbor regions (doubled).  When moving and adding more regions, the current region is probably mostly filled anyway if not completely filled, or will be by the time the avatar hits the border. And when flying or sailing the waterways, neighbor limits are _overall_ limits.  This might change back to 30% with more viewer tuning and higher bandwidth settings (coming soon, Drake is investigating after I reported these issues.) Also became a problem with the neighbors range of 2 increase a few years ago, since that increased neighbors from 8 to 24, and then we divide the neighbors limit by the number of neighbors. 1/24th of 30% is far too slow of a trickle, especially when we use 2/3rds of the bandwidth of other grids, and we also use it to limit textures via Aperture (nobody else does).
- Given the above, I'm also testing a minimum of 10% bandwidth for each neighbor.  The current viewer limits mean even a 5Mbit connection is underused, and most users probably have something better than that. Those with tight Internet connections can use reduced levels (like 1000) and still get some data from all regions.