### PR TITLE
Fixed NRE seen when avatar took enough damage just after crossing...

### DIFF
--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -4817,6 +4817,11 @@ namespace OpenSim.Region.Framework.Scenes
         public void RequestTeleportToLocation(ScenePresence avatar, ulong regionHandle, Vector3 position,
                                                       Vector3 lookAt, OpenMetaverse.TeleportFlags teleportFlags)
         {
+            if (avatar.IsInTransit || avatar.IsChildAgent)
+            {
+                m_log.DebugFormat("[SCENE COMMUNICATION SERVICE]: RequestTeleportToLocation cannot teleport {0} [{1}], not in region.", avatar.Name, avatar.UUID);
+                return;
+            }
             if (!Permissions.CanTeleport(avatar.UUID))
                 return;
 
@@ -4993,12 +4998,14 @@ namespace OpenSim.Region.Framework.Scenes
                         message.AppendLine(ex.Message);
                     }
 
-                    avatar.ControllingClient.SendTeleportFailed(message.ToString());
+                    if (avatar.ControllingClient != null) // null if the avatar is already in transit/gone
+                        avatar.ControllingClient.SendTeleportFailed(message.ToString());
                 }
                 catch (Exception e)
                 {
                     m_log.ErrorFormat("[SCENE]: Teleport failed for {0} {1}", avatar.Name, e);
-                    avatar.ControllingClient.SendTeleportFailed(e.Message);
+                    if (avatar.ControllingClient != null) // null if the avatar is already in transit/gone
+                        avatar.ControllingClient.SendTeleportFailed(e.Message);
                 }
             }
         }


### PR DESCRIPTION
…in damage-enabled region

```
2017-08-15 01:24:18 [SCENE]: Teleport failed for FirstName LastName
System.AggregateException: One or more errors occurred. --->
AvatarTransitException: Avatar is already in transit
at AvatarTransitController.<TryBeginTransit>d__10.MoveNext() in
AvatarTransitController.cs:line 124
--- End of inner exception stack trace ---
at System.Threading.Tasks.Task.Wait()
at System.Threading.Tasks.Task.Wait()
at Scene.RequestTeleportToLocation() in Scene.cs:line 4982
---> (Inner Exception #0) AvatarTransitException: Avatar is already in
transit
at AvatarTransitController.<TryBeginTransit>d__10.MoveNext() in
AvatarTransitController.cs:line 124<---

2017-08-15 01:24:30 [FIREANDFORGET] Call threw an exception
System.NullReferenceException: Object reference not set to an instance
of an object.
at Scene.RequestTeleportToLocation() in Scene.cs:line 4996
at Scene.RequestTeleportLocation() in Scene.cs:line 4775
at Scene.TeleportClientHome() in Scene.cs:line 3473
at CombatModule.KillAvatar() in CombatModule.cs:line 141
at EventManager.TriggerAvatarKill() in EventManager.cs:line 1145
at ScenePresence.<>c__DisplayClass356_0.<HandleDamage>b__0() in
ScenePresence.cs:line 4545
at Util.SmartThreadPoolCallback() in Framework\Util.cs:line 1785
```