### PR TITLE
Mdickson/materials lsl fixes

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -10261,11 +10261,14 @@ namespace InWorldz.Phlox.Engine
                         face = rules.GetLSLIntegerItem(idx++);
 
                         string specular_tex = rules.Data[idx++].ToString();
+                        if (specular_tex == "")
+                            specular_tex = UUID.Zero.ToString();
+
                         UUID SpecularTextureID = InventoryKey(specular_tex, (int)AssetType.Texture);
                         if (SpecularTextureID == UUID.Zero)
                             UUID.TryParse(specular_tex, out SpecularTextureID);
-                        if (SpecularTextureID == UUID.Zero)
-                            return;
+
+                        // UUID.Zero is valid.  It means to clear the specular settings.
                         specular_tex = SpecularTextureID.ToString();
 
                         LSL_Vector specular_repeats = rules.GetVector3Item(idx++);
@@ -10305,11 +10308,14 @@ namespace InWorldz.Phlox.Engine
                         face = rules.GetLSLIntegerItem(idx++);
 
                         string normal_tex = rules.Data[idx++].ToString();
+                        if (normal_tex == "")
+                            normal_tex = UUID.Zero.ToString();
+
                         UUID NormaLTextureID = InventoryKey(normal_tex, (int)AssetType.Texture);
                         if (NormaLTextureID == UUID.Zero)
                             UUID.TryParse(normal_tex, out NormaLTextureID);
-                        if (NormaLTextureID == UUID.Zero)
-                            return;
+
+                        // UUID.Zero is valid.  It means to clear the normal settings.
                         normal_tex = NormaLTextureID.ToString();
 
                         LSL_Vector normal_repeats = rules.GetVector3Item(idx++);

--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -10259,17 +10259,21 @@ namespace InWorldz.Phlox.Engine
                             return;
 
                         face = rules.GetLSLIntegerItem(idx++);
-
                         string specular_tex = rules.Data[idx++].ToString();
-                        if (specular_tex == "")
-                            specular_tex = UUID.Zero.ToString();
 
+                        // First see if its the name of a texture in inventory
                         UUID SpecularTextureID = InventoryKey(specular_tex, (int)AssetType.Texture);
-                        if (SpecularTextureID == UUID.Zero)
-                            UUID.TryParse(specular_tex, out SpecularTextureID);
 
-                        // UUID.Zero is valid.  It means to clear the specular settings.
-                        specular_tex = SpecularTextureID.ToString();
+                        // If we got UUID.Zero back its not a texture name.  Try and parse it as a UUID
+                        // If that fails we'll return an error (should shout one according to the specs)
+                        if (SpecularTextureID == UUID.Zero)
+                        {
+                            if (UUID.TryParse(specular_tex, out SpecularTextureID) == false)
+                                return;
+
+                            // UUID.Zero here is valid.  It means to clear the normal settings.
+                            specular_tex = SpecularTextureID.ToString();
+                        }
 
                         LSL_Vector specular_repeats = rules.GetVector3Item(idx++);
                         LSL_Vector specular_offsets = rules.GetVector3Item(idx++);
@@ -10306,17 +10310,21 @@ namespace InWorldz.Phlox.Engine
                             return;
 
                         face = rules.GetLSLIntegerItem(idx++);
-
                         string normal_tex = rules.Data[idx++].ToString();
-                        if (normal_tex == "")
-                            normal_tex = UUID.Zero.ToString();
 
-                        UUID NormaLTextureID = InventoryKey(normal_tex, (int)AssetType.Texture);
-                        if (NormaLTextureID == UUID.Zero)
-                            UUID.TryParse(normal_tex, out NormaLTextureID);
+                        // First see if its the name of a texture in inventory
+                        UUID NormalTextureID = InventoryKey(normal_tex, (int)AssetType.Texture);
 
-                        // UUID.Zero is valid.  It means to clear the normal settings.
-                        normal_tex = NormaLTextureID.ToString();
+                        // If we got UUID.Zero back its not a texture name.  Try and parse it as a UUID
+                        // If that fails we'll return an error (should shout one according to the specs)
+                        if (NormalTextureID == UUID.Zero)
+                        {
+                            if (UUID.TryParse(normal_tex, out NormalTextureID) == false)
+                                return;
+
+                            // UUID.Zero here is valid.  It means to clear the normal settings.
+                            normal_tex = NormalTextureID.ToString();
+                        }
 
                         LSL_Vector normal_repeats = rules.GetVector3Item(idx++);
                         LSL_Vector normal_offsets = rules.GetVector3Item(idx++);

--- a/InWorldz/InWorldz.Phlox.Engine/Tests/JsonTests.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/Tests/JsonTests.cs
@@ -6,6 +6,7 @@ using Nini.Ini;
 using OpenMetaverse;
 using System.Collections.Generic;
 using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
+using OpenSim.Region.Framework.Scenes;
 
 namespace InWorldz.Phlox.Engine.Tests
 {
@@ -14,6 +15,7 @@ namespace InWorldz.Phlox.Engine.Tests
     public class JsonTests
     {
         LSLSystemAPI lslSystemApi;
+        Scene world;
 
         [TestFixtureSetUp]
         public void Setup()
@@ -21,9 +23,15 @@ namespace InWorldz.Phlox.Engine.Tests
             var iniDoc = new IniDocument();
             var configSource = new IniConfigSource(iniDoc);
             configSource.AddConfig("InWorldz.Phlox");
-            var world = SceneHelper.CreateScene(9000, 1000, 1000);
+            world = SceneHelper.CreateScene(9000, 1000, 1000);
             var engine = new MockScriptEngine(world, configSource);
             lslSystemApi = new LSLSystemAPI(engine, null, 0, UUID.Zero);
+        }
+
+        [TestFixtureTearDown]
+        public void Teardown()
+        {
+            SceneHelper.TearDownScene(world);
         }
 
         [Test]

--- a/InWorldz/InWorldz.Phlox.Engine/Tests/MaterialsTests.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/Tests/MaterialsTests.cs
@@ -7,6 +7,7 @@ using OpenMetaverse;
 using System.Collections.Generic;
 using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
 using OpenSim.Region.FrameworkTests;
+using OpenSim.Region.Framework.Scenes;
 
 namespace InWorldz.Phlox.Engine.Tests
 {
@@ -14,7 +15,8 @@ namespace InWorldz.Phlox.Engine.Tests
     [TestFixture]
     public class MaterialsTests
     {
-        LSLSystemAPI lslSystemApi;
+        Scene world;
+        MockScriptEngine engine;
 
         [TestFixtureSetUp]
         public void Setup()
@@ -22,21 +24,91 @@ namespace InWorldz.Phlox.Engine.Tests
             var iniDoc = new IniDocument();
             var configSource = new IniConfigSource(iniDoc);
             configSource.AddConfig("InWorldz.Phlox");
-            var world = SceneHelper.CreateScene(9000, 1000, 1000);
-            var engine = new MockScriptEngine(world, configSource);
-            var sop = SceneUtil.RandomSOP("Root", 1);
+            world = SceneHelper.CreateScene(9000, 1000, 1000);
+            engine = new MockScriptEngine(world, configSource);
+        }
 
-            lslSystemApi = new LSLSystemAPI(engine, sop, 0, UUID.Zero);
+        [TestFixtureTearDown]
+        public void Teardown()
+        {
+            SceneHelper.TearDownScene(world);
         }
 
         [Test]
         public void TestGetMaterialsForFace()
         {
-            var expectedResult = new LSLList(new List<object> { "dummy", "data" });
+            var sop = SceneUtil.RandomSOP("Root", 1);
+            var group = new SceneObjectGroup(sop);
+            var lslSystemApi = new LSLSystemAPI(engine, sop, 0, UUID.Zero);
+            var expectedResult = new LSLList(new List<object> { UUID.Zero.ToString(), new Vector3(1, 1, 0), new Vector3(0, 0, 0), 0 });
             var rules = new LSLList(new List<object> { ScriptBaseClass.PRIM_NORMAL, 0 });
             LSLList asList = lslSystemApi.llGetPrimitiveParams(rules);
-            Assert.IsTrue(expectedResult.Equals(asList));
+            Assert.That(asList.ToString(), Is.EqualTo(expectedResult.ToString()));
         }
 
+        [Test]
+        public void TestSetAndClearMaterialsForFaceClearsEntry()
+        {
+            var sop = SceneUtil.RandomSOP("Root", 1);
+            sop.OwnerMask = (uint)(PermissionMask.Copy | PermissionMask.Transfer | PermissionMask.Modify);
+            var group = new SceneObjectGroup(sop);
+            var lslSystemApi = new LSLSystemAPI(engine, sop, 0, UUID.Zero);
+
+            // Check that its Zeroed
+            var emptyResult = new LSLList(new List<object> { UUID.Zero.ToString(), new Vector3(1, 1, 0), new Vector3(0, 0, 0), 0 });
+            var rules = new LSLList(new List<object> { ScriptBaseClass.PRIM_NORMAL, 0 });
+            LSLList asList = lslSystemApi.llGetPrimitiveParams(rules);
+            Assert.That(asList.ToString(), Is.EqualTo(emptyResult.ToString()));
+
+            // Set a value and check it
+            var textureId = UUID.Random();
+            var faceZeroData = new LSLList(new List<object> { textureId.ToString(), new Vector3(1, 1, 0), new Vector3(0, 0, 0), 0 });
+            var setMaterialsRequest = rules.Append(faceZeroData);
+            lslSystemApi.llSetLinkPrimitiveParamsFast(0, setMaterialsRequest);
+            LSLList setMaterialsResult = lslSystemApi.llGetLinkPrimitiveParams(0, rules);
+            Assert.That(setMaterialsResult.ToString(), Is.EqualTo(faceZeroData.ToString()));
+
+            // Clear it and Check thats its zeroed
+            var clearMaterialsRequest = rules.Append(emptyResult);
+            lslSystemApi.llSetLinkPrimitiveParamsFast(0, clearMaterialsRequest);
+            LSLList clearMaterialsResult = lslSystemApi.llGetLinkPrimitiveParams(0, clearMaterialsRequest);
+            Assert.That(clearMaterialsResult.ToString(), Is.EqualTo(emptyResult.ToString()));
+        }
+
+        [Test]
+        public void TestSetAndGetMaterialsForFaceForFullPermSOP()
+        {
+            var sop = SceneUtil.RandomSOP("Root", 1);
+            sop.OwnerMask = (uint)(PermissionMask.Copy | PermissionMask.Transfer | PermissionMask.Modify);
+            var group = new SceneObjectGroup(sop);
+            var lslSystemApi = new LSLSystemAPI(engine, sop, 0, UUID.Zero);
+
+            var textureId = UUID.Random();
+            var faceZeroData = new LSLList(new List<object> { textureId.ToString(), new Vector3(1, 1, 0), new Vector3(0, 0, 0), 0 });
+            var rules = new LSLList(new List<object> { ScriptBaseClass.PRIM_NORMAL, 0 });
+            var request = rules.Append(faceZeroData);
+
+            lslSystemApi.llSetLinkPrimitiveParamsFast(0, request);
+            LSLList result = lslSystemApi.llGetLinkPrimitiveParams(0, rules);
+            Assert.That(result.ToString(), Is.EqualTo(faceZeroData.ToString()));
+        }
+
+        [Test]
+        public void TestSetAndGetMaterialsForFaceForNoModSOP()
+        {
+            var sop = SceneUtil.RandomSOP("Root", 1);
+            sop.OwnerMask = (uint)(PermissionMask.Copy | PermissionMask.Transfer);
+            var group = new SceneObjectGroup(sop);
+            var lslSystemApi = new LSLSystemAPI(engine, sop, 0, UUID.Zero);
+
+            var textureId = UUID.Random();
+            var faceZeroData = new LSLList(new List<object> { textureId.ToString(), new Vector3(1, 1, 0), new Vector3(0, 0, 0), 0 });
+            var rules = new LSLList(new List<object> { ScriptBaseClass.PRIM_NORMAL, 0 });
+            var request = rules.Append(faceZeroData);
+
+            lslSystemApi.llSetLinkPrimitiveParamsFast(0, request);
+            LSLList result = lslSystemApi.llGetLinkPrimitiveParams(0, rules);
+            Assert.That(result.ToString(), !Is.EqualTo(faceZeroData.ToString()));
+        }
     }
 }

--- a/InWorldz/InWorldz.Phlox.Engine/Tests/MaterialsTests.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/Tests/MaterialsTests.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using Nini.Config;
+using InWorldz.Testing;
+using InWorldz.Phlox.Types;
+using Nini.Ini;
+using OpenMetaverse;
+using System.Collections.Generic;
+using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
+using OpenSim.Region.FrameworkTests;
+
+namespace InWorldz.Phlox.Engine.Tests
+{
+
+    [TestFixture]
+    public class MaterialsTests
+    {
+        LSLSystemAPI lslSystemApi;
+
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            var iniDoc = new IniDocument();
+            var configSource = new IniConfigSource(iniDoc);
+            configSource.AddConfig("InWorldz.Phlox");
+            var world = SceneHelper.CreateScene(9000, 1000, 1000);
+            var engine = new MockScriptEngine(world, configSource);
+            var sop = SceneUtil.RandomSOP("Root", 1);
+
+            lslSystemApi = new LSLSystemAPI(engine, sop, 0, UUID.Zero);
+        }
+
+        [Test]
+        public void TestGetMaterialsForFace()
+        {
+            var expectedResult = new LSLList(new List<object> { "dummy", "data" });
+            var rules = new LSLList(new List<object> { ScriptBaseClass.PRIM_NORMAL, 0 });
+            LSLList asList = lslSystemApi.llGetPrimitiveParams(rules);
+            Assert.IsTrue(expectedResult.Equals(asList));
+        }
+
+    }
+}

--- a/OpenSim/Region/FrameworkTests/SceneUtil.cs
+++ b/OpenSim/Region/FrameworkTests/SceneUtil.cs
@@ -37,7 +37,7 @@ using OpenSim.Region.Framework.Scenes;
 
 namespace OpenSim.Region.FrameworkTests
 {
-    internal class SceneUtil
+    public class SceneUtil
     {
         private readonly static Random rand = new Random();
 

--- a/prebuild.xml
+++ b/prebuild.xml
@@ -1870,6 +1870,7 @@
       <Reference name="System.Data.SQLite" path="../../bin/"/>
       <Reference name="SmartThreadPool"/>
       <Reference name="nunit.framework" path="../../bin/"/>
+      <Reference name="OpenSim.Region.FrameworkTests"/>
       <Files>
         <Match buildAction="EmbeddedResource" path="Resources" pattern="*.addin.xml" recurse="true"/>
         <Match path="Tests" pattern="*.cs" recurse="true"/>


### PR DESCRIPTION
PRIM_SPECULAR and PRIM_NORMAL now correctly clear a material setting from LSL if NULL_KEY is passed as the texture Id in a material call.  Also wrote test cases for this and to check that we are correctly handling the Get's with regard to texture ids similar in fashion to how PRIM_TEXTURE is handled.