### PR TITLE
Fix issue #418: Invoke the code to check and apply a fee on group creation if configured.

### DIFF
--- a/OpenSim/Region/CoreModules/Avatar/Currency/AvatarCurrency.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Currency/AvatarCurrency.cs
@@ -283,7 +283,6 @@ namespace OpenSim.Region.CoreModules.Avatar.Currency
 
         public bool GroupCreationCovered(UUID agentID)
         {
-            m_log.Debug("[MONEY]: In Group Creating, of GroupCreationCovered.");
             return AmountCovered(agentID, PriceGroupCreate);
         }
 

--- a/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
+++ b/OpenSim/Region/CoreModules/Capabilities/InventoryCapsModule.cs
@@ -454,10 +454,15 @@ namespace OpenSim.Region.CoreModules.Capabilities
                 CalculateCosts(mm, asset_type, map, out uploadCost, out resourceCost);
 
                 IClientAPI client = m_Scene.SceneContents.GetControllingClient(m_agentID);
-                if (!mm.AmountCovered(client.AgentId, uploadCost))
+                if ((mm == null) || !mm.AmountCovered(client.AgentId, uploadCost))
                 {
                     if (client != null)
-                        client.SendAgentAlertMessage("Unable to upload asset. Insufficient funds.", false);
+                    {
+                        if (mm == null)
+                            client.SendAgentAlertMessage("Unable to upload asset. Missing money module.", false);
+                        else
+                            client.SendAgentAlertMessage("Unable to upload asset. Insufficient funds.", false);
+                    }
 
                     OSDMap errorResponse = new OSDMap();
                     errorResponse["uploader"] = String.Empty;

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
@@ -1049,11 +1049,14 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
             }
 
             UUID groupID = m_groupData.CreateGroup(grID, name, charter, showInList, insigniaID, membershipFee, openEnrollment, allowPublish, maturePublish, remoteClient.AgentId);
-            if (groupID != UUID.Zero)
+            if (groupID == UUID.Zero)
             {
-                mm.ApplyGroupCreationCharge(remoteClient.AgentId);
-                remoteClient.SendCreateGroupReply(groupID, true, "Group created successfullly");
+                remoteClient.SendCreateGroupReply(groupID, true, "Server error attempting to create group (try again later).");
+                return UUID.Zero;
             }
+
+            mm.ApplyGroupCreationCharge(remoteClient.AgentId);
+            remoteClient.SendCreateGroupReply(groupID, true, "Group created successfully.");
 
             // Update the founder with new group information.
             SendAgentGroupDataUpdate(remoteClient, remoteClient.AgentId);

--- a/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/FlexiGroups/FlexiGroupsModule.cs
@@ -1047,15 +1047,16 @@ namespace OpenSim.Region.OptionalModules.Avatar.FlexiGroups
                 remoteClient.SendAgentAlertMessage("Unable to create group. Insufficient funds.", false);
                 return UUID.Zero;
             }
-            mm.ApplyGroupCreationCharge(remoteClient.AgentId);
 
             UUID groupID = m_groupData.CreateGroup(grID, name, charter, showInList, insigniaID, membershipFee, openEnrollment, allowPublish, maturePublish, remoteClient.AgentId);
-
-            remoteClient.SendCreateGroupReply(groupID, true, "Group created successfullly");
+            if (groupID != UUID.Zero)
+            {
+                mm.ApplyGroupCreationCharge(remoteClient.AgentId);
+                remoteClient.SendCreateGroupReply(groupID, true, "Group created successfullly");
+            }
 
             // Update the founder with new group information.
             SendAgentGroupDataUpdate(remoteClient, remoteClient.AgentId);
-
             return groupID;
         }
 


### PR DESCRIPTION
The code to check and apply a fee on group create has never been invoked. This commit updates the group creation (when using FlexiGroups) to check and apply if configured with `PriceGroupCreate` in the `Halcyon.ini` file.