### PR TITLE
Updated money transaction 5009 (ObjectPays) to match 5000 (ObjectBuy) format.

### DIFF
--- a/OpenSim/Region/CoreModules/Avatar/Currency/AvatarCurrency.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Currency/AvatarCurrency.cs
@@ -516,8 +516,13 @@ namespace OpenSim.Region.CoreModules.Avatar.Currency
                 return String.Empty;
             }
 
-            string objName = part.ParentGroup.Name;
-            string description = String.Format("{0} paid {1}", objName, resolveAgentName(destAvatarID));
+            string objName = part.ParentGroup.RootPart.Name;
+            Vector3 pos = part.AbsolutePosition;
+            int posx = (int)(pos.X + 0.5);
+            int posy = (int)(pos.Y + 0.5);
+            int posz = (int)(pos.Z + 0.5);
+            string description = String.Format("{0} in {1} at <{2},{3},{4}>", 
+                objName, part.ParentGroup.Scene.RegionInfo.RegionName, posx, posy, posz);
             int transType = (int)MoneyTransactionType.ObjectPays;
 
             if (amount > 0)


### PR DESCRIPTION
Will help with object name / location columns in transaction history CSV download on web.