### PR TITLE
Quick fix for fake SOP objects failing unit tests with real serialization calls.

### DIFF
--- a/InWorldz/InWorldz.Region.Data.Thoosa/Tests/Util.cs
+++ b/InWorldz/InWorldz.Region.Data.Thoosa/Tests/Util.cs
@@ -208,6 +208,7 @@ namespace InWorldz.Region.Data.Thoosa.Tests
             part.UUID = UUID.Random();
             part.Velocity = Util.RandomVector();
             part.FromItemID = UUID.Random();
+            part.ServerFlags |= (uint)ServerPrimFlags.SitTargetStateSaved;  // This one has been migrated to the new sit target storage
 
             part.SetSitTarget(true, Util.RandomVector(), Util.RandomQuat(), false);
 


### PR DESCRIPTION
These are only failing because they are "fake" (random) objects created for the test cases, bypassing the real code for the situations being tested. This change fixes the test cases by ensuring that the random SOP objects being created have the sit target persistence migrated flag on.