### PR TITLE
Several improvements to asset store operations

### DIFF
--- a/InWorldz/InWorldz.Data.Assets.Stratus/CloudFilesAssetClient.cs
+++ b/InWorldz/InWorldz.Data.Assets.Stratus/CloudFilesAssetClient.cs
@@ -485,7 +485,7 @@ namespace InWorldz.Data.Assets.Stratus
             }
             if (asset.Data.Length > Config.Constants.MAX_CACHEABLE_ASSET_SIZE)
             {
-                statBigAsset++;
+                if (stream == null) statBigAsset++; // only increment if this is the followup call
                 return false;
             }
 
@@ -549,10 +549,7 @@ namespace InWorldz.Data.Assets.Stratus
 
                     using (assetStream = worker.StoreAsset(wireAsset))
                     {
-                        m_log.Warn("Delaying 35 seconds for slow asset store similation for " + asset.FullID);
-                        Thread.Sleep(35000);    // sleep longer than the 
-                        if (this.CacheAssetIfAppropriate(asset.FullID, assetStream, wireAsset))
-                            statPutCached++;
+                        this.CacheAssetIfAppropriate(asset.FullID, assetStream, wireAsset);
                     }
                 }
                 catch (AssetAlreadyExistsException)

--- a/InWorldz/InWorldz.Data.Assets.Stratus/StratusAssetClient.cs
+++ b/InWorldz/InWorldz.Data.Assets.Stratus/StratusAssetClient.cs
@@ -283,7 +283,6 @@ namespace InWorldz.Data.Assets.Stratus
         //see IAssetReceiver
         public void AssetNotFound(OpenMetaverse.UUID assetID, AssetRequestInfo data)
         {
-            m_log.WarnFormat("[InWorldz.Stratus]: Asset not found {0}", assetID);
             this.HandleAssetCallback(assetID, data, null);
         }
 

--- a/OpenSim/Framework/LRUCache.cs
+++ b/OpenSim/Framework/LRUCache.cs
@@ -211,10 +211,14 @@ namespace OpenSim.Framework
             //insert the new item
             _storage.Add(kvp);
 
-            if (!removed)
+            if (_objectSizes != null)
             {
+                if (_objectSizes.ContainsKey(key))  // replaced
+                {
+                    _totalSize -= _objectSizes[key];
+                }
                 _totalSize += size;
-                if (_objectSizes != null) _objectSizes[key] = size;
+                _objectSizes[key] = size;
             }
 
             if (_lastAccessedTime != null)


### PR DESCRIPTION
- `StoreAsset` calls did not use the asset operations threadpool; they were synchronous. `StoreAsset` now precaches the `wireAsset` and immediately returns to the caller once the asset is cached.  Later, asynchronously, it may update the cache with the stream asset, or on error save it to the local cache (as in the past, just async now).
- Also fixed the accounting of sizes in `LRUCache` if an item is being replaced.
- Fixed the excessive "asset not found" reports. `AssetNotFound` is also called from the WHIP client, so all new (CF) assets would produce this report when the operation was in fact a success.