### PR TITLE
Moved the Halycon.exe.config (output) contents to the app.config file…

### DIFF
--- a/InWorldz/Halcyon/app.config
+++ b/InWorldz/Halcyon/app.config
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup> -->
+  <configSections>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler,log4net" />
+    <section name="aquilesConfiguration" type="Aquiles.Core.Configuration.AquilesConfigurationSection,Aquiles.Core"/>
+  </configSections>
+  <runtime>
+    <gcConcurrent enabled="true" />
+	  <gcServer enabled="false" />
+  </runtime>
+  <appSettings>
+  </appSettings>
+  <log4net>
+    <appender name="Console" type="OpenSim.Framework.Console.OpenSimAppender, OpenSim.Framework.Console">
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date{HH:mm:ss} - %message%newline" />
+      </layout>
+    </appender>
+    <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
+      <file value="Halcyon.log" />
+      <appendToFile value="true" />
+      <rollingStyle value="Size" />
+      <maxSizeRollBackups value="0" />
+      <maximumFileSize value="50MB" />
+      <staticLogFileName value="true" />
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5level %logger - %message%newline" />
+      </layout>
+    </appender>
+
+    <root>
+      <level value="DEBUG" />
+      <appender-ref ref="Console" />
+      <appender-ref ref="RollingFileAppender" />
+    </root>
+  </log4net>
+
+  <aquilesConfiguration>
+    <loggingManager>InWorldz.Data.Inventory.Cassandra.AquilesNullLogger, InWorldz.Data.Inventory.Cassandra, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</loggingManager>
+    <clusters>
+
+      <add friendlyName="local">
+        <connection poolType="SIZECONTROLLEDPOOL" factoryType="FRAMED">
+          <specialConnectionParameters>
+            <add key="minimumClientsToKeepInPool" value="0" />
+            <add key="maximumClientsToSupportInPool" value="100" />
+            <add key="magicNumber" value="4" />
+          </specialConnectionParameters>
+        </connection>
+        <endpointManager type="ROUNDROBIN" defaultTimeout="6000">
+          <cassandraEndpoints>
+            <add address="127.0.0.1" port="9160"/>
+          </cassandraEndpoints>
+        </endpointManager>
+      </add>
+
+    </clusters>
+
+  </aquilesConfiguration>
+
+</configuration>


### PR DESCRIPTION
… so it won't be lost on rebuilds, clean and other VS2017 IDE settings changes.

(Change to .NET 4.6.2 is in there but commented-out so that only one change is in this pull, which should result in no changes on the output files.)