### PR TITLE
Preserve the payee in description in 5009 payments from objects.

### DIFF
--- a/OpenSim/Region/CoreModules/Avatar/Currency/AvatarCurrency.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Currency/AvatarCurrency.cs
@@ -521,8 +521,9 @@ namespace OpenSim.Region.CoreModules.Avatar.Currency
             int posx = (int)(pos.X + 0.5);
             int posy = (int)(pos.Y + 0.5);
             int posz = (int)(pos.Z + 0.5);
-            string description = String.Format("{0} in {1} at <{2},{3},{4}>", 
-                objName, part.ParentGroup.Scene.RegionInfo.RegionName, posx, posy, posz);
+            string description = String.Format("Paid {0} via {1} in {2} at <{3},{4},{5}>",
+                resolveAgentName(destAvatarID), objName, 
+                part.ParentGroup.Scene.RegionInfo.RegionName, posx, posy, posz);
             int transType = (int)MoneyTransactionType.ObjectPays;
 
             if (amount > 0)


### PR DESCRIPTION
On second thought, let's preserve the payee in the description text, since these can be confusing with negative payments and the payee being in the "from" avatar.