### PR TITLE
Allow StoreAsset to be optionally async, default disabled (opt-in).

### DIFF
--- a/InWorldz/InWorldz.Data.Assets.Stratus/CloudFilesAssetClient.cs
+++ b/InWorldz/InWorldz.Data.Assets.Stratus/CloudFilesAssetClient.cs
@@ -625,8 +625,15 @@ namespace InWorldz.Data.Assets.Stratus
             statTotal++;
             statPut++;
 
-            // Now do the actual CF storage asychronously so as to not block the caller.
-            _threadPool.QueueWorkItem(() => StoreCFAsset(asset, wireAsset));
+            if (Config.Settings.Instance.UseAsyncStore)
+            {
+                // Now do the actual CF storage asychronously so as to not block the caller.
+                _threadPool.QueueWorkItem(() => StoreCFAsset(asset, wireAsset));
+            } else
+            {
+                // This is a blocking write, session/caller will be blocked awaiting completion.
+                StoreCFAsset(asset, wireAsset);
+            }
         }
 
         private static void ReportThrowStorageError(AssetBase asset, Exception e)

--- a/InWorldz/InWorldz.Data.Assets.Stratus/Config/Settings.cs
+++ b/InWorldz/InWorldz.Data.Assets.Stratus/Config/Settings.cs
@@ -64,6 +64,7 @@ namespace InWorldz.Data.Assets.Stratus.Config
         public int CFCacheSize { get; set; }
         public bool DisableWritebackCache { get; set; }
         public bool EnableCFOverwrite { get; set; }
+        public bool UseAsyncStore { get; set; }
 
         //Settings that are for use during unit tests only
         public bool UnitTest_ThrowTimeout { get; set; }

--- a/InWorldz/InWorldz.Data.Assets.Stratus/StratusAssetClient.cs
+++ b/InWorldz/InWorldz.Data.Assets.Stratus/StratusAssetClient.cs
@@ -79,6 +79,7 @@ namespace InWorldz.Data.Assets.Stratus
                 Config.Settings.Instance.CFSupport = stratusConfig.GetBoolean("CFSupport", true);
                 Config.Settings.Instance.LegacySupport = stratusConfig.GetBoolean("LegacySupport", false);
                 Config.Settings.Instance.WhipURL = stratusConfig.GetString("WhipURL", null);
+                Config.Settings.Instance.UseAsyncStore = stratusConfig.GetBoolean("UseAsyncStore", false);
 
                 if (Config.Settings.Instance.LegacySupport == true && Config.Settings.Instance.WhipURL == null)
                 {

--- a/bin/Halcyon.sample.ini
+++ b/bin/Halcyon.sample.ini
@@ -597,3 +597,5 @@
     LegacySupport = true
     WhipURL = "whip://password@localhost:32700"
     WriteTarget = "whip"
+	; developer testing WIP only - never enable this
+	UseAsyncStore = false


### PR DESCRIPTION
Due to subsequent fetches coming only from Aperture (which is unaware of the new asset until the StoreAsset completes the write to CF), we can't signal the session to continue by returning early (as soon as the asset is in the region server cache).

This change effectively reverts the change to make StoreAsset asynchronous, although it leaves it optional in the Halcyon.ini file (default off).

By default, this restores the previous behavior of synchronous CF writes that block the session.