### PR TITLE
Added support for deleted users

### DIFF
--- a/OpenSim/Data/MySQL/MySQLUserData.cs
+++ b/OpenSim/Data/MySQL/MySQLUserData.cs
@@ -507,18 +507,21 @@ namespace OpenSim.Data.MySQL
                 {
                     using (ISimpleDB conn = _connFactory.GetConnection())
                     {
-                        string squery = "SELECT UUID,username,lastname FROM " + m_usersTableName +
+                        string squery = "SELECT UUID,username,lastname,customType FROM " + m_usersTableName +
                                 " WHERE username like ?first AND lastname like ?second LIMIT 100";
 
                         using (IDataReader reader = conn.QueryAndUseReader(squery, param))
                         {
                             while (reader.Read())
                             {
-                                AvatarPickerAvatar user = new AvatarPickerAvatar();
-                                user.AvatarID = new UUID(Convert.ToString(reader["UUID"]));
-                                user.firstName = (string)reader["username"];
-                                user.lastName = (string)reader["lastname"];
-                                returnlist.Add(user);
+                                if ((string)reader["customType"] != "DELETED")
+                                {
+                                    AvatarPickerAvatar user = new AvatarPickerAvatar();
+                                    user.AvatarID = new UUID(Convert.ToString(reader["UUID"]));
+                                    user.firstName = (string)reader["username"];
+                                    user.lastName = (string)reader["lastname"];
+                                    returnlist.Add(user);
+                                }
                             }
                         }
                     }
@@ -538,18 +541,21 @@ namespace OpenSim.Data.MySQL
 
                     using (ISimpleDB conn = _connFactory.GetConnection())
                     {
-                        string squery = "SELECT UUID,username,lastname FROM " + m_usersTableName +
+                        string squery = "SELECT UUID,username,lastname,customType FROM " + m_usersTableName +
                             " WHERE username like ?first OR lastname like ?first LIMIT 100";
 
                         using (IDataReader reader = conn.QueryAndUseReader(squery, param))
                         {
                             while (reader.Read())
                             {
-                                AvatarPickerAvatar user = new AvatarPickerAvatar();
-                                user.AvatarID = new UUID(Convert.ToString(reader["UUID"]));
-                                user.firstName = (string)reader["username"];
-                                user.lastName = (string)reader["lastname"];
-                                returnlist.Add(user);
+                                if ((string)reader["customType"] != "DELETED")
+                                {
+                                    AvatarPickerAvatar user = new AvatarPickerAvatar();
+                                    user.AvatarID = new UUID(Convert.ToString(reader["UUID"]));
+                                    user.firstName = (string)reader["username"];
+                                    user.lastName = (string)reader["lastname"];
+                                    returnlist.Add(user);
+                                }
                             }
                         }
                     }

--- a/OpenSim/Framework/Communications/Services/LoginService.cs
+++ b/OpenSim/Framework/Communications/Services/LoginService.cs
@@ -818,7 +818,20 @@ namespace OpenSim.Framework.Communications.Services
         public virtual UserProfileData GetTheUser(string firstname, string lastname)
         {
             // Login service must always force a refresh here, since local/VM User server may have updated data on logout.
-            return m_userManager.GetUserProfile(firstname, lastname, true);
+            UserProfileData userProfile = m_userManager.GetUserProfile(firstname, lastname, true);
+            if (userProfile == null)
+                return null;
+
+            // Is this a deleted account?
+            if (m_userManager.IsCustomTypeDeleted(userProfile.CustomType))
+                return null;
+
+            // Is it a profile that was remapped from a deleted account?
+            if (m_userManager.IsDeletedUserAccount(userProfile))
+                if ((userProfile.FirstName != firstname) || (userProfile.SurName != lastname))
+                    return null;
+
+            return userProfile;
         }
 
         /// <summary>

--- a/OpenSim/Framework/Communications/Services/LoginService.cs
+++ b/OpenSim/Framework/Communications/Services/LoginService.cs
@@ -826,11 +826,6 @@ namespace OpenSim.Framework.Communications.Services
             if (m_userManager.IsCustomTypeDeleted(userProfile.CustomType))
                 return null;
 
-            // Is it a profile that was remapped from a deleted account?
-            if (m_userManager.IsDeletedUserAccount(userProfile))
-                if ((userProfile.FirstName != firstname) || (userProfile.SurName != lastname))
-                    return null;
-
             return userProfile;
         }
 

--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -127,8 +127,6 @@ namespace OpenSim.Framework.Communications
         private readonly Dictionary<string, CachedUserInfo> m_userInfoByName
             = new Dictionary<string, CachedUserInfo>();
 
-        private Dictionary<String, UUID> customUserMap = new Dictionary<string, UUID>();
-
         public const string CUSTOM_TYPE_DELETED = "DELETED";
         private UUID m_deletedUserAccount = UUID.Zero;
 
@@ -153,7 +151,6 @@ namespace OpenSim.Framework.Communications
                 UUID uuid = UUID.Zero;
                 if (UUID.TryParse(deletedStr.Trim(), out uuid))
                 {
-                    customUserMap.Add(CUSTOM_TYPE_DELETED, uuid);
                     m_deletedUserAccount = uuid;
                 }
             }
@@ -301,17 +298,16 @@ namespace OpenSim.Framework.Communications
             if (profile == null)
                 return null;
 
-            // Check if it's a special
-            string customType = profile.CustomType.Trim().ToUpper();
-            UUID remappedID = UUID.Zero;
-            if (!customUserMap.TryGetValue(customType, out remappedID))
+            // Continue on right away if it's not a deleted account.
+            if (profile.CustomType.Trim().ToUpper() != CUSTOM_TYPE_DELETED)
                 return profile;
 
-            if (profile.ID == remappedID)
+            // Check if it's THE substitute deleted account
+            if (profile.ID == DeletedUserAccount)
                 return profile; // avoid infinite recursion
 
-            // Otherwise it's a special customType (DELETED) and remap the UUID to the special account.
-            return GetUserProfile(remappedID);
+            // Otherwise it's a special customType==DELETED and remap the UUID to the special account.
+            return GetUserProfile(DeletedUserAccount);
         }
 
         private UserProfileData _GetUserProfileData(UUID uuid)

--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -390,7 +390,6 @@ namespace OpenSim.Framework.Communications
                                     // still not found, get it from User service (or db if this is User).
                                     profile = _GetUserProfileData(uuid);
                                     if (profile != null)
-                                    if (profile != null)
                                     {
                                         // Refresh agent data (possibly forced refresh)
                                         profile.CurrentAgent = GetUserAgent(uuid, forceRefresh);

--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -156,7 +156,17 @@ namespace OpenSim.Framework.Communications
             }
         }
 
-        public UUID DeletedUserAccount { get => m_deletedUserAccount; set => m_deletedUserAccount = value; }
+        public UUID DeletedUserAccount
+        {
+            get
+            {
+                return m_deletedUserAccount;
+            }
+            set
+            {
+                m_deletedUserAccount = value;
+            }
+        }
 
         public bool IsDeletedUserAccount(UserProfileData user)
         {

--- a/OpenSim/Framework/Communications/UserProfileManager.cs
+++ b/OpenSim/Framework/Communications/UserProfileManager.cs
@@ -129,6 +129,9 @@ namespace OpenSim.Framework.Communications
 
         private Dictionary<String, UUID> customUserMap = new Dictionary<string, UUID>();
 
+        public const string CUSTOM_TYPE_DELETED = "DELETED";
+        private UUID m_deletedUserAccount = UUID.Zero;
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -144,26 +147,28 @@ namespace OpenSim.Framework.Communications
         public void InitConfig(UserConfig cfg)
         {
             // Currently we only support DeletedUserAccount from the XML config.
-            string customType = "DELETED";
             string deletedStr = cfg.DeletedUserAccount;
             if (deletedStr != String.Empty)
             {
                 UUID uuid = UUID.Zero;
                 if (UUID.TryParse(deletedStr.Trim(), out uuid))
                 {
-                    customUserMap.Add(customType, uuid);
+                    customUserMap.Add(CUSTOM_TYPE_DELETED, uuid);
+                    m_deletedUserAccount = uuid;
                 }
             }
         }
 
-        // Allow deleted users to be remapped to a different account.
-        public UUID RemapCustomProfile(UUID targetUUID, string customType)
-        {
-            string testKey = customType.Trim().ToUpper();
-            if ((testKey != String.Empty)  && customUserMap.ContainsKey(testKey))
-                return customUserMap[testKey];  // special customType override (DELETED)
+        public UUID DeletedUserAccount { get => m_deletedUserAccount; set => m_deletedUserAccount = value; }
 
-            return targetUUID;  // just pass this one through
+        public bool IsDeletedUserAccount(UserProfileData user)
+        {
+            return (user != null) && (user.ID == m_deletedUserAccount);
+        }
+
+        public bool IsCustomTypeDeleted(string customType)
+        {
+            return customType.Trim().ToUpper() == CUSTOM_TYPE_DELETED;
         }
 
         /// <summary>

--- a/OpenSim/Framework/UserConfig.cs
+++ b/OpenSim/Framework/UserConfig.cs
@@ -154,8 +154,12 @@ namespace OpenSim.Framework
                                                 "Known good region X", "1000", false);
             m_configMember.addConfigurationOption("default_Y", ConfigurationOption.ConfigurationTypes.TYPE_UINT32,
                                                 "Known good region Y", "1000", false);
-            m_configMember.addConfigurationOption("deleted_user_account", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
-                                                "Dummy account UUID for deleted users", "1f7d5b12-2241-48fb-8837-9124af453fb5", true);
+            m_configMember.addConfigurationOption("deleted_customtype", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                "customType to recognize as deleted account, e.g. 'DELETED'", DeletedCustomType, true);
+            m_configMember.addConfigurationOption("deleted_username", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                "Text to use to replace user profile first name for deleted users", DeletedUsername, true);
+            m_configMember.addConfigurationOption("deleted_lastname", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                "Text to use to replace user profile last name for deleted users", DeletedLastname, true);
             m_configMember.addConfigurationOption("map_server_uri", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
                                                 "Map server URI?", String.Empty, false);
             m_configMember.addConfigurationOption("profile_server_uri", ConfigurationOption.ConfigurationTypes.TYPE_STRING,

--- a/OpenSim/Framework/UserConfig.cs
+++ b/OpenSim/Framework/UserConfig.cs
@@ -47,7 +47,9 @@ namespace OpenSim.Framework
         public uint HttpPort = ConfigSettings.DefaultUserServerHttpPort;
         public bool HttpSSL = ConfigSettings.DefaultUserServerHttpSSL;
         public uint DefaultUserLevel = 0;
-        public string DeletedUserAccount = String.Empty;
+        public string DeletedCustomType = "DELETED";
+        public string DeletedUsername = "Deleted";
+        public string DeletedLastname = "Account";
 
         public string LibraryName = String.Empty;
         public string LibraryXmlfile = String.Empty;
@@ -216,8 +218,14 @@ namespace OpenSim.Framework
                 case "default_Y":
                     DefaultY = (uint) configuration_result;
                     break;
-                case "deleted_user_account":
-                    DeletedUserAccount = (string)configuration_result;
+                case "deleted_customtype":
+                    DeletedCustomType = (string)configuration_result;
+                    break;
+                case "deleted_username":
+                    DeletedUsername = (string)configuration_result;
+                    break;
+                case "deleted_lastname":
+                    DeletedLastname = (string)configuration_result;
                     break;
                 case "enable_hg_login":
                     EnableHGLogin = (bool)configuration_result;

--- a/OpenSim/Framework/UserConfig.cs
+++ b/OpenSim/Framework/UserConfig.cs
@@ -47,6 +47,7 @@ namespace OpenSim.Framework
         public uint HttpPort = ConfigSettings.DefaultUserServerHttpPort;
         public bool HttpSSL = ConfigSettings.DefaultUserServerHttpSSL;
         public uint DefaultUserLevel = 0;
+        public string DeletedUserAccount = String.Empty;
 
         public string LibraryName = String.Empty;
         public string LibraryXmlfile = String.Empty;
@@ -151,6 +152,8 @@ namespace OpenSim.Framework
                                                 "Known good region X", "1000", false);
             m_configMember.addConfigurationOption("default_Y", ConfigurationOption.ConfigurationTypes.TYPE_UINT32,
                                                 "Known good region Y", "1000", false);
+            m_configMember.addConfigurationOption("deleted_user_account", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
+                                                "Dummy account UUID for deleted users", "1f7d5b12-2241-48fb-8837-9124af453fb5", true);
             m_configMember.addConfigurationOption("map_server_uri", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
                                                 "Map server URI?", String.Empty, false);
             m_configMember.addConfigurationOption("profile_server_uri", ConfigurationOption.ConfigurationTypes.TYPE_STRING,
@@ -212,6 +215,9 @@ namespace OpenSim.Framework
                     break;
                 case "default_Y":
                     DefaultY = (uint) configuration_result;
+                    break;
+                case "deleted_user_account":
+                    DeletedUserAccount = (string)configuration_result;
                     break;
                 case "enable_hg_login":
                     EnableHGLogin = (bool)configuration_result;

--- a/OpenSim/Grid/UserServer.Modules/UserDataBaseService.cs
+++ b/OpenSim/Grid/UserServer.Modules/UserDataBaseService.cs
@@ -64,6 +64,11 @@ namespace OpenSim.Grid.UserServer.Modules
 
         public void PostInitialize()
         {
+            UserConfig cfg;
+            if (m_core.TryGet<UserConfig>(out cfg))
+            {
+                base.InitConfig(cfg);
+            }
         }
 
         public void RegisterHandlers(BaseHttpServer httpServer)

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2137,6 +2137,12 @@ namespace OpenSim.Region.Framework.Scenes
             return false;
         }
 
+        private UUID RemapUserUUID(UUID uuid)
+        {
+            UserProfileData userProfile = this.CommsManager.UserService.GetUserProfile(uuid);
+            return (userProfile == null) ? uuid : userProfile.ID;
+        }
+
         /// <summary>
         /// Loads the World's objects
         /// </summary>
@@ -2154,11 +2160,19 @@ namespace OpenSim.Region.Framework.Scenes
                                       group.GetParts().Count);
                 }
 
+                // Remap user UUIDs to handle deleted user accounts
+                group.OwnerID = RemapUserUUID(group.OwnerID);
+
                 if (IsBadUserLoad(group) || IsBlacklistedLoad(group))
                     continue;   // already reported above
 
                 group.ForEachPart(delegate(SceneObjectPart part)
                 {
+                    // Remap user UUIDs to handle deleted user accounts
+                    part.OwnerID = RemapUserUUID(part.OwnerID);
+                    part.CreatorID = RemapUserUUID(part.CreatorID);
+                    part.LastOwnerID = RemapUserUUID(part.LastOwnerID);
+
                     /// This fixes inconsistencies between this part and the root part.
                     /// In the past, there was a bug in Link operations that did not force
                     /// these permissions on child prims when linking.

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -2137,12 +2137,6 @@ namespace OpenSim.Region.Framework.Scenes
             return false;
         }
 
-        private UUID RemapUserUUID(UUID uuid)
-        {
-            UserProfileData userProfile = this.CommsManager.UserService.GetUserProfile(uuid);
-            return (userProfile == null) ? uuid : userProfile.ID;
-        }
-
         /// <summary>
         /// Loads the World's objects
         /// </summary>
@@ -2160,19 +2154,11 @@ namespace OpenSim.Region.Framework.Scenes
                                       group.GetParts().Count);
                 }
 
-                // Remap user UUIDs to handle deleted user accounts
-                group.OwnerID = RemapUserUUID(group.OwnerID);
-
                 if (IsBadUserLoad(group) || IsBlacklistedLoad(group))
                     continue;   // already reported above
 
                 group.ForEachPart(delegate(SceneObjectPart part)
                 {
-                    // Remap user UUIDs to handle deleted user accounts
-                    part.OwnerID = RemapUserUUID(part.OwnerID);
-                    part.CreatorID = RemapUserUUID(part.CreatorID);
-                    part.LastOwnerID = RemapUserUUID(part.LastOwnerID);
-
                     /// This fixes inconsistencies between this part and the root part.
                     /// In the past, there was a bug in Link operations that did not force
                     /// these permissions on child prims when linking.


### PR DESCRIPTION
Does not remove accounts, just remaps profile lookups if the customType is set to DELETED. Blocks logins by these deleted users, eliminates them from search, remaps their UUIDs on prims.  Allows login of _the_ substitute profile user account.

For GDPR support, this allows the right to be forgotten, even if viewers cache the UUID to name relationship, since this substitutes the deleted user's UUID with a dummy one for a substitute user account.  It does not remove content tagged with the old user's UUID, however it remaps those IDs on region loading to refer to the substitute deleted account.