### PR TITLE
RandomSOPs should have zero FromItemIDs

### DIFF
--- a/OpenSim/Region/FrameworkTests/SceneUtil.cs
+++ b/OpenSim/Region/FrameworkTests/SceneUtil.cs
@@ -113,7 +113,7 @@ namespace OpenSim.Region.FrameworkTests
             part.TouchName = "DoIt";
             part.UUID = UUID.Random();
             part.Velocity = SceneUtil.RandomVector();
-            part.FromItemID = UUID.Random();
+            part.FromItemID = UUID.Zero;    // Always zero for child prims, non-zero for root prims associated with inventory items, after being rezzed only.
 
             part.SetSitTarget(true, SceneUtil.RandomVector(), SceneUtil.RandomQuat(), false);
 


### PR DESCRIPTION
only rezzed objects have non-zero FromItemID but they are serialized from SceneObjectPartSnapshot instead of a normal SOP.  This should fix the remaining SOP serialization/deserialization testcases that were failing.