### PR TITLE
Net4.7.1

### DIFF
--- a/InWorldz/Halcyon/Halcyon.csproj
+++ b/InWorldz/Halcyon/Halcyon.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../bin/</OutputPath>
 	  <OutputType>Exe</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>
@@ -64,45 +64,45 @@
 	  <PlatformTarget>x64</PlatformTarget>
 	</PropertyGroup>
 	<ItemGroup>
-	  <Reference Include="LibreMetaverse" >
+	  <Reference Include="LibreMetaverse">
 		  <Name>LibreMetaverse</Name>
 		<HintPath>..\..\bin\LibreMetaverse.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="LibreMetaverse.StructuredData" >
+	  <Reference Include="LibreMetaverse.StructuredData">
 		  <Name>LibreMetaverse.StructuredData</Name>
 		<HintPath>..\..\bin\LibreMetaverse.StructuredData.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="LibreMetaverse.Types" >
+	  <Reference Include="LibreMetaverse.Types">
 		  <Name>LibreMetaverse.Types</Name>
 		<HintPath>..\..\bin\LibreMetaverse.Types.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="log4net" >
+	  <Reference Include="log4net">
 		  <Name>log4net</Name>
 		<HintPath>..\..\bin\log4net.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="Mono.Addins" >
+	  <Reference Include="Mono.Addins">
 		  <Name>Mono.Addins</Name>
 		<HintPath>..\..\bin\Mono.Addins.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="Nini" >
+	  <Reference Include="Nini">
 		  <Name>Nini</Name>
 		<HintPath>..\..\bin\Nini.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="System" >
+	  <Reference Include="System">
 		  <Name>System</Name>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="System.Xml" >
+	  <Reference Include="System.Xml">
 		  <Name>System.Xml</Name>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="XmlRpcCS" >
+	  <Reference Include="XmlRpcCS">
 		  <Name>XmlRpcCS</Name>
 		<HintPath>..\..\bin\XmlRpcCS.dll</HintPath>
 		<Private>False</Private>

--- a/InWorldz/InWorldz.ApplicationPlugins/InWorldz.ApplicationPlugins.csproj
+++ b/InWorldz/InWorldz.ApplicationPlugins/InWorldz.ApplicationPlugins.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/InWorldz/InWorldz.Arbiter/InWorldz.Arbiter.csproj
+++ b/InWorldz/InWorldz.Arbiter/InWorldz.Arbiter.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/InWorldz/InWorldz.Data.Assets.Stratus/InWorldz.Data.Assets.Stratus.csproj
+++ b/InWorldz/InWorldz.Data.Assets.Stratus/InWorldz.Data.Assets.Stratus.csproj
@@ -13,8 +13,8 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputPath>../../bin/</OutputPath>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>

--- a/InWorldz/InWorldz.Data.Inventory.Cassandra/InWorldz.Data.Inventory.Cassandra.csproj
+++ b/InWorldz/InWorldz.Data.Inventory.Cassandra/InWorldz.Data.Inventory.Cassandra.csproj
@@ -13,8 +13,8 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputPath>../../bin/</OutputPath>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>

--- a/InWorldz/InWorldz.Phlox.Engine/InWorldz.Phlox.Engine.csproj
+++ b/InWorldz/InWorldz.Phlox.Engine/InWorldz.Phlox.Engine.csproj
@@ -13,8 +13,8 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputPath>../../bin/</OutputPath>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>

--- a/InWorldz/InWorldz.PhysxPhysics/InWorldz.PhysxPhysics.csproj
+++ b/InWorldz/InWorldz.PhysxPhysics/InWorldz.PhysxPhysics.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  
 	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+	  <OutputPath>..\..\bin\Physics\</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>
 	  <RootNamespace>InWorldz.PhysxPhysics</RootNamespace>

--- a/InWorldz/InWorldz.PhysxPhysics/InWorldz.PhysxPhysics.csproj
+++ b/InWorldz/InWorldz.PhysxPhysics/InWorldz.PhysxPhysics.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>
 	  <RootNamespace>InWorldz.PhysxPhysics</RootNamespace>

--- a/InWorldz/InWorldz.Region.Data.Thoosa/InWorldz.Region.Data.Thoosa.csproj
+++ b/InWorldz/InWorldz.Region.Data.Thoosa/InWorldz.Region.Data.Thoosa.csproj
@@ -13,8 +13,8 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputPath>../../bin/</OutputPath>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>

--- a/InWorldz/InWorldz.RemoteAdmin/InWorldz.RemoteAdmin.csproj
+++ b/InWorldz/InWorldz.RemoteAdmin/InWorldz.RemoteAdmin.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/InWorldz/InWorldz.Testing/InWorldz.Testing.csproj
+++ b/InWorldz/InWorldz.Testing/InWorldz.Testing.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/InWorldz/InWorldz.VivoxVoice/InWorldz.VivoxVoice.csproj
+++ b/InWorldz/InWorldz.VivoxVoice/InWorldz.VivoxVoice.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/InWorldz/JWT/InWorldz.JWT.csproj
+++ b/InWorldz/JWT/InWorldz.JWT.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/MOSES/FreeswitchVoice/MOSES.FreeSwitchVoice.csproj
+++ b/MOSES/FreeswitchVoice/MOSES.FreeSwitchVoice.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  
 	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+	  <OutputPath>..\..\bin\</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>
 	  <RootNamespace>MOSES.FreeSwitchVoice</RootNamespace>

--- a/MOSES/FreeswitchVoice/MOSES.FreeSwitchVoice.csproj
+++ b/MOSES/FreeswitchVoice/MOSES.FreeSwitchVoice.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>
 	  <RootNamespace>MOSES.FreeSwitchVoice</RootNamespace>

--- a/OpenSim/ApplicationPlugins/CreateCommsManager/OpenSim.ApplicationPlugins.CreateCommsManager.csproj
+++ b/OpenSim/ApplicationPlugins/CreateCommsManager/OpenSim.ApplicationPlugins.CreateCommsManager.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/ApplicationPlugins/LoadRegions/OpenSim.ApplicationPlugins.LoadRegions.csproj
+++ b/OpenSim/ApplicationPlugins/LoadRegions/OpenSim.ApplicationPlugins.LoadRegions.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/ApplicationPlugins/RegionModulesController/OpenSim.ApplicationPlugins.RegionModulesController.csproj
+++ b/OpenSim/ApplicationPlugins/RegionModulesController/OpenSim.ApplicationPlugins.RegionModulesController.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/ApplicationPlugins/ScriptEngine/OpenSim.ApplicationPlugins.ScriptEngine.csproj
+++ b/OpenSim/ApplicationPlugins/ScriptEngine/OpenSim.ApplicationPlugins.ScriptEngine.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Base/OpenSim.Base.csproj
+++ b/OpenSim/Base/OpenSim.Base.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Client/Linden/OpenSim.Client.Linden.csproj
+++ b/OpenSim/Client/Linden/OpenSim.Client.Linden.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Data/MySQL/OpenSim.Data.MySQL.csproj
+++ b/OpenSim/Data/MySQL/OpenSim.Data.MySQL.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Data/MySQL/Tests/OpenSim.Data.MySQL.Tests.csproj
+++ b/OpenSim/Data/MySQL/Tests/OpenSim.Data.MySQL.Tests.csproj
@@ -13,7 +13,7 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
+    
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Data/Null/OpenSim.Data.Null.csproj
+++ b/OpenSim/Data/Null/OpenSim.Data.Null.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Data/OpenSim.Data.csproj
+++ b/OpenSim/Data/OpenSim.Data.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Framework/AssetLoader/Filesystem/OpenSim.Framework.AssetLoader.Filesystem.csproj
+++ b/OpenSim/Framework/AssetLoader/Filesystem/OpenSim.Framework.AssetLoader.Filesystem.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Framework/Communications/OpenSim.Framework.Communications.csproj
+++ b/OpenSim/Framework/Communications/OpenSim.Framework.Communications.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Framework/Configuration/HTTP/OpenSim.Framework.Configuration.HTTP.csproj
+++ b/OpenSim/Framework/Configuration/HTTP/OpenSim.Framework.Configuration.HTTP.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Framework/Configuration/XML/OpenSim.Framework.Configuration.XML.csproj
+++ b/OpenSim/Framework/Configuration/XML/OpenSim.Framework.Configuration.XML.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Framework/Console/OpenSim.Framework.Console.csproj
+++ b/OpenSim/Framework/Console/OpenSim.Framework.Console.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Framework/OpenSim.Framework.csproj
+++ b/OpenSim/Framework/OpenSim.Framework.csproj
@@ -13,6 +13,7 @@
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
 	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+	  <OutputPath>..\..\bin\</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>
 	  <RootNamespace>OpenSim.Framework</RootNamespace>

--- a/OpenSim/Framework/OpenSim.Framework.csproj
+++ b/OpenSim/Framework/OpenSim.Framework.csproj
@@ -1,649 +1,689 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
 	<PropertyGroup>
-	  <ProjectType>Local</ProjectType>
-	  <ProductVersion>14.0.23107.0</ProductVersion>
-	  <SchemaVersion>2.0</SchemaVersion>
-	  <ProjectGuid>{BCCDBB55-0000-0000-0000-000000000000}</ProjectGuid>
-	  <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-	  <ApplicationIcon></ApplicationIcon>
-	  <AssemblyKeyContainerName>
-	  </AssemblyKeyContainerName>
-	  <AssemblyName>OpenSim.Framework</AssemblyName>
-	  <DefaultClientScript>JScript</DefaultClientScript>
-	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
-	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
-	  <OutputPath>..\..\bin\</OutputPath>
-	  <OutputType>Library</OutputType>
-	  <AppDesignerFolder></AppDesignerFolder>
-	  <RootNamespace>OpenSim.Framework</RootNamespace>
-	  <StartupObject></StartupObject>
-	  <StartArguments></StartArguments>
-	  <FileUpgradeFlags>
-	  </FileUpgradeFlags>
+		<ProjectType>Local</ProjectType>
+		<ProductVersion>14.0.23107.0</ProductVersion>
+		<SchemaVersion>2.0</SchemaVersion>
+		<ProjectGuid>{BCCDBB55-0000-0000-0000-000000000000}</ProjectGuid>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<ApplicationIcon></ApplicationIcon>
+		<AssemblyKeyContainerName>
+		</AssemblyKeyContainerName>
+		<AssemblyName>OpenSim.Framework</AssemblyName>
+		<DefaultClientScript>JScript</DefaultClientScript>
+		<DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
+		<DefaultTargetSchema>IE50</DefaultTargetSchema>
+		<TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+		<OutputPath>..\..\bin\</OutputPath>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder></AppDesignerFolder>
+		<RootNamespace>OpenSim.Framework</RootNamespace>
+		<StartupObject></StartupObject>
+		<StartArguments></StartArguments>
+		<FileUpgradeFlags>
+		</FileUpgradeFlags>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-	  <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
-	  <BaseAddress>285212672</BaseAddress>
-	  <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
-	  <ConfigurationOverrideFile>
-	  </ConfigurationOverrideFile>
-	  <DefineConstants>TRACE;DEBUG</DefineConstants>
-	  <DocumentationFile></DocumentationFile>
-	  <DebugSymbols>True</DebugSymbols>
-	  <FileAlignment>4096</FileAlignment>
-	  <Optimize>False</Optimize>
-	  <OutputPath>..\..\bin\</OutputPath>
-	  <RegisterForComInterop>False</RegisterForComInterop>
-	  <RemoveIntegerChecks>False</RemoveIntegerChecks>
-	  <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
-	  <WarningLevel>4</WarningLevel>
-	  <NoStdLib>False</NoStdLib>
-	  <NoWarn></NoWarn>
-	  <PlatformTarget>x64</PlatformTarget>
+	<PropertyGroup Condition=" ( '$(Configuration)|$(Platform)' == 'Debug|x64' ) And ( '$(OS)' == 'Windows_NT' ) ">
+		<AllowUnsafeBlocks>False</AllowUnsafeBlocks>
+		<BaseAddress>285212672</BaseAddress>
+		<CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+		<ConfigurationOverrideFile>
+		</ConfigurationOverrideFile>
+		<DefineConstants>TRACE;DEBUG</DefineConstants>
+		<DocumentationFile></DocumentationFile>
+		<DebugSymbols>True</DebugSymbols>
+		<FileAlignment>4096</FileAlignment>
+		<Optimize>False</Optimize>
+		<OutputPath>..\..\bin\</OutputPath>
+		<RegisterForComInterop>False</RegisterForComInterop>
+		<RemoveIntegerChecks>False</RemoveIntegerChecks>
+		<TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+		<WarningLevel>4</WarningLevel>
+		<NoStdLib>False</NoStdLib>
+		<NoWarn></NoWarn>
+		<PlatformTarget>x64</PlatformTarget>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-	  <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
-	  <BaseAddress>285212672</BaseAddress>
-	  <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
-	  <ConfigurationOverrideFile>
-	  </ConfigurationOverrideFile>
-	  <DefineConstants>TRACE</DefineConstants>
-	  <DocumentationFile></DocumentationFile>
-	  <DebugSymbols>False</DebugSymbols>
-	  <FileAlignment>4096</FileAlignment>
-	  <Optimize>True</Optimize>
-	  <OutputPath>..\..\bin\</OutputPath>
-	  <RegisterForComInterop>False</RegisterForComInterop>
-	  <RemoveIntegerChecks>False</RemoveIntegerChecks>
-	  <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
-	  <WarningLevel>4</WarningLevel>
-	  <NoStdLib>False</NoStdLib>
-	  <NoWarn></NoWarn>
-	  <PlatformTarget>x64</PlatformTarget>
+	<PropertyGroup Condition=" ( '$(Configuration)|$(Platform)' == 'Debug|x64' ) And ( '$(OS)' != 'Windows_NT' ) ">
+		<AllowUnsafeBlocks>False</AllowUnsafeBlocks>
+		<BaseAddress>285212672</BaseAddress>
+		<CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+		<ConfigurationOverrideFile>
+		</ConfigurationOverrideFile>
+		<DefineConstants>TRACE;DEBUG;_MONO_CLI_FLAG_</DefineConstants>
+		<DocumentationFile></DocumentationFile>
+		<DebugSymbols>True</DebugSymbols>
+		<FileAlignment>4096</FileAlignment>
+		<Optimize>False</Optimize>
+		<OutputPath>..\..\bin\</OutputPath>
+		<RegisterForComInterop>False</RegisterForComInterop>
+		<RemoveIntegerChecks>False</RemoveIntegerChecks>
+		<TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+		<WarningLevel>4</WarningLevel>
+		<NoStdLib>False</NoStdLib>
+		<NoWarn></NoWarn>
+		<PlatformTarget>x64</PlatformTarget>
+	</PropertyGroup>
+	<PropertyGroup Condition=" ( '$(Configuration)|$(Platform)' == 'Release|x64' ) And ( '$(OS)' == 'Windows_NT' ) ">
+		<AllowUnsafeBlocks>False</AllowUnsafeBlocks>
+		<BaseAddress>285212672</BaseAddress>
+		<CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+		<ConfigurationOverrideFile>
+		</ConfigurationOverrideFile>
+		<DefineConstants>TRACE</DefineConstants>
+		<DocumentationFile></DocumentationFile>
+		<DebugSymbols>False</DebugSymbols>
+		<FileAlignment>4096</FileAlignment>
+		<Optimize>True</Optimize>
+		<OutputPath>..\..\bin\</OutputPath>
+		<RegisterForComInterop>False</RegisterForComInterop>
+		<RemoveIntegerChecks>False</RemoveIntegerChecks>
+		<TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+		<WarningLevel>4</WarningLevel>
+		<NoStdLib>False</NoStdLib>
+		<NoWarn></NoWarn>
+		<PlatformTarget>x64</PlatformTarget>
+	</PropertyGroup>
+	<PropertyGroup Condition=" ( '$(Configuration)|$(Platform)' == 'Release|x64' ) And ( '$(OS)' != 'Windows_NT' ) ">
+		<AllowUnsafeBlocks>False</AllowUnsafeBlocks>
+		<BaseAddress>285212672</BaseAddress>
+		<CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+		<ConfigurationOverrideFile>
+		</ConfigurationOverrideFile>
+		<DefineConstants>TRACE;_MONO_CLI_FLAG_</DefineConstants>
+		<DocumentationFile></DocumentationFile>
+		<DebugSymbols>False</DebugSymbols>
+		<FileAlignment>4096</FileAlignment>
+		<Optimize>True</Optimize>
+		<OutputPath>..\..\bin\</OutputPath>
+		<RegisterForComInterop>False</RegisterForComInterop>
+		<RemoveIntegerChecks>False</RemoveIntegerChecks>
+		<TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+		<WarningLevel>4</WarningLevel>
+		<NoStdLib>False</NoStdLib>
+		<NoWarn></NoWarn>
+		<PlatformTarget>x64</PlatformTarget>
 	</PropertyGroup>
 	<ItemGroup>
-	  <Reference Include="BclExtras35">
-		  <Name>BclExtras35</Name>
+		<Reference Include="BclExtras35">
+			<Name>BclExtras35</Name>
 		<HintPath>..\..\bin\BclExtras35.dll</HintPath>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="C5">
-		  <Name>C5</Name>
+		</Reference>
+		<Reference Include="C5">
+			<Name>C5</Name>
 		<HintPath>..\..\bin\C5.dll</HintPath>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="LibreMetaverse">
-		  <Name>LibreMetaverse</Name>
+		</Reference>
+		<Reference Include="LibreMetaverse">
+			<Name>LibreMetaverse</Name>
 		<HintPath>..\..\bin\LibreMetaverse.dll</HintPath>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="LibreMetaverse.StructuredData">
-		  <Name>LibreMetaverse.StructuredData</Name>
+		</Reference>
+		<Reference Include="LibreMetaverse.StructuredData">
+			<Name>LibreMetaverse.StructuredData</Name>
 		<HintPath>..\..\bin\LibreMetaverse.StructuredData.dll</HintPath>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="LibreMetaverse.Types">
-		  <Name>LibreMetaverse.Types</Name>
+		</Reference>
+		<Reference Include="LibreMetaverse.Types">
+			<Name>LibreMetaverse.Types</Name>
 		<HintPath>..\..\bin\LibreMetaverse.Types.dll</HintPath>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="log4net">
-		  <Name>log4net</Name>
+		</Reference>
+		<Reference Include="log4net">
+			<Name>log4net</Name>
 		<HintPath>..\..\bin\log4net.dll</HintPath>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="Mono.Addins">
-		  <Name>Mono.Addins</Name>
+		</Reference>
+		<Reference Include="Mono.Addins">
+			<Name>Mono.Addins</Name>
 		<HintPath>..\..\bin\Mono.Addins.dll</HintPath>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="Nini">
-		  <Name>Nini</Name>
+		</Reference>
+		<Reference Include="Nini">
+			<Name>Nini</Name>
 		<HintPath>..\..\bin\Nini.dll</HintPath>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="protobuf-net">
-		  <Name>protobuf-net</Name>
+		</Reference>
+		<Reference Include="protobuf-net">
+			<Name>protobuf-net</Name>
 		<HintPath>..\..\bin\protobuf-net.dll</HintPath>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="SmartThreadPool">
-		  <Name>SmartThreadPool</Name>
+		</Reference>
+		<Reference Include="SmartThreadPool">
+			<Name>SmartThreadPool</Name>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="System">
-		  <Name>System</Name>
+		</Reference>
+		<Reference Include="System">
+			<Name>System</Name>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="System.Core">
-		  <Name>System.Core</Name>
+		</Reference>
+		<Reference Include="System.Core">
+			<Name>System.Core</Name>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="System.Data">
-		  <Name>System.Data</Name>
+		</Reference>
+		<Reference Include="System.Data">
+			<Name>System.Data</Name>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="System.DirectoryServices.AccountManagement">
-		  <Name>System.DirectoryServices.AccountManagement</Name>
+		</Reference>
+		<Reference Include="System.DirectoryServices.AccountManagement" Condition=" '$OS' == 'Window_NT' ">
+			<Name>System.DirectoryServices.AccountManagement</Name>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="System.Drawing">
-		  <Name>System.Drawing</Name>
+		</Reference>
+		<Reference Include="System.Drawing">
+			<Name>System.Drawing</Name>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="System.Web">
-		  <Name>System.Web</Name>
+		</Reference>
+		<Reference Include="System.Web">
+			<Name>System.Web</Name>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="System.Xml">
-		  <Name>System.Xml</Name>
+		</Reference>
+		<Reference Include="System.Xml">
+			<Name>System.Xml</Name>
 		<Private>False</Private>
-	  </Reference>
-	  <Reference Include="XmlRpcCS">
-		  <Name>XmlRpcCS</Name>
+		</Reference>
+		<Reference Include="XmlRpcCS">
+			<Name>XmlRpcCS</Name>
 		<HintPath>..\..\bin\XmlRpcCS.dll</HintPath>
 		<Private>False</Private>
-	  </Reference>
+		</Reference>
 	</ItemGroup>
 	<ItemGroup>
 	</ItemGroup>
 	<ItemGroup>
-	  <Compile Include="ACL.cs">
+		<Compile Include="ACL.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AgentCircuitData.cs">
+		</Compile>
+		<Compile Include="AgentCircuitData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AgentCircuitManager.cs">
+		</Compile>
+		<Compile Include="AgentCircuitManager.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AgentPreferencesData.cs">
+		</Compile>
+		<Compile Include="AgentPreferencesData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AgentUpdateArgs.cs">
+		</Compile>
+		<Compile Include="AgentUpdateArgs.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Animation.cs">
+		</Compile>
+		<Compile Include="Animation.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AssemblyInfo.cs">
+		</Compile>
+		<Compile Include="AssemblyInfo.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AssetAlreadyExistsException.cs">
+		</Compile>
+		<Compile Include="AssetAlreadyExistsException.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AssetBase.cs">
+		</Compile>
+		<Compile Include="AssetBase.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AssetConfig.cs">
+		</Compile>
+		<Compile Include="AssetConfig.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AssetLandmark.cs">
+		</Compile>
+		<Compile Include="AssetLandmark.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AssetRequest.cs">
+		</Compile>
+		<Compile Include="AssetRequest.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AssetRequestInfo.cs">
+		</Compile>
+		<Compile Include="AssetRequestInfo.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AssetRequestToClient.cs">
+		</Compile>
+		<Compile Include="AssetRequestToClient.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AssetsCommon.cs">
+		</Compile>
+		<Compile Include="AssetsCommon.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AssetServerException.cs">
+		</Compile>
+		<Compile Include="AssetServerException.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AssetStorage.cs">
+		</Compile>
+		<Compile Include="AssetStorage.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AuthenticateResponse.cs">
+		</Compile>
+		<Compile Include="AuthenticateResponse.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AvatarAppearance.cs">
+		</Compile>
+		<Compile Include="AvatarAppearance.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AvatarAttachment.cs">
+		</Compile>
+		<Compile Include="AvatarAttachment.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AvatarConnectionState.cs">
+		</Compile>
+		<Compile Include="AvatarConnectionState.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AvatarPickerAvatar.cs">
+		</Compile>
+		<Compile Include="AvatarPickerAvatar.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AvatarPickerReplyAgentDataArgs.cs">
+		</Compile>
+		<Compile Include="AvatarPickerReplyAgentDataArgs.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AvatarPickerReplyDataArgs.cs">
+		</Compile>
+		<Compile Include="AvatarPickerReplyDataArgs.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AvatarWearable.cs">
+		</Compile>
+		<Compile Include="AvatarWearable.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="AvatarWearingArgs.cs">
+		</Compile>
+		<Compile Include="AvatarWearingArgs.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="BlockingMultiQueue.cs">
+		</Compile>
+		<Compile Include="BlockingMultiQueue.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="BlockingQueue.cs">
+		</Compile>
+		<Compile Include="BlockingQueue.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ByteBufferPool.cs">
+		</Compile>
+		<Compile Include="ByteBufferPool.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Cache.cs">
+		</Compile>
+		<Compile Include="Cache.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="CapsUtil.cs">
+		</Compile>
+		<Compile Include="CapsUtil.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ChatTypeEnum.cs">
+		</Compile>
+		<Compile Include="ChatTypeEnum.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ChildAgentDataUpdate.cs">
+		</Compile>
+		<Compile Include="ChildAgentDataUpdate.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ClientInfo.cs">
+		</Compile>
+		<Compile Include="ClientInfo.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ClientManager.cs">
+		</Compile>
+		<Compile Include="ClientManager.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ColliderData.cs">
+		</Compile>
+		<Compile Include="ColliderData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ConfigBase.cs">
+		</Compile>
+		<Compile Include="ConfigBase.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ConfigSettings.cs">
+		</Compile>
+		<Compile Include="ConfigSettings.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ConfigurationMember.cs">
+		</Compile>
+		<Compile Include="ConfigurationMember.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ConfigurationOption.cs">
+		</Compile>
+		<Compile Include="ConfigurationOption.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Constants.cs">
+		</Compile>
+		<Compile Include="Constants.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Crypto.cs">
+		</Compile>
+		<Compile Include="Crypto.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Culture.cs">
+		</Compile>
+		<Compile Include="Culture.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="EstateBan.cs">
+		</Compile>
+		<Compile Include="EstateBan.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="EstateSettings.cs">
+		</Compile>
+		<Compile Include="EstateSettings.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="EventData.cs">
+		</Compile>
+		<Compile Include="EventData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="FileCompressor.cs">
+		</Compile>
+		<Compile Include="FileCompressor.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="FixedSizeMRU.cs">
+		</Compile>
+		<Compile Include="FixedSizeMRU.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ForeignUserProfileData.cs">
+		</Compile>
+		<Compile Include="ForeignUserProfileData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="FriendListItem.cs">
+		</Compile>
+		<Compile Include="FriendListItem.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="FriendRegionInfo.cs">
+		</Compile>
+		<Compile Include="FriendRegionInfo.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="GridConfig.cs">
+		</Compile>
+		<Compile Include="GridConfig.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="GridInstantMessage.cs">
+		</Compile>
+		<Compile Include="GridInstantMessage.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="GroupData.cs">
+		</Compile>
+		<Compile Include="GroupData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="HGNetworkServersInfo.cs">
+		</Compile>
+		<Compile Include="HGNetworkServersInfo.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="HttpExtensions.cs">
+		</Compile>
+		<Compile Include="HttpExtensions.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IAssetCache.cs">
+		</Compile>
+		<Compile Include="IAssetCache.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IAssetLoader.cs">
+		</Compile>
+		<Compile Include="IAssetLoader.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IAssetReceiver.cs">
+		</Compile>
+		<Compile Include="IAssetReceiver.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IAssetServer.cs">
+		</Compile>
+		<Compile Include="IAssetServer.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IAvatarConnection.cs">
+		</Compile>
+		<Compile Include="IAvatarConnection.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IChatMessageLogBackend.cs">
+		</Compile>
+		<Compile Include="IChatMessageLogBackend.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IClientAPI.cs">
+		</Compile>
+		<Compile Include="IClientAPI.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IClientFileTransfer.cs">
+		</Compile>
+		<Compile Include="IClientFileTransfer.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ICommandConsole.cs">
+		</Compile>
+		<Compile Include="ICommandConsole.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IConsole.cs">
+		</Compile>
+		<Compile Include="IConsole.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IGenericConfig.cs">
+		</Compile>
+		<Compile Include="IGenericConfig.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IImprovedAssetCache.cs">
+		</Compile>
+		<Compile Include="IImprovedAssetCache.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IInventoryItem.cs">
+		</Compile>
+		<Compile Include="IInventoryItem.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ILoginServiceToRegionsConnector.cs">
+		</Compile>
+		<Compile Include="ILoginServiceToRegionsConnector.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ImmutableTimestampedItem.cs">
+		</Compile>
+		<Compile Include="ImmutableTimestampedItem.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IMoneyModule.cs">
+		</Compile>
+		<Compile Include="IMoneyModule.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IndexedPriorityQueue.cs">
+		</Compile>
+		<Compile Include="IndexedPriorityQueue.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="InventoryCollection.cs">
+		</Compile>
+		<Compile Include="InventoryCollection.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="InventoryConfig.cs">
+		</Compile>
+		<Compile Include="InventoryConfig.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="InventoryFolderBase.cs">
+		</Compile>
+		<Compile Include="InventoryFolderBase.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="InventoryFolderImpl.cs">
+		</Compile>
+		<Compile Include="InventoryFolderImpl.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="InventoryItemBase.cs">
+		</Compile>
+		<Compile Include="InventoryItemBase.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="InventoryNodeBase.cs">
+		</Compile>
+		<Compile Include="InventoryNodeBase.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="InventoryObjectMissingException.cs">
+		</Compile>
+		<Compile Include="InventoryObjectMissingException.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="InventorySecurityException.cs">
+		</Compile>
+		<Compile Include="InventorySecurityException.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="InventoryStorageException.cs">
+		</Compile>
+		<Compile Include="InventoryStorageException.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="InventorySubFolderBase.cs">
+		</Compile>
+		<Compile Include="InventorySubFolderBase.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IObjectCache.cs">
+		</Compile>
+		<Compile Include="IObjectCache.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IPlugin.cs">
+		</Compile>
+		<Compile Include="IPlugin.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IRegionCommsListener.cs">
+		</Compile>
+		<Compile Include="IRegionCommsListener.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IRegionCreator.cs">
+		</Compile>
+		<Compile Include="IRegionCreator.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IRegionLoader.cs">
+		</Compile>
+		<Compile Include="IRegionLoader.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IRegistryCore.cs">
+		</Compile>
+		<Compile Include="IRegistryCore.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="IScene.cs">
+		</Compile>
+		<Compile Include="IScene.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ISceneEntity.cs">
+		</Compile>
+		<Compile Include="ISceneEntity.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ISceneObject.cs">
+		</Compile>
+		<Compile Include="ISceneObject.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ItemPermissionBlock.cs">
+		</Compile>
+		<Compile Include="ItemPermissionBlock.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="KeyframeAnimation.cs">
+		</Compile>
+		<Compile Include="KeyframeAnimation.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="LandData.cs">
+		</Compile>
+		<Compile Include="LandData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="LandStatReportItem.cs">
+		</Compile>
+		<Compile Include="LandStatReportItem.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="LandUpdateArgs.cs">
+		</Compile>
+		<Compile Include="LandUpdateArgs.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="LLSDSerializationDictionary.cs">
+		</Compile>
+		<Compile Include="LLSDSerializationDictionary.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Location.cs">
+		</Compile>
+		<Compile Include="Location.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="LocklessQueue.cs">
+		</Compile>
+		<Compile Include="LocklessQueue.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Login.cs">
+		</Compile>
+		<Compile Include="Login.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="LRUCache.cs">
+		</Compile>
+		<Compile Include="LRUCache.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="MainConsole.cs">
+		</Compile>
+		<Compile Include="MainConsole.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="MapBlockData.cs">
+		</Compile>
+		<Compile Include="MapBlockData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="MapItemReplyStruct.cs">
+		</Compile>
+		<Compile Include="MapItemReplyStruct.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="MessageServerConfig.cs">
+		</Compile>
+		<Compile Include="MessageServerConfig.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="MovingIntegerAverage.cs">
+		</Compile>
+		<Compile Include="MovingIntegerAverage.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="NeighbourInfo.cs">
+		</Compile>
+		<Compile Include="NeighbourInfo.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="NetworkServersInfo.cs">
+		</Compile>
+		<Compile Include="NetworkServersInfo.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ObjectPool.cs">
+		</Compile>
+		<Compile Include="ObjectPool.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="OSChatMessage.cs">
+		</Compile>
+		<Compile Include="OSChatMessage.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="PacketPool.cs">
+		</Compile>
+		<Compile Include="PacketPool.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ParcelMediaCommandEnum.cs">
+		</Compile>
+		<Compile Include="ParcelMediaCommandEnum.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="PIDFileManager.cs">
+		</Compile>
+		<Compile Include="PIDFileManager.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="PluginLoader.cs">
+		</Compile>
+		<Compile Include="PluginLoader.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="PrimitiveBaseShape.cs">
+		</Compile>
+		<Compile Include="PrimitiveBaseShape.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="PriorityQueue.cs">
+		</Compile>
+		<Compile Include="PriorityQueue.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ProviderRegistry.cs">
+		</Compile>
+		<Compile Include="ProviderRegistry.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ProxyCodec.cs">
+		</Compile>
+		<Compile Include="ProxyCodec.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="RateLimitingDetector.cs">
+		</Compile>
+		<Compile Include="RateLimitingDetector.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="RegionCommsListener.cs">
+		</Compile>
+		<Compile Include="RegionCommsListener.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="RegionEnvironmentData.cs">
+		</Compile>
+		<Compile Include="RegionEnvironmentData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="RegionHandshakeArgs.cs">
+		</Compile>
+		<Compile Include="RegionHandshakeArgs.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="RegionInfo.cs">
+		</Compile>
+		<Compile Include="RegionInfo.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="RegionInfoForEstateMenuArgs.cs">
+		</Compile>
+		<Compile Include="RegionInfoForEstateMenuArgs.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="RegionSettings.cs">
+		</Compile>
+		<Compile Include="RegionSettings.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="RegionUpData.cs">
+		</Compile>
+		<Compile Include="RegionUpData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="RegistryCore.cs">
+		</Compile>
+		<Compile Include="RegistryCore.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="RemotePresenceInfo.cs">
+		</Compile>
+		<Compile Include="RemotePresenceInfo.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Remoting.cs">
+		</Compile>
+		<Compile Include="Remoting.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="RenderMaterials.cs">
+		</Compile>
+		<Compile Include="RenderMaterials.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ReplaceItemArgs.cs">
+		</Compile>
+		<Compile Include="ReplaceItemArgs.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="RequestAssetArgs.cs">
+		</Compile>
+		<Compile Include="RequestAssetArgs.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="SerializableInventory.cs">
+		</Compile>
+		<Compile Include="SerializableInventory.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="SimpleRegionInfoSnapshot.cs">
+		</Compile>
+		<Compile Include="SimpleRegionInfoSnapshot.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="SimStats.cs">
+		</Compile>
+		<Compile Include="SimStats.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="sLLVector3.cs">
+		</Compile>
+		<Compile Include="sLLVector3.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="SurfaceTouchEventArgs.cs">
+		</Compile>
+		<Compile Include="SurfaceTouchEventArgs.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="TaskInventoryDictionary.cs">
+		</Compile>
+		<Compile Include="TaskInventoryDictionary.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="TaskInventoryItem.cs">
+		</Compile>
+		<Compile Include="TaskInventoryItem.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Telehub.cs">
+		</Compile>
+		<Compile Include="Telehub.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="TextureRequestArgs.cs">
+		</Compile>
+		<Compile Include="TextureRequestArgs.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ThreadTracker.cs">
+		</Compile>
+		<Compile Include="ThreadTracker.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ThrottleOutPacketType.cs">
+		</Compile>
+		<Compile Include="ThrottleOutPacketType.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="TimestampedItem.cs">
+		</Compile>
+		<Compile Include="TimestampedItem.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="TrustManager.cs">
+		</Compile>
+		<Compile Include="TrustManager.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="UndoStack.cs">
+		</Compile>
+		<Compile Include="UndoStack.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="UnrecoverableAssetServerException.cs">
+		</Compile>
+		<Compile Include="UnrecoverableAssetServerException.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="UnrecoverableInventoryStorageException.cs">
+		</Compile>
+		<Compile Include="UnrecoverableInventoryStorageException.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="UpdateItemResponse.cs">
+		</Compile>
+		<Compile Include="UpdateItemResponse.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="UpdateShapeArgs.cs">
+		</Compile>
+		<Compile Include="UpdateShapeArgs.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="UserAgentData.cs">
+		</Compile>
+		<Compile Include="UserAgentData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="UserConfig.cs">
+		</Compile>
+		<Compile Include="UserConfig.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="UserPreferencesData.cs">
+		</Compile>
+		<Compile Include="UserPreferencesData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="UserProfileData.cs">
+		</Compile>
+		<Compile Include="UserProfileData.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Util.cs">
+		</Compile>
+		<Compile Include="Util.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="ViewerEffectEventHandlerArg.cs">
+		</Compile>
+		<Compile Include="ViewerEffectEventHandlerArg.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Watchdog.cs">
+		</Compile>
+		<Compile Include="Watchdog.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Client\IClientChat.cs">
+		</Compile>
+		<Compile Include="Client\IClientChat.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Client\IClientCore.cs">
+		</Compile>
+		<Compile Include="Client\IClientCore.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Client\IClientIM.cs">
+		</Compile>
+		<Compile Include="Client\IClientIM.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Client\IClientIPEndpoint.cs">
+		</Compile>
+		<Compile Include="Client\IClientIPEndpoint.cs">
 		<SubType>Code</SubType>
-	  </Compile>
-	  <Compile Include="Geom\Box.cs">
+		</Compile>
+		<Compile Include="Geom\Box.cs">
 		<SubType>Code</SubType>
-	  </Compile>
+		</Compile>
 	</ItemGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<PropertyGroup>
-	  <PreBuildEvent>
-	  </PreBuildEvent>
-	  <PostBuildEvent>
-	  </PostBuildEvent>
+		<PreBuildEvent>
+		</PreBuildEvent>
+		<PostBuildEvent>
+		</PostBuildEvent>
 	</PropertyGroup>
 </Project>

--- a/OpenSim/Framework/OpenSim.Framework.csproj
+++ b/OpenSim/Framework/OpenSim.Framework.csproj
@@ -164,7 +164,7 @@
 			<Name>System.Data</Name>
 		<Private>False</Private>
 		</Reference>
-		<Reference Include="System.DirectoryServices.AccountManagement" Condition=" '$OS' == 'Window_NT' ">
+		<Reference Include="System.DirectoryServices.AccountManagement" Condition=" '$(OS)' == 'Windows_NT' ">
 			<Name>System.DirectoryServices.AccountManagement</Name>
 		<Private>False</Private>
 		</Reference>

--- a/OpenSim/Framework/OpenSim.Framework.csproj
+++ b/OpenSim/Framework/OpenSim.Framework.csproj
@@ -12,8 +12,7 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>
 	  <RootNamespace>OpenSim.Framework</RootNamespace>
@@ -63,84 +62,84 @@
 	  <PlatformTarget>x64</PlatformTarget>
 	</PropertyGroup>
 	<ItemGroup>
-	  <Reference Include="BclExtras35" >
+	  <Reference Include="BclExtras35">
 		  <Name>BclExtras35</Name>
 		<HintPath>..\..\bin\BclExtras35.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="C5" >
+	  <Reference Include="C5">
 		  <Name>C5</Name>
 		<HintPath>..\..\bin\C5.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="LibreMetaverse" >
+	  <Reference Include="LibreMetaverse">
 		  <Name>LibreMetaverse</Name>
 		<HintPath>..\..\bin\LibreMetaverse.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="LibreMetaverse.StructuredData" >
+	  <Reference Include="LibreMetaverse.StructuredData">
 		  <Name>LibreMetaverse.StructuredData</Name>
 		<HintPath>..\..\bin\LibreMetaverse.StructuredData.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="LibreMetaverse.Types" >
+	  <Reference Include="LibreMetaverse.Types">
 		  <Name>LibreMetaverse.Types</Name>
 		<HintPath>..\..\bin\LibreMetaverse.Types.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="log4net" >
+	  <Reference Include="log4net">
 		  <Name>log4net</Name>
 		<HintPath>..\..\bin\log4net.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="Mono.Addins" >
+	  <Reference Include="Mono.Addins">
 		  <Name>Mono.Addins</Name>
 		<HintPath>..\..\bin\Mono.Addins.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="Nini" >
+	  <Reference Include="Nini">
 		  <Name>Nini</Name>
 		<HintPath>..\..\bin\Nini.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="protobuf-net" >
+	  <Reference Include="protobuf-net">
 		  <Name>protobuf-net</Name>
 		<HintPath>..\..\bin\protobuf-net.dll</HintPath>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="SmartThreadPool" >
+	  <Reference Include="SmartThreadPool">
 		  <Name>SmartThreadPool</Name>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="System" >
+	  <Reference Include="System">
 		  <Name>System</Name>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="System.Core" >
+	  <Reference Include="System.Core">
 		  <Name>System.Core</Name>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="System.Data" >
+	  <Reference Include="System.Data">
 		  <Name>System.Data</Name>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="System.DirectoryServices.AccountManagement" >
+	  <Reference Include="System.DirectoryServices.AccountManagement">
 		  <Name>System.DirectoryServices.AccountManagement</Name>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="System.Drawing" >
+	  <Reference Include="System.Drawing">
 		  <Name>System.Drawing</Name>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="System.Web" >
+	  <Reference Include="System.Web">
 		  <Name>System.Web</Name>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="System.Xml" >
+	  <Reference Include="System.Xml">
 		  <Name>System.Xml</Name>
 		<Private>False</Private>
 	  </Reference>
-	  <Reference Include="XmlRpcCS" >
+	  <Reference Include="XmlRpcCS">
 		  <Name>XmlRpcCS</Name>
 		<HintPath>..\..\bin\XmlRpcCS.dll</HintPath>
 		<Private>False</Private>

--- a/OpenSim/Framework/RegionLoader/Filesystem/OpenSim.Framework.RegionLoader.Filesystem.csproj
+++ b/OpenSim/Framework/RegionLoader/Filesystem/OpenSim.Framework.RegionLoader.Filesystem.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Framework/RegionLoader/Web/OpenSim.Framework.RegionLoader.Web.csproj
+++ b/OpenSim/Framework/RegionLoader/Web/OpenSim.Framework.RegionLoader.Web.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Framework/Serialization/OpenSim.Framework.Serialization.csproj
+++ b/OpenSim/Framework/Serialization/OpenSim.Framework.Serialization.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Framework/Servers/HttpServer/OpenSim.Framework.Servers.HttpServer.csproj
+++ b/OpenSim/Framework/Servers/HttpServer/OpenSim.Framework.Servers.HttpServer.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Framework/Servers/HttpServer/Tests/OpenSim.Framework.Servers.HttpServer.Tests.csproj
+++ b/OpenSim/Framework/Servers/HttpServer/Tests/OpenSim.Framework.Servers.HttpServer.Tests.csproj
@@ -13,7 +13,7 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
+    
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <OutputPath>..\..\..\..\..\bin\</OutputPath>
     <OutputType>Library</OutputType>

--- a/OpenSim/Framework/Servers/OpenSim.Framework.Servers.csproj
+++ b/OpenSim/Framework/Servers/OpenSim.Framework.Servers.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Framework/Servers/Tests/OpenSim.Framework.Servers.Tests.csproj
+++ b/OpenSim/Framework/Servers/Tests/OpenSim.Framework.Servers.Tests.csproj
@@ -13,7 +13,7 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
+    
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <OutputPath>..\..\..\..\bin\</OutputPath>
     <OutputType>Library</OutputType>

--- a/OpenSim/Framework/Statistics/OpenSim.Framework.Statistics.csproj
+++ b/OpenSim/Framework/Statistics/OpenSim.Framework.Statistics.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Framework/Tests/OpenSim.Framework.Tests.csproj
+++ b/OpenSim/Framework/Tests/OpenSim.Framework.Tests.csproj
@@ -13,8 +13,8 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputPath>../../../bin/</OutputPath>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>

--- a/OpenSim/Grid/Framework/OpenSim.Grid.Framework.csproj
+++ b/OpenSim/Grid/Framework/OpenSim.Grid.Framework.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Grid/GridServer.Modules/OpenSim.Grid.GridServer.Modules.csproj
+++ b/OpenSim/Grid/GridServer.Modules/OpenSim.Grid.GridServer.Modules.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Grid/GridServer/OpenSim.Grid.GridServer.csproj
+++ b/OpenSim/Grid/GridServer/OpenSim.Grid.GridServer.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Exe</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Grid/MessagingServer.Modules/OpenSim.Grid.MessagingServer.Modules.csproj
+++ b/OpenSim/Grid/MessagingServer.Modules/OpenSim.Grid.MessagingServer.Modules.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Grid/MessagingServer/OpenSim.Grid.MessagingServer.csproj
+++ b/OpenSim/Grid/MessagingServer/OpenSim.Grid.MessagingServer.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Exe</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Grid/UserServer.Modules/OpenSim.Grid.UserServer.Modules.csproj
+++ b/OpenSim/Grid/UserServer.Modules/OpenSim.Grid.UserServer.Modules.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Grid/UserServer/OpenSim.Grid.UserServer.csproj
+++ b/OpenSim/Grid/UserServer/OpenSim.Grid.UserServer.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Exe</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/ClientStack/LindenUDP/OpenSim.Region.ClientStack.LindenUDP.csproj
+++ b/OpenSim/Region/ClientStack/LindenUDP/OpenSim.Region.ClientStack.LindenUDP.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/ClientStack/OpenSim.Region.ClientStack.csproj
+++ b/OpenSim/Region/ClientStack/OpenSim.Region.ClientStack.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/Communications/Local/OpenSim.Region.Communications.Local.csproj
+++ b/OpenSim/Region/Communications/Local/OpenSim.Region.Communications.Local.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/Communications/OGS1/OpenSim.Region.Communications.OGS1.csproj
+++ b/OpenSim/Region/Communications/OGS1/OpenSim.Region.Communications.OGS1.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/CoreModules/OpenSim.Region.CoreModules.Tests.csproj
+++ b/OpenSim/Region/CoreModules/OpenSim.Region.CoreModules.Tests.csproj
@@ -13,7 +13,7 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
+    
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
     <OutputType>Library</OutputType>

--- a/OpenSim/Region/CoreModules/OpenSim.Region.CoreModules.csproj
+++ b/OpenSim/Region/CoreModules/OpenSim.Region.CoreModules.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/CoreModules/World/Terrain/DefaultEffects/OpenSim.Region.CoreModules.World.Terrain.DefaultEffects.csproj
+++ b/OpenSim/Region/CoreModules/World/Terrain/DefaultEffects/OpenSim.Region.CoreModules.World.Terrain.DefaultEffects.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../../../bin/Terrain/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/Framework/OpenSim.Region.Framework.Tests.csproj
+++ b/OpenSim/Region/Framework/OpenSim.Region.Framework.Tests.csproj
@@ -13,7 +13,7 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
+    
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
     <OutputType>Library</OutputType>

--- a/OpenSim/Region/Framework/OpenSim.Region.Framework.csproj
+++ b/OpenSim/Region/Framework/OpenSim.Region.Framework.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/FrameworkTests/OpenSim.Region.FrameworkTests.csproj
+++ b/OpenSim/Region/FrameworkTests/OpenSim.Region.FrameworkTests.csproj
@@ -13,8 +13,8 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputPath>../../../bin/</OutputPath>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>

--- a/OpenSim/Region/Interfaces/OpenSim.Region.Interfaces.csproj
+++ b/OpenSim/Region/Interfaces/OpenSim.Region.Interfaces.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>
 	  <RootNamespace>OpenSim.Region.Interfaces</RootNamespace>

--- a/OpenSim/Region/Interfaces/OpenSim.Region.Interfaces.csproj
+++ b/OpenSim/Region/Interfaces/OpenSim.Region.Interfaces.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  
 	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+	  <OutputPath>..\..\..\bin\</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>
 	  <RootNamespace>OpenSim.Region.Interfaces</RootNamespace>

--- a/OpenSim/Region/OptionalModules/OpenSim.Region.OptionalModules.csproj
+++ b/OpenSim/Region/OptionalModules/OpenSim.Region.OptionalModules.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/Physics/BasicPhysicsPlugin/OpenSim.Region.Physics.BasicPhysicsPlugin.csproj
+++ b/OpenSim/Region/Physics/BasicPhysicsPlugin/OpenSim.Region.Physics.BasicPhysicsPlugin.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/Physics/ConvexDecompositionDotNet/OpenSim.Region.Physics.ConvexDecompositionDotNet.csproj
+++ b/OpenSim/Region/Physics/ConvexDecompositionDotNet/OpenSim.Region.Physics.ConvexDecompositionDotNet.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/Physics/Manager/OpenSim.Region.Physics.Manager.csproj
+++ b/OpenSim/Region/Physics/Manager/OpenSim.Region.Physics.Manager.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/Physics/Meshing/OpenSim.Region.Physics.Meshing.csproj
+++ b/OpenSim/Region/Physics/Meshing/OpenSim.Region.Physics.Meshing.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/ScriptEngine/OpenSim.Region.ScriptEngine.Tests.csproj
+++ b/OpenSim/Region/ScriptEngine/OpenSim.Region.ScriptEngine.Tests.csproj
@@ -13,7 +13,7 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
+    
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
     <OutputType>Library</OutputType>

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/OpenSim.Region.ScriptEngine.Shared.Api.csproj
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/OpenSim.Region.ScriptEngine.Shared.Api.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/OpenSim.Region.ScriptEngine.Shared.Api.Runtime.csproj
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/OpenSim.Region.ScriptEngine.Shared.Api.Runtime.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Region/ScriptEngine/Shared/OpenSim.Region.ScriptEngine.Shared.csproj
+++ b/OpenSim/Region/ScriptEngine/Shared/OpenSim.Region.ScriptEngine.Shared.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/ScriptEngine/Shared.Script/OpenSim.ScriptEngine.Shared.Script.csproj
+++ b/OpenSim/ScriptEngine/Shared.Script/OpenSim.ScriptEngine.Shared.Script.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>
 	  <RootNamespace>OpenSim.ScriptEngine.Shared.Script</RootNamespace>

--- a/OpenSim/ScriptEngine/Shared.Script/OpenSim.ScriptEngine.Shared.Script.csproj
+++ b/OpenSim/ScriptEngine/Shared.Script/OpenSim.ScriptEngine.Shared.Script.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  
 	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+	  <OutputPath>..\..\..\bin\</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>
 	  <RootNamespace>OpenSim.ScriptEngine.Shared.Script</RootNamespace>

--- a/OpenSim/ScriptEngine/Shared/OpenSim.ScriptEngine.Shared.csproj
+++ b/OpenSim/ScriptEngine/Shared/OpenSim.ScriptEngine.Shared.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Servers/Base/OpenSim.Servers.Base.csproj
+++ b/OpenSim/Servers/Base/OpenSim.Servers.Base.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Services/AssetService/OpenSim.Services.AssetService.csproj
+++ b/OpenSim/Services/AssetService/OpenSim.Services.AssetService.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Services/Base/OpenSim.Services.Base.csproj
+++ b/OpenSim/Services/Base/OpenSim.Services.Base.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Services/Interfaces/OpenSim.Services.Interfaces.csproj
+++ b/OpenSim/Services/Interfaces/OpenSim.Services.Interfaces.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/Services/UserService/OpenSim.Services.UserService.csproj
+++ b/OpenSim/Services/UserService/OpenSim.Services.UserService.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSim/TestSuite/OpenSim.TestSuite.csproj
+++ b/OpenSim/TestSuite/OpenSim.TestSuite.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../bin/</OutputPath>
 	  <OutputType>Exe</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>

--- a/OpenSimProfile/Modules/OpenSimProfile.Modules.csproj
+++ b/OpenSimProfile/Modules/OpenSimProfile.Modules.csproj
@@ -12,8 +12,8 @@
 	  <DefaultClientScript>JScript</DefaultClientScript>
 	  <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
 	  <DefaultTargetSchema>IE50</DefaultTargetSchema>
-	  <DelaySign>false</DelaySign>
-	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  
+	  <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
 	  <OutputPath>../../bin/</OutputPath>
 	  <OutputType>Library</OutputType>
 	  <AppDesignerFolder></AppDesignerFolder>


### PR DESCRIPTION
Stage 1 of PhysX update is getting to the most recent release of the .NET Framework.  This is a project-file only change, no code has been touched.

Proven to compile on:

- CLI msbuild under Ubuntu Linux 16.04.4 against Mono 5.14.0.173
- Visual Studio 2017 on Windows 10

MonoDevelop 7.6 build 711 seems to be having a problem getting the `_MONO_CLI_FLAG_` set when it goes to build, probably having a problem parsing the customized project files.