### PR TITLE
Fixed the offsets to be relative to the specified prim at function execute time.

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -8754,8 +8754,9 @@ namespace InWorldz.Phlox.Engine
             var parts = GetLinkPrimsOnly(linknumber);
             foreach (SceneObjectPart part in parts)
             {
-                part.SetCameraEyeOffset(new Vector3((float)eyeOffset.X, (float)eyeOffset.Y, (float)eyeOffset.Z));
-                part.SetCameraAtOffset(new Vector3((float)cameraAt.X, (float)cameraAt.Y, (float)cameraAt.Z));
+                Vector3 localPos = part.IsRootPart() ? Vector3.Zero : part.OffsetPosition;
+                part.SetCameraEyeOffset(new Vector3(localPos + eyeOffset));
+                part.SetCameraAtOffset(new Vector3(localPos + cameraAt));
             }
         }
 


### PR DESCRIPTION
There may be a second problem with the actual offsets applied to either root or child prims, but if confirmed, that will be a separate fix. This commit addresses the lack of offset from the root prim when the specified link is a child prim.