### PR TITLE
 Performance changes to iwAvatarName2Key

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -14685,20 +14685,22 @@ namespace InWorldz.Phlox.Engine
         /// <param name="lastname">Avatar last name</param>
         public void iwAvatarName2Key(string firstname, string lastname)
         {
-            const int LONG_DELAY = 5000;
+            const int LONG_DELAY = 1000;
             const int SHORT_DELAY = 100;
             int delay = LONG_DELAY;
+            UUID agentID = UUID.Zero;
 
             try
             {
-                UUID agentID = World.CommsManager.UserService.Name2Key(firstname, lastname);
-                if (agentID != UUID.Zero)
+                ScenePresence avatar = World.GetScenePresence(firstname, lastname);
+                if (avatar != null)
                 {
-                    // local avatars are cached lookups, so don't penalize if local
-                    ScenePresence avatar = World.GetScenePresence(agentID);
-                    if (avatar != null) 
-                        if (!avatar.IsChildAgent)   // just this region
-                            delay = SHORT_DELAY;    // see Mantis #2263
+                    agentID = avatar.UUID;
+                    delay = SHORT_DELAY;    // see Mantis #2263
+                }
+                else
+                {
+                    agentID = World.CommsManager.UserService.Name2Key(firstname, lastname);
                 }
                 m_ScriptEngine.SysReturn(this.m_itemID, agentID.ToString(), delay);
             }

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -14692,15 +14692,24 @@ namespace InWorldz.Phlox.Engine
 
             try
             {
-                ScenePresence avatar = World.GetScenePresence(firstname, lastname);
-                if (avatar != null)
+                if (!String.IsNullOrWhiteSpace(firstname))
                 {
-                    agentID = avatar.UUID;
-                    delay = SHORT_DELAY;    // see Mantis #2263
-                }
-                else
-                {
-                    agentID = World.CommsManager.UserService.Name2Key(firstname, lastname);
+                    if (String.IsNullOrWhiteSpace(lastname))
+                        lastname = "Resident";
+                    else
+                        lastname = lastname.Trim();
+                    firstname = firstname.Trim();
+
+                    ScenePresence avatar = World.GetScenePresence(firstname, lastname);
+                    if (avatar != null)
+                    {
+                        agentID = avatar.UUID;
+                        delay = SHORT_DELAY;    // see Mantis #2263
+                    }
+                    else
+                    {
+                        agentID = World.CommsManager.UserService.Name2Key(firstname, lastname);
+                    }
                 }
                 m_ScriptEngine.SysReturn(this.m_itemID, agentID.ToString(), delay);
             }

--- a/OpenSim/Framework/Servers/VersionInfo.cs
+++ b/OpenSim/Framework/Servers/VersionInfo.cs
@@ -36,8 +36,6 @@ using System.Reflection;
 namespace OpenSim
 {
     using System;
-    using System.IO;
-    using System.Reflection;
    
     public class VersionInfo
     {

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -5391,6 +5391,16 @@ namespace OpenSim.Region.Framework.Scenes
             return m_sceneGraph.GetScenePresences(filter);
         }
 
+        public ScenePresence GetScenePresence(string first, string last)
+        {
+            string name = first + " " + last;
+            ScenePresence avatar = null;
+            if (TryGetAvatarByName(name, out avatar))
+                return avatar;
+
+            return null;
+        }
+
         /// <summary>
         /// Request a scene presence by UUID
         /// </summary>


### PR DESCRIPTION
- Do not attempt to contact the central User grid service for an ID if the agent is known to the current region. (!) Avoids a network call, and makes lookups of local users very consistently only the 100ms delay.
- Any avatar known to the current region (not just those in the current region) gets the shorter delay on lookup. (i.e. The short delay now applies to lookups of avatars in neighbor regions.)
- Changed the long delay to be 1 second (applied in addition to the User grid service network/lookup time), was 5 seconds.  (That still slows the impact on User when called in a loop by well over 90%.)