### PR TITLE
Mantis 3337: Increase the limit on iwMakeNotecard to 64K characters.

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -14728,7 +14728,7 @@ namespace InWorldz.Phlox.Engine
         public void iwMakeNotecard(string notecardName, LSL_List contents)
         {
             const int DELAY = 5000;
-            const int MAX_LENGTH = 16384;
+            const int MAX_LENGTH = 65536;   // 64K characters (including newlines)
 
             try
             {


### PR DESCRIPTION
This matches the viewer limit on reading notecards, as well as SL and OpenSim limits for notecards, while still providing a sanity limit for memory use.