### PR TITLE
Eliminate an extra space that was freaking out GitKraken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
-*.mdb 
+*.mdb
 *.mdp
 
 # Nant


### PR DESCRIPTION
The match in GitKraken was against "*.mdb " as that's what was in the file since the line was added.  CLI git must be trimming the strings.