### PR TITLE
Added reasonable values for the missing [Economy] section for #439 startup exception

### DIFF
--- a/bin/Halcyon.sample.ini
+++ b/bin/Halcyon.sample.ini
@@ -481,16 +481,17 @@
     ;slurl_base = "http://places.inworldz.com/"
 
 [Economy]
-    ; CurrencyServer = "http://localhost/currency.php"
-    LandServer = "http://localhost/landtool.php"
-
-    ObjectCapacity = 45000
-
     ; Money Unit fee to upload textures, animations etc
     PriceUpload = 0
 
     ; Money Unit fee to create groups
     PriceGroupCreate = 0
+
+    ; CurrencyServer = "http://localhost/currency.php"
+    LandServer = "http://localhost/landtool.php"
+
+    ; This is the account Money goes to for fees.  Remember, economy requires that money circulates somewhere... even if it's an upload fee. blank = not used.
+    ; EconomyBaseAccount = 
 
 [Groups]
     Enabled = true

--- a/bin/Halcyon.sample.ini
+++ b/bin/Halcyon.sample.ini
@@ -480,6 +480,18 @@
     ; MUST end with a forward slash.
     ;slurl_base = "http://places.inworldz.com/"
 
+[Economy]
+    ; CurrencyServer = "http://localhost/currency.php"
+    LandServer = "http://localhost/landtool.php"
+
+    ObjectCapacity = 45000
+
+    ; Money Unit fee to upload textures, animations etc
+    PriceUpload = 0
+
+    ; Money Unit fee to create groups
+    PriceGroupCreate = 0
+
 [Groups]
     Enabled = true
 


### PR DESCRIPTION
Doesn't actually fix the null reference exception, that would require another code change, but the default Halcyon.sample.ini file should not ship with the missing section anyway.