### PR TITLE
Mitigate against a late CompleteMovement retry which is a Bad Thing

### DIFF
--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1532,16 +1532,16 @@ namespace OpenSim.Region.Framework.Scenes
         public void CompleteMovement()
         {
             int completeMovementStart = Environment.TickCount;
+            m_log.InfoFormat("[SCENE PRESENCE]: CompleteMovement received for {0} ({1}) in region {2} status={3}",
+                UUID.ToString(), Name, Scene.RegionInfo.RegionName, (uint)this.AgentInRegion);
+            DumpDebug("CompleteMovement", "n/a");
+
+            if (this.AgentInRegion != AgentInRegionFlags.None)
+                return; // Duplicate parallel request? Avoid duplicate online notifications and other problems.
+
             // this.AgentInRegion is initialized to AgentInRegionFlags.None
             try
             {
-                m_log.InfoFormat("[SCENE PRESENCE]: CompleteMovement received for {0} ({1}) in region {2} status={3}", 
-                    UUID.ToString(), Name, Scene.RegionInfo.RegionName, (uint)this.AgentInRegion);
-                DumpDebug("CompleteMovement", "n/a");
-
-                if (this.AgentInRegion != AgentInRegionFlags.None)
-                    return; // Duplicate parallel request? Avoid duplicate online notifications and other problems.
-
                 Vector3 look = Velocity;
                 if (m_isChildAgent)
                 {

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1532,12 +1532,15 @@ namespace OpenSim.Region.Framework.Scenes
         public void CompleteMovement()
         {
             int completeMovementStart = Environment.TickCount;
-            this.AgentInRegion = AgentInRegionFlags.None;
+            // this.AgentInRegion is initialized to AgentInRegionFlags.None
             try
             {
                 m_log.InfoFormat("[SCENE PRESENCE]: CompleteMovement received for {0} ({1}) in region {2} status={3}", 
                     UUID.ToString(), Name, Scene.RegionInfo.RegionName, (uint)this.AgentInRegion);
                 DumpDebug("CompleteMovement", "n/a");
+
+                if (this.AgentInRegion != AgentInRegionFlags.None)
+                    return; // Duplicate parallel request? Avoid duplicate online notifications and other problems.
 
                 Vector3 look = Velocity;
                 if (m_isChildAgent)


### PR DESCRIPTION
This may resolve a large number of "login-status-is-completely-screwed" cases, as well as [Mantis #3287](https://bugs.inworldz.com/mantis/view.php?id=3287).  This `CompleteMovement` request is handled with `PacketHandlingDisposition.HandleSynchronized` however it has an async section at the end, and no protection from queuing up the duplicate request for serial processing once the first call is complete. We're tracking `AgentInRegion` status here so just avoid resetting it at the start, and instead, use it to recognize the duplicate.