### PR TITLE
Tell the ServicePointManager to prefer TLS1.2

### DIFF
--- a/OpenSim/Framework/Servers/HttpServer/BaseHttpServer.cs
+++ b/OpenSim/Framework/Servers/HttpServer/BaseHttpServer.cs
@@ -1496,7 +1496,7 @@ namespace OpenSim.Framework.Servers.HttpServer
 
             try
             {
-                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
                 m_httpListener = new HttpListener();
                 m_httpListener.Prefixes.Add(Protocol + "+:" + Port.ToString() + "/");

--- a/OpenSim/Framework/Servers/HttpServer/BaseHttpServer.cs
+++ b/OpenSim/Framework/Servers/HttpServer/BaseHttpServer.cs
@@ -1496,6 +1496,8 @@ namespace OpenSim.Framework.Servers.HttpServer
 
             try
             {
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
                 m_httpListener = new HttpListener();
                 m_httpListener.Prefixes.Add(Protocol + "+:" + Port.ToString() + "/");
 


### PR DESCRIPTION
Set an enum that makes .NET 4.5 prefer TLS 1.2