### PR TITLE
Fixed null reference exception when an object included a MOAP whitelist

### DIFF
--- a/OpenSim/Framework/PrimitiveBaseShape.cs
+++ b/OpenSim/Framework/PrimitiveBaseShape.cs
@@ -1358,7 +1358,7 @@ namespace OpenSim.Framework
                 newEntry.InteractPermissions = entry.InteractPermissions;
                 newEntry.Width = entry.Width;
                 if (entry.WhiteList != null)
-                    entry.WhiteList.CopyTo(newEntry.WhiteList, 0);
+                    newEntry.WhiteList = (string[])entry.WhiteList.Clone();
                 else
                     entry.WhiteList = null;
                 newEntry.Width = entry.Width;


### PR DESCRIPTION
Causes failure to send updates, an exception during region persistence (backup), or any time the prim is then copied.